### PR TITLE
fix: add check if manual run parameters keys are unique

### DIFF
--- a/src/locales/en/validations/translation.json
+++ b/src/locales/en/validations/translation.json
@@ -6,5 +6,6 @@
     "functionNameIsRequired": "Function name is required",
     "nameIsRequired": "Name is required",
     "valueIsRequired": "Value is required",
-    "keyIsRequired": "Key is required"
+    "keyIsRequired": "Key is required",
+    "duplicateKeyError": "Key must be unique"
 }

--- a/src/validations/manualRun.schema.ts
+++ b/src/validations/manualRun.schema.ts
@@ -22,15 +22,31 @@ i18n.on("initialized", () => {
 		params: z
 			.array(paramSchema)
 			.superRefine((items, ctx) => {
+				const keys = new Set<string>();
 				items.forEach((item, index) => {
-					if (item.key?.trim().length === 0) {
+					if (!item.key?.trim()) {
 						ctx.addIssue({
 							code: z.ZodIssueCode.custom,
 							message: i18n.t("keyIsRequired", { ns: "validations" }),
 							path: [`params.${index}.key`],
 						});
+
+						return;
 					}
-					if (item.value?.trim().length === 0) {
+
+					if (keys.has(item.key)) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							message: i18n.t("duplicateKeyError", { ns: "validations" }),
+							path: [`params.${index}.key`],
+						});
+
+						return;
+					}
+
+					keys.add(item.key);
+
+					if (!item.value?.trim()) {
 						ctx.addIssue({
 							code: z.ZodIssueCode.custom,
 							message: i18n.t("valueIsRequired", { ns: "validations" }),


### PR DESCRIPTION
## Description
When you add params to a manual run, the keys must be unique.

The following is invalid:
![image](https://github.com/user-attachments/assets/f6c47504-100b-48e6-b840-7a8f00717824)

## Linear Ticket
https://linear.app/autokitteh/issue/UI-682/param-keys-need-to-be-unique-in-manual-runs

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
