### PR TITLE
fix: show loader component only once

### DIFF
--- a/src/components/organisms/code/addModal.tsx
+++ b/src/components/organisms/code/addModal.tsx
@@ -52,7 +52,6 @@ export const AddFileModal = ({ onSuccess }: ModalAddCodeAssetsProps) => {
 			const newFileContent = new TextEncoder().encode(tTabsEditor("initialContentForNewFile"));
 			await addFile(newFile, newFileContent);
 			openFileAsActive(newFile);
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			addToast({
 				message: t("fileAddFailed", { fileName: name }),

--- a/src/components/organisms/code/table.tsx
+++ b/src/components/organisms/code/table.tsx
@@ -87,7 +87,6 @@ export const CodeTable = () => {
 				await saveFile(file.name, fileContent);
 			}
 			fetchResources();
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			addToast({
 				message: tErrors("fileAddFailed", { fileName: files[0]?.name }),
@@ -132,7 +131,6 @@ export const CodeTable = () => {
 		try {
 			await deleteFile(selectedRemoveFileName);
 			getResources();
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			addToast({
 				message: tErrors("failedRemoveFile", { fileName: selectedRemoveFileName }),

--- a/src/components/organisms/deployments/table.tsx
+++ b/src/components/organisms/deployments/table.tsx
@@ -47,8 +47,6 @@ export const DeploymentsTable = () => {
 			return;
 		}
 
-		setIsLoadingDeployments(true);
-
 		try {
 			const { data, error } = await DeploymentsService.listByProjectId(projectId);
 			if (error) {

--- a/src/components/organisms/settings/security/security.tsx
+++ b/src/components/organisms/settings/security/security.tsx
@@ -33,7 +33,6 @@ export const Security = () => {
 				message: t("copySuccess"),
 				type: "success",
 			});
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			addToast({
 				message: t("copyFailure"),

--- a/src/components/organisms/triggers/add.tsx
+++ b/src/components/organisms/triggers/add.tsx
@@ -61,7 +61,6 @@ export const AddTrigger = () => {
 					value: name,
 				}));
 				setFilesNameList(formattedResources);
-				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			} catch (error) {
 				addToast({
 					message: tErrors("resourcesFetchError"),
@@ -108,7 +107,6 @@ export const AddTrigger = () => {
 				type: "success",
 			});
 			navigate(`/projects/${projectId}/triggers/${triggerId}/edit`);
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			addToast({
 				message: tErrors("triggerNotCreated"),

--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -64,7 +64,6 @@ export const EditTrigger = () => {
 					value: name,
 				}));
 				setFilesNameList(formattedResources);
-				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			} catch (error) {
 				addToast({
 					message: tErrors("resourcesFetchError"),
@@ -128,7 +127,6 @@ export const EditTrigger = () => {
 				message: t("updatedSuccessfully"),
 				type: "success",
 			});
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			addToast({
 				message: tErrors("triggerNotUpdated"),

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -6,7 +6,6 @@ declare module "*.svg" {
 // For handling SVG imports with the '?react' query
 
 declare module "*.svg?react" {
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	import React = require("react");
 
 	const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -274,7 +274,6 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		try {
 			await navigator.clipboard.writeText(text);
 			toastAndLog("success", "copySuccess", true);
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			toastAndLog("error", "copyError", true);
 		}

--- a/src/services/integrations.service.ts
+++ b/src/services/integrations.service.ts
@@ -15,7 +15,6 @@ export class IntegrationsService {
 			const integrationsConverted = integrations.map(convertIntegrationProtoToModel);
 
 			return { data: integrationsConverted, error: undefined };
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			const errorMessage = i18n.t("intergrationsNotFound", { ns: "services" });
 			LoggerService.error(namespaces.integrationService, errorMessage);

--- a/src/utilities/copyToClipboard.utils.ts
+++ b/src/utilities/copyToClipboard.utils.ts
@@ -5,7 +5,6 @@ export const copyToClipboard = async (text: string): Promise<{ isError: boolean;
 		await navigator.clipboard.writeText(text);
 
 		return { isError: false, message: i18n.t("copySuccess", { ns: "global" }) };
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	} catch (error) {
 		return { isError: false, message: i18n.t("copyFailure", { ns: "global" }) };
 	}


### PR DESCRIPTION
## Description

## Linear Ticket
https://linear.app/autokitteh/issue/UI-587/show-loader-component-only-once-in-deployments-page
## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
