### PR TITLE
refactor: add project tabs divider

### DIFF
--- a/src/components/atoms/tabs/tab.tsx
+++ b/src/components/atoms/tabs/tab.tsx
@@ -8,7 +8,7 @@ import { TabsContext } from "@components/atoms/tabs/tabsContext";
 export const Tab = ({ activeTab, ariaLabel, children, className, onClick, title, value, variant }: TabProps) => {
 	const { setActiveTab } = useContext(TabsContext);
 	const tabStyle = cn(
-		"cursor-pointer border-b-2 border-transparent pb-1 uppercase tracking-tight text-gray-500 ml-2",
+		"cursor-pointer border-b-2 border-transparent pb-1 uppercase tracking-tight text-gray-500",
 		{
 			"border-white text-white": activeTab === value,
 			"text-gray-1200": variant === "dark",

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -5,7 +5,7 @@ import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { defaultProjectTab, projectTabs } from "@constants/project.constants";
 import { useProjectStore, useProjectValidationStore } from "@src/store";
-import { calculatePathDepth } from "@utilities";
+import { calculatePathDepth, cn } from "@utilities";
 
 import { IconSvg, PageTitle, Tab } from "@components/atoms";
 import { SplitFrame } from "@components/organisms";
@@ -53,12 +53,13 @@ export const Project = () => {
 				{displayTabs ? (
 					<div className="flex h-full flex-1 flex-col">
 						<div className="sticky -top-8 z-20 -mt-5 bg-gray-1100 pb-0 pt-3">
-							<div className="scrollbar sm:px-4 md:px-6 flex shrink-0 select-none items-center overflow-x-auto overflow-y-hidden whitespace-nowrap px-2 pb-5 pt-1">
+							<div className="scrollbar flex shrink-0 select-none items-center overflow-x-auto overflow-y-hidden whitespace-nowrap pb-5 pt-1">
 								{projectTabs.map((tabKey, index) => {
 									const tabState =
 										projectValidationState[tabKey.value as keyof typeof projectValidationState];
 									const warning = tabState.level === "warning" ? tabState.message : "";
 									const error = tabState.level === "error" ? tabState.message : "";
+									const tabClass = cn("py-1 pr-1", { "ml-2": index !== 0 });
 
 									return (
 										<div className="flex items-center" key={tabKey.value}>
@@ -66,7 +67,7 @@ export const Project = () => {
 											<Tab
 												activeTab={activeTab}
 												ariaLabel={tabState?.message || tabKey.label}
-												className="p-1"
+												className={tabClass}
 												onClick={() => goTo(tabKey.value)}
 												title={tabState?.message || tabKey.label}
 												value={tabKey.value}


### PR DESCRIPTION
## Description
This shows a project with warnings in both the connections and the triggers:
![image](https://github.com/user-attachments/assets/799e453f-3f08-4774-8081-ffdc793e3f57)

The tabs are too close to each other - so it's not obvious to the user what is the meaning of the yellow warning icons.

The result after the modification:
![image](https://github.com/user-attachments/assets/9bb50587-dad7-4829-9825-ebcdaa006a05)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-689/tabs-in-assets-page-too-close-so-warning-icons-are-unclear

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
