### PR TITLE
fix: re-fetch sessions always and remove last-time-scroll

### DIFF
--- a/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
@@ -14,7 +14,6 @@ export const ActivityList = () => {
 	const [selectedActivity, setSelectedActivity] = useState<SessionActivity>();
 
 	const {
-		handleScroll,
 		isRowLoaded,
 		items: activities,
 		listRef,
@@ -79,7 +78,6 @@ export const ActivityList = () => {
 								className="scrollbar"
 								height={height}
 								onRowsRendered={onRowsRendered}
-								onScroll={handleScroll}
 								ref={(ref) => {
 									if (ref) {
 										registerChild(ref);

--- a/src/components/organisms/deployments/sessions/tabs/outputs.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/outputs.tsx
@@ -33,7 +33,6 @@ OutputRow.displayName = "OutputRow";
 
 export const SessionOutputs = () => {
 	const {
-		handleScroll,
 		isRowLoaded,
 		items: outputs,
 		listRef,
@@ -110,7 +109,6 @@ export const SessionOutputs = () => {
 									deferredMeasurementCache={cacheRef.current}
 									height={height}
 									onRowsRendered={onRowsRendered}
-									onScroll={handleScroll}
 									overscanRowCount={10}
 									ref={(ref) => {
 										setListRef(ref);

--- a/src/hooks/useVirtualizedList.tsx
+++ b/src/hooks/useVirtualizedList.tsx
@@ -39,8 +39,6 @@ export function useVirtualizedList<T extends SessionOutput | SessionActivity>(
 
 	const { loadLogs, loading, reset } = store;
 
-	const [scrollPosition, setScrollPosition] = useState(0);
-
 	const cache = useMemo(
 		() =>
 			new CellMeasurerCache({
@@ -60,10 +58,6 @@ export function useVirtualizedList<T extends SessionOutput | SessionActivity>(
 		}
 		await loadLogs(sessionId, pageSize * 2);
 	}, [sessionId, shouldLoadMore, loadLogs, pageSize]);
-
-	const handleScroll = useCallback(({ scrollTop }: { scrollTop: number }): void => {
-		if (scrollTop !== 0) setScrollPosition(scrollTop);
-	}, []);
 
 	const calculatePageSize = useCallback(() => {
 		const frameHeight = frameRef?.current?.offsetHeight || minimumSessionLogsRecordsFrameHeightFallback;
@@ -92,18 +86,9 @@ export function useVirtualizedList<T extends SessionOutput | SessionActivity>(
 	}, [sessionId, type, session, reset, loadMoreRows, itemHeight]);
 
 	useEffect(() => {
-		if (!pageSize) return;
 		loadMoreRows();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [pageSize]);
-
-	useEffect(() => {
-		return () => {
-			if (sessionId) {
-				sessionStorage.setItem(`scrollPosition_${sessionId}_${type}`, scrollPosition.toString());
-			}
-		};
-	}, [sessionId, type, scrollPosition]);
 
 	const rowRenderer = useCallback(
 		(props: ListRowProps): React.ReactNode => {
@@ -125,7 +110,6 @@ export function useVirtualizedList<T extends SessionOutput | SessionActivity>(
 		loading,
 		isRowLoaded,
 		loadMoreRows,
-		handleScroll,
 		cache,
 		listRef,
 		frameRef,

--- a/src/interfaces/hooks/useVirtualizedList.interface.ts
+++ b/src/interfaces/hooks/useVirtualizedList.interface.ts
@@ -5,7 +5,6 @@ export interface VirtualizedListHookResult<T> {
 	loading: boolean;
 	isRowLoaded: (params: { index: number }) => boolean;
 	loadMoreRows: (params: { startIndex: number; stopIndex: number }) => Promise<void>;
-	handleScroll: (params: { scrollTop: number }) => void;
 	cache: CellMeasurerCache;
 	listRef: React.MutableRefObject<List | null>;
 	frameRef: React.RefObject<HTMLDivElement>;


### PR DESCRIPTION
## Description
Session log doesn't display moving from session to session

## Linear Ticket
https://linear.app/autokitteh/issue/UI-761/session-log-doesnt-display-moving-from-session-to-session
https://linear.app/autokitteh/issue/UI-762/remove-last-time-scroll-in-sessionactivities-feature

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
