### PR TITLE
feat: cache connections

### DIFF
--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -6,10 +6,10 @@ import { useNavigate, useParams } from "react-router-dom";
 import { ModalName } from "@enums/components";
 import { ConnectionService, LoggerService } from "@services";
 import { namespaces } from "@src/constants";
+import { useCacheStore, useConnectionCheckerStore, useModalStore, useToastStore } from "@src/store";
 import { Connection } from "@type/models";
 
 import { useSort } from "@hooks";
-import { useConnectionCheckerStore, useModalStore, useProjectValidationStore, useToastStore } from "@store";
 
 import { Button, IconButton, IconSvg, Loader, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import { ConnectionTableStatus, EmptyTableAddButton, SortButton } from "@components/molecules";
@@ -24,45 +24,23 @@ export const ConnectionsTable = () => {
 	const { closeModal, openModal } = useModalStore();
 	const { projectId } = useParams();
 	const navigate = useNavigate();
-	const { checkState } = useProjectValidationStore();
 
-	const [isLoading, setIsLoading] = useState(false);
 	const [isLoadingDeleteConnection, setIsLoadingDeleteConnection] = useState(false);
-	const [connections, setConnections] = useState<Connection[]>([]);
 	const [connectionId, setConnectionId] = useState<string>();
+
+	const {
+		connections,
+		fetchConnections,
+		loading: { connections: isLoading },
+	} = useCacheStore();
 
 	const addToast = useToastStore((state) => state.addToast);
 	const { items: sortedConnections, requestSort, sortConfig } = useSort<Connection>(connections, "name");
 	const { resetChecker, setFetchConnectionsCallback } = useConnectionCheckerStore();
 
-	const fetchConnections = useCallback(async () => {
-		setIsLoading(true);
-		try {
-			const { data: connectionsResponse, error } = await ConnectionService.listByProjectId(projectId!);
-			if (error) {
-				throw error;
-			}
-			if (!connectionsResponse) {
-				return;
-			}
-
-			setConnections(connectionsResponse);
-			checkState(projectId!, true);
-		} catch (error) {
-			addToast({
-				message: (error as Error).message,
-				type: "error",
-			});
-		} finally {
-			setIsLoading(false);
-		}
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
 	useEffect(() => {
-		fetchConnections();
-		setFetchConnectionsCallback(fetchConnections);
+		fetchConnections(projectId!);
+		setFetchConnectionsCallback(() => fetchConnections(projectId!));
 
 		return () => {
 			resetChecker();
@@ -100,7 +78,7 @@ export const ConnectionsTable = () => {
 		setConnectionId(undefined);
 		resetChecker();
 
-		const connection = connections.find((connection) => connection.connectionId === connectionId);
+		const connection = connections.find((connection: Connection) => connection.connectionId === connectionId);
 
 		addToast({
 			message: t("connectionRemoveSuccess", { connectionName: connection?.name }),
@@ -112,7 +90,7 @@ export const ConnectionsTable = () => {
 			t("connectionRemoveSuccessExtended", { connectionId, connectionName: connection?.name })
 		);
 
-		fetchConnections();
+		fetchConnections(projectId!);
 	};
 
 	const handleConnectionEditClick = useCallback(

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -90,7 +90,7 @@ export const ConnectionsTable = () => {
 			t("connectionRemoveSuccessExtended", { connectionId, connectionName: connection?.name })
 		);
 
-		fetchConnections(projectId!);
+		fetchConnections(projectId!, true);
 	};
 
 	const handleConnectionEditClick = useCallback(

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -13,7 +13,7 @@ import { namespaces } from "@src/constants";
 import { ConnectionAuthType } from "@src/enums";
 import { Integrations, defaultGoogleConnectionName } from "@src/enums/components";
 import { SelectOption } from "@src/interfaces/components";
-import { useConnectionCheckerStore, useToastStore } from "@src/store";
+import { useCacheStore, useConnectionCheckerStore, useProjectValidationStore, useToastStore } from "@src/store";
 import { FormMode } from "@src/types/components";
 import { Variable } from "@src/types/models";
 import { flattenFormData, getApiBaseUrl, openPopup } from "@src/utilities";
@@ -32,6 +32,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 	const apiBaseUrl = getApiBaseUrl();
 	const [formSchema, setFormSchema] = useState<ZodObject<ZodRawShape>>(validationSchema);
 	const { startCheckingStatus } = useConnectionCheckerStore();
+	const { checkState } = useProjectValidationStore();
 
 	const {
 		clearErrors,
@@ -57,6 +58,8 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 	const [connectionName, setConnectionName] = useState<string>();
 	const [integration, setIntegration] = useState<SingleValue<SelectOption>>();
 	const addToast = useToastStore((state) => state.addToast);
+
+	const { fetchConnections } = useCacheStore();
 
 	const getConnectionAuthType = async (connectionId: string) => {
 		const { data: vars, error } = await VariablesService.list(connectionId);
@@ -272,6 +275,8 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 			);
 
 			setConnectionId(responseConnectionId);
+			fetchConnections(projectId!, true);
+			checkState(projectId!, true);
 		} catch (error) {
 			addToast({
 				message: tErrors("connectionNotCreated"),

--- a/src/interfaces/store/cacheStore.interface.ts
+++ b/src/interfaces/store/cacheStore.interface.ts
@@ -1,19 +1,22 @@
-import { Deployment, Trigger, Variable } from "@src/types/models";
+import { Connection, Deployment, Trigger, Variable } from "@src/types/models";
 
 interface LoadingState {
 	deployments: boolean;
 	triggers: boolean;
 	variables: boolean;
+	connections: boolean;
 }
 
 export interface CacheStore {
 	deployments?: Deployment[];
 	triggers: Trigger[];
 	variables: Variable[];
+	connections: Connection[];
 	loading: LoadingState;
 	currentProjectId?: string;
 	envId?: string;
 	fetchDeployments: (projectId: string, force?: boolean) => Promise<void | Deployment[]>;
 	fetchTriggers: (projectId: string, force?: boolean) => Promise<void | Trigger[]>;
 	fetchVariables: (projectId: string, force?: boolean) => Promise<void | Variable[]>;
+	fetchConnections: (projectId: string, force?: boolean) => Promise<void | Connection[]>;
 }

--- a/src/interfaces/store/connectionCheckerStore.interface.ts
+++ b/src/interfaces/store/connectionCheckerStore.interface.ts
@@ -1,3 +1,5 @@
+import { Connection } from "@src/types/models";
+
 export interface ConnectionCheckerStore {
 	retries: number;
 	incrementRetries: () => void;
@@ -5,6 +7,6 @@ export interface ConnectionCheckerStore {
 	recheckIntervalId: NodeJS.Timeout | null;
 	startCheckingStatus: (connectionId: string) => void;
 	avoidNextRerenderCleanup: boolean;
-	fetchConnectionsCallback: (() => void) | null;
-	setFetchConnectionsCallback: (callback: (() => Promise<void>) | null) => void;
+	fetchConnectionsCallback: (() => Promise<void | Connection[]>) | null;
+	setFetchConnectionsCallback: (callback: (() => Promise<void | Connection[]>) | null) => void;
 }

--- a/src/locales/en/errors/translation.json
+++ b/src/locales/en/errors/translation.json
@@ -9,6 +9,8 @@
 	"errorEditingNewConnectionExtended": "Error while editing a connection, error: {{error}}",
 	"errorFetchingConnection": "Error while fetching connection, connection ID: {{connectionId}}",
 	"errorFetchingDeployments": "Error fetching deployments",
+	"errorFetchingConnections": "Error fetching connections",
+	"errorFetchingConnectionsExtended": "Error fetching connections, error: {{error}}",
 	"errorFetchingDeploymentsExtended": "Error fetching deployments, error: {{error}}",
 	"errorFetchingConnectionType": "Error while fetching connection authentication type",
 	"errorFetchingConnectionTypeUnknown": "Unknown connection authentication type",

--- a/src/store/cache/useCacheStore.ts
+++ b/src/store/cache/useCacheStore.ts
@@ -38,7 +38,7 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 
 	fetchConnections: async (projectId, force) => {
 		const { connections, currentProjectId } = get();
-		if (currentProjectId === projectId && !force && connections) {
+		if (currentProjectId === projectId && !force && connections.length) {
 			return connections;
 		}
 

--- a/src/store/useConnectionCheckerStore.ts
+++ b/src/store/useConnectionCheckerStore.ts
@@ -7,7 +7,7 @@ import { StoreName } from "@enums";
 import { ConnectionCheckerStore } from "@interfaces/store";
 import { ConnectionService, LoggerService } from "@services";
 import { namespaces } from "@src/constants";
-import { ConnectionStatusType } from "@type/models";
+import { Connection, ConnectionStatusType } from "@type/models";
 
 import { useToastStore } from "@store";
 
@@ -15,7 +15,7 @@ const store: StateCreator<ConnectionCheckerStore> = (set, get) => ({
 	retries: 0,
 	recheckIntervalId: null,
 	avoidNextRerenderCleanup: true,
-	fetchConnectionsCallback: () => {},
+	fetchConnectionsCallback: null,
 
 	incrementRetries: () => {
 		set((state) => {
@@ -25,7 +25,7 @@ const store: StateCreator<ConnectionCheckerStore> = (set, get) => ({
 		});
 	},
 
-	setFetchConnectionsCallback: (callback: (() => void) | null) => {
+	setFetchConnectionsCallback: (callback: (() => Promise<void | Connection[]>) | null) => {
 		set((state) => {
 			state.fetchConnectionsCallback = callback;
 


### PR DESCRIPTION
## Description
Cache the connections to behave following way:
1. If the user fetched the connections list once, it won't change until:
- The user won't refresh the page
- The user won't create/edit or delete a connection

## Linear Ticket
https://linear.app/autokitteh/issue/UI-650/cache-connections

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
