### PR TITLE
fix: fetch missing logs state to display the final error

### DIFF
--- a/src/services/sessions.service.ts
+++ b/src/services/sessions.service.ts
@@ -41,7 +41,7 @@ export class SessionsService {
 		try {
 			const selectedTypes =
 				logType === SessionLogType.Output
-					? SessionLogRecord_Type.PRINT
+					? SessionLogRecord_Type.PRINT | SessionLogRecord_Type.STATE
 					: SessionLogRecord_Type.CALL_SPEC |
 						SessionLogRecord_Type.CALL_ATTEMPT_START |
 						SessionLogRecord_Type.CALL_ATTEMPT_COMPLETE;


### PR DESCRIPTION
## Description
The last error for a failed session is stored in a session log record of "state" type, and for this moment, we are not displaying it on our WebUI.
This means any final state (error/completed/stopped) information is not displayed.
This means that if we had an exception in the session run, but we had no prints before the exception, we won't see any logs:

![image](https://github.com/user-attachments/assets/6e7cf854-66a9-45a5-b58f-da8cebaa0c2e)

## Linear Ticket
https://linear.app/autokitteh/issue/UI-733/fix-missing-logs-for-a-session

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
