### PR TITLE
fix: clean files tabs and editor on error or when change project

### DIFF
--- a/src/components/organisms/code/table.tsx
+++ b/src/components/organisms/code/table.tsx
@@ -69,6 +69,7 @@ export const CodeTable = () => {
 
 			getProjectResources(resources);
 		} catch (error) {
+			getProjectResources({});
 			addToast({
 				id: Date.now().toString(),
 				message: (error as Error).message,

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -97,6 +97,8 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 			}
 
 			if (!resources) {
+				state.openedFiles = [];
+
 				return state;
 			}
 


### PR DESCRIPTION
## Description
Bug: when we move between projects, we clean the files tabs, but the content of the editor stays.
Fix: clean the opened files array when we move between projects.

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
