### PR TITLE
fix: display form and cal and json in google connection forms

### DIFF
--- a/src/components/organisms/connections/integrations/googleforms/add.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/add.tsx
@@ -9,7 +9,7 @@ import { ConnectionAuthType } from "@enums";
 import { SelectOption } from "@interfaces/components";
 import { Integrations, defaultGoogleConnectionName } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
-import { googleFormsIntegrationSchema, googleIntegrationSchema, oauthSchema } from "@validations";
+import { googleFormsIntegrationSchema, oauthSchema } from "@validations";
 
 import { Select } from "@components/molecules";
 
@@ -64,7 +64,7 @@ export const GoogleFormsIntegrationAddForm = ({
 			return;
 		}
 		setValue("auth_type", ConnectionAuthType.Json);
-		setValidationSchema(googleIntegrationSchema);
+		setValidationSchema(googleFormsIntegrationSchema);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionType, type]);

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -87,18 +87,14 @@ export const IntegrationEditForm = ({
 	};
 
 	useEffect(() => {
-		const formId = connectionVariables?.find((variable) => variable.name === "FormID")?.value;
-		if (formId) {
-			setValue("form_id", formId);
-		}
-		const calendarId = connectionVariables?.find((variable) => variable.name === "CalendarID")?.value;
-		if (calendarId) {
-			setValue("cal_id", calendarId);
-		}
-		const jsonKey = connectionVariables?.find((variable) => variable.name === "JSON")?.value;
-		if (jsonKey) {
-			setValue("json", jsonKey);
-		}
+		const setFormValue = (fieldName: string, variableName: string) => {
+			const value = connectionVariables?.find((variable) => variable.name === variableName)?.value;
+			if (!value) return;
+			setValue(fieldName, value);
+		};
+		setFormValue("form_id", "FormID");
+		setFormValue("cal_id", "CalendarID");
+		setFormValue("json", "JSON");
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -25,6 +25,7 @@ export const IntegrationEditForm = ({
 	const {
 		connectionId,
 		connectionType,
+		connectionVariables,
 		copyToClipboard,
 		errors,
 		handleGoogleOauth,
@@ -84,6 +85,22 @@ export const IntegrationEditForm = ({
 		}
 		onSubmitEdit();
 	};
+
+	useEffect(() => {
+		const formId = connectionVariables?.find((variable) => variable.name === "FormID")?.value;
+		if (formId) {
+			setValue("form_id", formId);
+		}
+		const calendarId = connectionVariables?.find((variable) => variable.name === "CalendarID")?.value;
+		if (calendarId) {
+			setValue("cal_id", calendarId);
+		}
+		const jsonKey = connectionVariables?.find((variable) => variable.name === "JSON")?.value;
+		if (jsonKey) {
+			setValue("json", jsonKey);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [connectionVariables]);
 
 	const handleConnectionTypeChange = (option: SingleValue<SelectOption>) => {
 		setIsFirstConnectionType(false);

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -96,10 +96,10 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		integrationName?: string
 	) => {
 		const connectionData = flattenFormData(getValues(), formSchema);
-		let formattedIntegrationName = integrationName;
-		if (integrationName && isGoogleIntegration(stripGoogleConnectionName(integrationName) as Integrations)) {
-			formattedIntegrationName = defaultGoogleConnectionName;
-		}
+		const formattedIntegrationName =
+			integrationName && isGoogleIntegration(stripGoogleConnectionName(integrationName) as Integrations)
+				? defaultGoogleConnectionName
+				: integrationName;
 
 		return { connectionData, formattedIntegrationName };
 	};

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -11,12 +11,12 @@ import { ZodObject, ZodRawShape } from "zod";
 import { ConnectionService, HttpService, LoggerService, VariablesService } from "@services";
 import { namespaces } from "@src/constants";
 import { ConnectionAuthType } from "@src/enums";
-import { Integrations, defaultGoogleConnectionName } from "@src/enums/components";
+import { Integrations, defaultGoogleConnectionName, isGoogleIntegration } from "@src/enums/components";
 import { SelectOption } from "@src/interfaces/components";
 import { useConnectionCheckerStore, useToastStore } from "@src/store";
 import { FormMode } from "@src/types/components";
 import { Variable } from "@src/types/models";
-import { flattenFormData, getApiBaseUrl, openPopup } from "@src/utilities";
+import { flattenFormData, getApiBaseUrl, openPopup, stripGoogleConnectionName } from "@src/utilities";
 
 const GoogleIntegrationsPrefixRequired = [
 	Integrations.sheets,
@@ -96,8 +96,12 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		integrationName?: string
 	) => {
 		const connectionData = flattenFormData(getValues(), formSchema);
+		let formattedIntegrationName = integrationName;
+		if (integrationName && isGoogleIntegration(stripGoogleConnectionName(integrationName) as Integrations)) {
+			formattedIntegrationName = defaultGoogleConnectionName;
+		}
 
-		return { connectionData, formattedIntegrationName: integrationName };
+		return { connectionData, formattedIntegrationName };
 	};
 
 	const getSpecificParams = (connectionData: Record<string, string>, specificKeys: string[]) => {


### PR DESCRIPTION
## Description
1. User creates a Google Calendar/Forms connection and specifies a calendar/form ID
2. User edits the connection

Expected: the previously-specified ID should be displayed in the ID field
Actual: the ID field is always empty when editing an existing connection, even if an ID was specified originally

## Linear Ticket
https://linear.app/autokitteh/issue/UI-734/show-previous-calendar-and-form-ids-when-editing-google-connections

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
