### PR TITLE
fix: reset connection id on it deletion

### DIFF
--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -74,7 +74,6 @@ export const ConnectionsTable = () => {
 		if (!connectionId) {
 			return;
 		}
-		setConnectionId(undefined);
 		setIsLoadingDeleteConnection(true);
 		const { error } = await ConnectionService.delete(connectionId);
 		setIsLoadingDeleteConnection(false);
@@ -88,6 +87,8 @@ export const ConnectionsTable = () => {
 
 			return;
 		}
+		setConnectionId(undefined);
+
 		fetchConnections();
 	};
 


### PR DESCRIPTION
## Description
When we remove a connection - the ui re-renders and trying to fetch the deleted connection.
Right after we deleted it, we should delete it id so the modal won't try to re-fetch the connection.

## Linear Ticket

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
