### PR TITLE
fix: display descope login when axios request to login fails

### DIFF
--- a/src/components/templates/descopeMiddleware.tsx
+++ b/src/components/templates/descopeMiddleware.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { IconLogoAuth } from "@assets/image";
 import { Badge, Frame, LogoCatLarge } from "@components/atoms";
 import { baseUrl } from "@constants";
@@ -22,7 +22,7 @@ export const DescopeMiddleware = ({ children }: { children: React.ReactNode }) =
 	const { t } = useTranslation("login");
 	const benefits = Object.values(t("benefits", { returnObjects: true }));
 
-	const [descopeRenderKey, setDescopeRenderKey] = React.useState(0);
+	const [descopeRenderKey, setDescopeRenderKey] = useState(0);
 
 	useEffect(() => {
 		setLogoutFunction(handleLogout);


### PR DESCRIPTION
## Description
Bug: when the axios request to the server fails, we get empty screen instead of the descope login:
![image](https://github.com/autokitteh/web-platform/assets/7413072/1e2f27d9-16e8-45d3-b287-ab7dd3011561)

Fix: Re-render descope component when the request fails by increasing the key of it:
![image](https://github.com/autokitteh/web-platform/assets/7413072/985cede1-2c6f-4622-93ff-c786fad7aadb)


## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
