### PR TITLE
fix: editor tabs key error

### DIFF
--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -11,12 +11,12 @@ import { editor } from "monaco-editor";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
-export const EditorTabs = ({ key = 0 }: { key?: number }) => {
+export const EditorTabs = ({ editorKey = 0 }: { editorKey?: number }) => {
 	const { projectId } = useParams();
 	const { t } = useTranslation("tabs", { keyPrefix: "editor" });
 	const { resources, openedFiles, setUpdateFileContent, updateEditorOpenedFiles, updateEditorClosedFiles } =
 		useProjectStore();
-	const [editorKey, setEditorKey] = useState(key);
+	const [key, setKey] = useState(editorKey);
 	const initialContent = "// Code A: Initialize your code here...";
 
 	const activeEditorFileName = openedFiles?.find(({ isActive }) => isActive)?.name || "";
@@ -28,7 +28,7 @@ export const EditorTabs = ({ key = 0 }: { key?: number }) => {
 	const content = String.fromCharCode.apply(null, byteArray) || initialContent;
 
 	useEffect(() => {
-		const handleResize = () => setEditorKey((prevKey) => prevKey + 1);
+		const handleResize = () => setKey((prevKey) => prevKey + 1);
 
 		window.addEventListener("resize", handleResize);
 
@@ -107,7 +107,7 @@ export const EditorTabs = ({ key = 0 }: { key?: number }) => {
 							<Editor
 								aria-label={fileName}
 								beforeMount={handleEditorWillMount}
-								key={editorKey}
+								key={key}
 								language={languageEditor}
 								onChange={handleUpdateContent}
 								onMount={handleEditorDidMount}

--- a/src/components/organisms/splitFrame.tsx
+++ b/src/components/organisms/splitFrame.tsx
@@ -22,7 +22,7 @@ export const SplitFrame = ({ children }: SplitFrameProps) => {
 			<div className="z-10 w-2 -mr-2 resize-handle-horizontal cursor-ew-resize" />
 			<div className="flex" style={{ width: `calc(100% - ${leftSideWidth}%)` }}>
 				<Frame className={mainFrameStyle}>
-					<EditorTabs key={outputHeight as number} />
+					<EditorTabs editorKey={outputHeight as number} />
 					<div className="h-2 -mx-8 cursor-ns-resize resize-handle-vertical" />
 					<div className="px-8 -mx-8 border-0 border-t pt-7 border-t-gray-600" style={{ height: `${outputHeight}%` }}>
 						<OutputTabs />


### PR DESCRIPTION
## Description
Bug:
![image](https://github.com/autokitteh/web-platform/assets/7413072/a5d15891-92f8-4b00-a864-b14b72520a56)

Fix:
https://stackoverflow.com/questions/42261505/getting-error-message-li-key-is-not-a-prop

## Linear ticket
https://linear.app/autokitteh/issue/UI-384/fix-key-error-in-tabs-editor-component

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
