### PR TITLE
fix: enlarge row height when the window is smaller

### DIFF
--- a/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { AutoSizer, InfiniteLoader, List, ListRowProps } from "react-virtualized";
 
@@ -22,6 +22,20 @@ export const ActivityList = () => {
 		nextPageToken,
 		t,
 	} = useVirtualizedList<SessionActivity>(SessionLogType.Activity, 60);
+
+	const [rowHeight, setRowHeight] = useState(60);
+
+	useEffect(() => {
+		const handleResize = () => {
+			setRowHeight(window.innerWidth < 1500 ? 80 : 60);
+		};
+
+		handleResize();
+
+		window.addEventListener("resize", handleResize);
+
+		return () => window.removeEventListener("resize", handleResize);
+	}, []);
 
 	const customRowRenderer = useCallback(
 		({ index, key, style }: ListRowProps) => (
@@ -85,7 +99,7 @@ export const ActivityList = () => {
 									}
 								}}
 								rowCount={activities.length}
-								rowHeight={60}
+								rowHeight={rowHeight}
 								rowRenderer={customRowRenderer}
 								width={width}
 							/>

--- a/src/components/organisms/deployments/sessions/tabs/activities/infiniteRow.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/infiniteRow.tsx
@@ -36,7 +36,7 @@ const ActivityRow = memo(({ data: activity, setActivity, style }: ActivityRowPro
 
 	return (
 		<div
-			className="group flex w-full cursor-pointer gap-2.5 p-2 text-white hover:bg-gray-700"
+			className="scrollbar group flex w-full cursor-pointer gap-2.5 overflow-x-auto p-2 text-white hover:bg-gray-700"
 			onClick={handleClick}
 			onKeyDown={handleKeyDown}
 			role="button"


### PR DESCRIPTION
## Description
In almost every function long enough, it will take 2 rows on a smaller screen sizes, this screenshot is from 1440*900px resolution:
![image](https://github.com/user-attachments/assets/17dbc843-d4ca-4427-952d-2008c1c11756)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-742/increase-the-height-of-a-row-in-the-activity-log

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
