### PR TITLE
fix: manual run

### DIFF
--- a/src/utilities/convertBuildRuntimesToViewTriggers.utils.ts
+++ b/src/utilities/convertBuildRuntimesToViewTriggers.utils.ts
@@ -6,11 +6,11 @@ import { BuildInfoRuntimes, SessionEntrypoint } from "@type/models";
 
 const processRuntime = (runtime: BuildInfoRuntimes): Record<string, SessionEntrypoint[]> => {
 	const result: Record<string, SessionEntrypoint[]> = {};
-	const fileNames = Object.keys(runtime.artifact.compiled_data).filter((fileName) => fileName !== "archive");
+	const fileNames = Object.keys(runtime.artifact.compiled_data)?.filter((fileName) => fileName !== "archive");
 
-	fileNames.forEach((fileName) => {
+	fileNames?.forEach((fileName) => {
 		const entrypointsForFile = runtime.artifact.exports
-			.filter(({ location: { path }, symbol: name }) => path === fileName && !name.startsWith("_"))
+			?.filter(({ location: { path }, symbol: name }) => path === fileName && !name.startsWith("_"))
 			.map(({ location: { col, path, row }, symbol: name }) => ({
 				path,
 				row,


### PR DESCRIPTION
## Description
Allow the user to open the Manual Run configuration when there are no runtimes.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-667/allow-the-user-to-open-the-manual-run-configuration-when-there-are-no

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
