### PR TITLE
refactor: move webhook url in triggers to the end of the form

### DIFF
--- a/src/components/atoms/input.tsx
+++ b/src/components/atoms/input.tsx
@@ -61,6 +61,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 				"border-white": hasValue && variant !== InputVariant.light,
 				"pointer-events-none select-none border-gray-950": disabled,
 				"border-error": isError,
+				"border-gray-950": hasValue,
 			},
 			className
 		);

--- a/src/components/organisms/triggers/add.tsx
+++ b/src/components/organisms/triggers/add.tsx
@@ -107,7 +107,9 @@ export const AddTrigger = () => {
 
 			checkState(projectId!, true);
 			await fetchTriggers(projectId!, true);
-			navigate(`/projects/${projectId}/triggers/${triggerId}/edit`);
+			navigate(`/projects/${projectId}/triggers/${triggerId}/edit`, {
+				state: { highlightWebhookUrl: true },
+			});
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		} catch (error) {
 			addToast({
@@ -142,11 +144,11 @@ export const AddTrigger = () => {
 				>
 					<NameAndConnectionFields connections={connections} />
 
-					{connectionType === TriggerTypes.webhook ? <WebhookFields /> : null}
-
 					{connectionType === TriggerTypes.schedule ? <SchedulerFields /> : null}
 
 					<TriggerSpecificFields filesNameList={filesNameList} />
+
+					{connectionType === TriggerTypes.webhook ? <WebhookFields /> : null}
 				</form>
 
 				{connectionType === TriggerTypes.schedule ? <SchedulerInfo /> : null}

--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import { z } from "zod";
 
 import { TriggerSpecificFields } from "./formParts/fileAndFunction";
@@ -32,7 +32,9 @@ export const EditTrigger = () => {
 	const { t } = useTranslation("tabs", { keyPrefix: "triggers.form" });
 	const { t: tErrors } = useTranslation("errors");
 	const addToast = useToastStore((state) => state.addToast);
-
+	const location = useLocation();
+	const navigationData = location.state;
+	const [webhookUrlHighlight, setWebhookUrlHighlight] = useState(false);
 	const { connections, isLoading: isLoadingConnections } = useFetchConnections(projectId!);
 	const { isLoading: isLoadingTrigger, trigger } = useFetchTrigger(triggerId!);
 	const { fetchResources } = useFileOperations(projectId!);
@@ -40,6 +42,10 @@ export const EditTrigger = () => {
 
 	const [filesNameList, setFilesNameList] = useState<SelectOption[]>([]);
 	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		setWebhookUrlHighlight(navigationData?.highlightWebhookUrl || false);
+	}, [navigationData]);
 
 	const methods = useForm<TriggerFormData>({
 		defaultValues: {
@@ -164,11 +170,11 @@ export const EditTrigger = () => {
 
 					{trigger?.sourceType === TriggerTypes.schedule ? <SchedulerFields /> : null}
 
-					{trigger?.sourceType === TriggerTypes.webhook ? (
-						<WebhookFields webhookSlug={trigger.webhookSlug || ""} />
-					) : null}
-
 					<TriggerSpecificFields filesNameList={filesNameList} />
+
+					{trigger?.sourceType === TriggerTypes.webhook ? (
+						<WebhookFields highlight={webhookUrlHighlight} webhookSlug={trigger.webhookSlug || ""} />
+					) : null}
 				</form>
 
 				{trigger?.sourceType === TriggerTypes.schedule ? <SchedulerInfo /> : null}

--- a/src/components/organisms/triggers/formParts/webhook.tsx
+++ b/src/components/organisms/triggers/formParts/webhook.tsx
@@ -2,12 +2,12 @@ import React, { useEffect, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { getApiBaseUrl } from "@src/utilities";
+import { cn, getApiBaseUrl } from "@src/utilities";
 
 import { Input } from "@components/atoms";
 import { CopyButton } from "@components/molecules";
 
-export const WebhookFields = ({ webhookSlug }: { webhookSlug?: string }) => {
+export const WebhookFields = ({ highlight, webhookSlug }: { highlight?: boolean; webhookSlug?: string }) => {
 	const { t } = useTranslation("tabs", { keyPrefix: "triggers.form" });
 	const apiBaseUrl = getApiBaseUrl();
 
@@ -18,11 +18,13 @@ export const WebhookFields = ({ webhookSlug }: { webhookSlug?: string }) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
+	const webhookClassName = cn("w-full", { "shadow-sm shadow-green-200/80": highlight });
+
 	return (
 		<div className="relative flex gap-2">
 			<Input
 				aria-label={t("placeholders.webhookUrl")}
-				className="w-full"
+				className={webhookClassName}
 				disabled
 				label={t("placeholders.webhookUrl")}
 				name="webhookUrl"


### PR DESCRIPTION
## Description
1. Moved the webhook URL field to the end of the "Add new trigger" form
2. Highlighted the Webhook URL field after trigger creation

## Linear Ticket
https://linear.app/autokitteh/issue/UI-754/triggers-add-form-move-webhook-url-to-the-bottom

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
