### PR TITLE
refactor: dont capitalize in placeholders

### DIFF
--- a/src/locales/en/deployments/translation.json
+++ b/src/locales/en/deployments/translation.json
@@ -41,8 +41,8 @@
 				"entrypoint": "Entrypoint",
 				"key": "Key",
 				"value": "Value",
-				"enterKey": "Enter Key",
-				"enterValue": "Enter Value"
+				"enterKey": "Enter key",
+				"enterValue": "Enter value"
 			},
 			"buttons": {
 				"addNewParameter": "Add Parameter"


### PR DESCRIPTION
## Description
Task: Don't capitalize all words in manual-run param tips

This should be consistent with other fields tips in the UI that are capitalized like sentences, not like titles:

1. "Enter Key" -> "Enter key"
2. "Enter Value" -> "Enter value"

## Linear Ticket
https://linear.app/autokitteh/issue/UI-685/dont-capitalize-all-words-in-manual-run-param-tips

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
