### PR TITLE
ci: fix "no-artifacts" issue for tests timeout in github actions

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
 
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: [
-		["html"],
+		["html", { open: "never" }],
 		["list", { printSteps: true }],
 		["@estruyf/github-actions-reporter", { useDetails: true, showError: true }],
 	],
@@ -67,6 +67,10 @@ export default defineConfig({
 
 	timeout: 2 * 60 * 1000,
 
+	expect: {
+		timeout: 30 * 1000,
+	},
+
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
@@ -74,7 +78,8 @@ export default defineConfig({
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: "on",
-		video: "retain-on-failure",
+		video: "on",
+		screenshot: "on",
 		extraHTTPHeaders: {
 			Authorization: `Bearer ${process.env.TESTS_JWT_AUTH_TOKEN}`,
 		},


### PR DESCRIPTION
## Description
Current bug:
Tests are failing GitHub actions because of Playwright timeout (defined in config), but no report is being uploaded since it's a timeout.
In the current PR we are setting a few things:
- expect timeout
- video and screenshot traces are always on

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
