### PR TITLE
fix: reload deployments on manual run

### DIFF
--- a/src/components/organisms/deployments/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/deployments/manualRunSettingsDrawer.tsx
@@ -17,7 +17,7 @@ import { ManualRunParamsForm, ManualRunSuccessToastMessage } from "@components/o
 
 import { RunIcon } from "@assets/image";
 
-export const ManualRunSettingsDrawer = () => {
+export const ManualRunSettingsDrawer = ({ onRun }: { onRun: () => void }) => {
 	const { t: tButtons } = useTranslation("buttons");
 	const { t } = useTranslation("deployments", { keyPrefix: "history.manualRun" });
 	const { closeDrawer } = useDrawerStore();
@@ -81,6 +81,7 @@ export const ManualRunSettingsDrawer = () => {
 
 		const { data: sessionId, error } = await saveProjectManualRun(projectId, params);
 		setSendingManualRun(false);
+		onRun();
 		if (error) {
 			addToast({
 				message: t("executionFailed"),

--- a/src/components/organisms/deployments/table.tsx
+++ b/src/components/organisms/deployments/table.tsx
@@ -215,7 +215,7 @@ export const DeploymentsTable = () => {
 				<DeploymentsTableContent deployments={deployments} updateDeployments={() => fetchDeployments(false)} />
 			) : null}
 
-			<ManualRunSettingsDrawer />
+			<ManualRunSettingsDrawer onRun={() => fetchDeployments()} />
 		</Frame>
 	);
 };


### PR DESCRIPTION
## Description
After we run the manual run - the deployments table should refresh.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-597/on-session-manual-run-error-update-deployments

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
