### PR TITLE
fix: add session viewer loading state

### DIFF
--- a/src/components/organisms/deployments/sessions/table.tsx
+++ b/src/components/organisms/deployments/sessions/table.tsx
@@ -216,7 +216,7 @@ export const SessionsTable = () => {
 
 			<Button className={resizeClass} />
 
-			<div className="flex" style={{ width: `${100 - (leftSideWidth as number)}%` }}>
+			<div className="flex bg-black" style={{ width: `${100 - (leftSideWidth as number)}%` }}>
 				{sessionId ? (
 					<Outlet />
 				) : (

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -13,7 +13,7 @@ import { SessionState } from "@src/enums";
 import { useActivitiesCacheStore, useOutputsCacheStore, useToastStore } from "@src/store";
 import { ViewerSession } from "@src/types/models/session.type";
 
-import { Frame, IconButton, IconSvg, LogoCatLarge, Tab } from "@components/atoms";
+import { Frame, IconButton, IconSvg, Loader, LogoCatLarge, Tab } from "@components/atoms";
 import { Accordion, CopyButton, RefreshButton } from "@components/molecules";
 import { SessionsTableState } from "@components/organisms/deployments";
 
@@ -44,10 +44,9 @@ export const SessionViewer = () => {
 	);
 
 	const fetchSessionInfo = useCallback(async () => {
-		if (!sessionId) return;
 		setIsLoading(true);
 		try {
-			const { data: sessionInfoResponse, error } = await SessionsService.getSessionInfo(sessionId);
+			const { data: sessionInfoResponse, error } = await SessionsService.getSessionInfo(sessionId!);
 			if (error) {
 				addToast({ message: tErrors("fetchSessionFailed"), type: "error" });
 
@@ -121,7 +120,9 @@ export const SessionViewer = () => {
 
 	if (!sessionInfo) return null;
 
-	return (
+	return isLoading ? (
+		<Loader size="xl" />
+	) : (
 		<Frame className="overflow-hidden rounded-l-none pb-3 font-fira-code">
 			<div className="flex items-center justify-between border-b border-gray-950 pb-3.5">
 				<div className="flex gap-3 font-fira-sans text-base text-gray-500">


### PR DESCRIPTION
## Description
Current state: when you click on a session in the sessions table - white screen flashes.
Fix: set the section background to black and add a loader.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-741/loading-state-for-session-info-open

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
