### PR TITLE
fix: prevent connections-checker retries on project delete

### DIFF
--- a/src/components/organisms/topbar/project/buttons.tsx
+++ b/src/components/organisms/topbar/project/buttons.tsx
@@ -7,7 +7,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { ModalName, TopbarButton } from "@enums/components";
 import { LoggerService, ProjectsService } from "@services";
 import { namespaces } from "@src/constants";
-import { useCacheStore, useModalStore, useProjectStore, useProjectValidationStore, useToastStore } from "@src/store";
+import {
+	useCacheStore,
+	useConnectionCheckerStore,
+	useModalStore,
+	useProjectStore,
+	useProjectValidationStore,
+	useToastStore,
+} from "@src/store";
 
 import { useFileOperations } from "@hooks";
 
@@ -27,6 +34,7 @@ export const ProjectTopbarButtons = () => {
 	const { isValid, projectValidationState } = useProjectValidationStore();
 	const projectValidationErrors = Object.values(projectValidationState).filter((error) => error.message !== "");
 	const projectErrors = isValid ? "" : Object.values(projectValidationErrors).join(", ");
+	const { resetChecker } = useConnectionCheckerStore();
 
 	const { deleteProject } = useProjectStore();
 	const addToast = useToastStore((state) => state.addToast);
@@ -133,6 +141,9 @@ export const ProjectTopbarButtons = () => {
 
 			return;
 		}
+
+		resetChecker();
+
 		addToast({
 			message: t("topbar.deleteProjectSuccess"),
 			type: "success",


### PR DESCRIPTION
## Description
When we start OAuth with some of the connections, we also start an engine that checks in the background if the connection status changed, and if so, it updates the table.

But if we delete a project, the checker doesn't stop and keep checking, but the project is gone, and also the connection, so it raises an error toast every 10 seconds, which should be fixed by stopping the checker interval after a project is deleted.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-718/prevent-connections-checker-retries-to-fetch-connection-status-after-a

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
