### PR TITLE
fix: google form connection issues with the connection form

### DIFF
--- a/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
@@ -19,8 +19,8 @@ export const OauthGoogleFormsForm = ({ register }: { register: UseFormRegister<{
 				<Input
 					label={t("google.labels.formId")}
 					{...register("form_id")}
-					aria-label={t("google.placeholders.calendarId")}
-					placeholder={t("google.placeholders.calendarId")}
+					aria-label={t("google.placeholders.formId")}
+					placeholder={t("google.placeholders.formId")}
 				/>
 			</div>
 			<Button

--- a/src/components/organisms/connections/integrations/googleforms/edit.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/edit.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { selectIntegrationGoogle } from "@constants/lists/connections";
 import { ConnectionAuthType } from "@enums";
 import { Integrations } from "@src/enums/components";
-import { googleIntegrationSchema, oauthSchema } from "@validations";
+import { googleFormsIntegrationSchema, oauthSchema } from "@validations";
 
 import { IntegrationEditForm } from "@components/organisms/connections/integrations";
 
@@ -14,9 +14,9 @@ export const GoogleFormsIntegrationEditForm = ({
 }) => (
 	<IntegrationEditForm
 		googleIntegrationApplication={googleIntegrationApplication}
-		integrationType={Integrations.google}
+		integrationType={Integrations.forms}
 		schemas={{
-			[ConnectionAuthType.JsonKey]: googleIntegrationSchema,
+			[ConnectionAuthType.JsonKey]: googleFormsIntegrationSchema,
 			[ConnectionAuthType.Oauth]: oauthSchema,
 		}}
 		selectOptions={selectIntegrationGoogle}

--- a/src/locales/en/integrations/translation.json
+++ b/src/locales/en/integrations/translation.json
@@ -49,13 +49,12 @@
 		},
 		"labels":{
 			"calendarId":"Calendar ID (optional)",
-			"formId": "Form ID"
+			"formId": "Form ID (optional)"
 		},
 		"placeholders": {
 			"jsonKey": "JSON Key",
 			"calendarId": "Optional: Calendar ID (To Receive Events, e.g. 'primary')",
 			"formId": "Optional: Form ID (To Receive Events)"
-
 		}
 	},
 	"slack": {


### PR DESCRIPTION
## Description

1. The tip inside the field was copied from Google Calendar, so it's wrong, it should be "Optional: Form ID (To Receive Events)"
2. When editing an existing Google Forms connection, the form ID field isn't displayed at all, it should always be visible, like in calendar connections
3. 

## Linear Ticket
https://linear.app/autokitteh/issue/UI-700/3-issues-with-form-id-field-in-google-forms-connections

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
