### PR TITLE
fix: load logs each time we enter the session

### DIFF
--- a/src/components/organisms/deployments/sessions/table.tsx
+++ b/src/components/organisms/deployments/sessions/table.tsx
@@ -213,7 +213,7 @@ export const SessionsTable = () => {
 						</div>
 					</div>
 
-					<div className="relative my-6 flex h-full flex-col overflow-hidden">
+					<div className="relative my-6 flex h-full flex-col overflow-hidden pb-5">
 						{isInitialLoad ? (
 							<div className="flex h-full items-center justify-center">
 								<Loader firstColor="light-gray" size="md" />

--- a/src/hooks/useVirtualizedList.tsx
+++ b/src/hooks/useVirtualizedList.tsx
@@ -60,7 +60,7 @@ export function useVirtualizedList<T extends SessionOutput | SessionActivity>(
 	const shouldLoadMore = useMemo(() => !(loading || (session && session.fullyLoaded)), [loading, session]);
 
 	const frameHeight = frameRef?.current?.offsetHeight || standardScreenHeightFallback;
-	const pageSize = Math.ceil(frameHeight / itemHeight) * 1.5;
+	const pageSize = Math.ceil((frameHeight / itemHeight) * 1.5);
 
 	const loadMoreRows = async (): Promise<void> => {
 		if (!sessionId || !shouldLoadMore) {

--- a/src/store/cache/useOutputsCacheStore.ts
+++ b/src/store/cache/useOutputsCacheStore.ts
@@ -37,12 +37,6 @@ const createOutputsStore: StateCreator<OutputsStore> = (set, get) => ({
 				fullyLoaded: false,
 			};
 
-			if (currentSession.fullyLoaded) {
-				set({ loading: false });
-
-				return;
-			}
-
 			const { data, error } = await SessionsService.getLogRecordsBySessionId(
 				sessionId,
 				currentSession.nextPageToken || undefined,


### PR DESCRIPTION
## Description
At this moment after we loaded the logs (outputs/activities) for the first time, when we approach next time to the same session, it won't reload, and we will need to reload it manually.

The desired: every time we click a session row in the table, the logs would reload.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-773/load-logs-each-time-we-enter-the-session

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
