### PR TITLE
refactor: improve session information for session-viewer

### DIFF
--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -151,8 +151,14 @@ export const SessionViewer = () => {
 						<div className="w-44 text-gray-1550">{t("status")}</div>
 						<SessionsTableState sessionState={sessionInfo.state} />
 					</div>
+					{sessionInfo.destinationName ? (
+						<div className="flex items-center gap-4">
+							<div className="w-44 text-gray-1550">{t("source")}</div>
+							{sessionInfo.destinationName}
+						</div>
+					) : null}
 					<div className="flex items-center gap-4">
-						<div className="w-44 text-gray-1550">{t("source")}</div>
+						<div className="w-44 text-gray-1550">{t("sourceType")}</div>
 						{sessionInfo.sourceType}
 					</div>
 					<div className="flex items-center gap-4">

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -145,24 +145,24 @@ export const SessionViewer = () => {
 				</div>
 			</div>
 
-			<div className="mt-2.5 flex justify-between gap-6">
+			<div className="mt-2.5 flex justify-between">
 				<div className="flex flex-col gap-0.5 leading-6">
 					<div className="flex items-center gap-4">
-						<div className="w-44 text-gray-1550">{t("status")}</div>
+						<div className="w-32 text-gray-1550">{t("status")}</div>
 						<SessionsTableState sessionState={sessionInfo.state} />
 					</div>
 					{sessionInfo.destinationName ? (
 						<div className="flex items-center gap-4">
-							<div className="w-44 text-gray-1550">{t("source")}</div>
+							<div className="w-32 text-gray-1550">{t("source")}</div>
 							{sessionInfo.destinationName}
 						</div>
 					) : null}
 					<div className="flex items-center gap-4">
-						<div className="w-44 text-gray-1550">{t("sourceType")}</div>
+						<div className="w-32 text-gray-1550">{t("sourceType")}</div>
 						{sessionInfo.sourceType}
 					</div>
 					<div className="flex items-center gap-4">
-						<div className="w-44 text-gray-1550">{t("entrypoint")}</div>
+						<div className="w-32 text-gray-1550">{t("entrypoint")}</div>
 						<div className="inline">
 							<div className="inline">{sessionInfo.entrypoint.path}</div>
 							<IconSvg className="mx-2 inline fill-white" size="sm" src={ArrowRightIcon} />
@@ -170,7 +170,7 @@ export const SessionViewer = () => {
 						</div>
 					</div>
 					<div className="flex items-center gap-4">
-						<div className="w-44 text-gray-1550" title="Start Time">
+						<div className="w-32 text-gray-1550" title="Start Time">
 							Time:
 						</div>
 						<div className="flex flex-row items-center">
@@ -185,7 +185,7 @@ export const SessionViewer = () => {
 						</div>
 					</div>
 					<div className="flex items-center gap-4">
-						<div className="w-44 text-gray-1550">Duration</div>
+						<div className="w-32 text-gray-1550">Duration</div>
 						{sessionInfo.state === SessionState.completed || sessionInfo.state === SessionState.error ? (
 							formatTimeDifference(sessionInfo.updatedAt, sessionInfo.createdAt)
 						) : (

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -156,9 +156,6 @@ export const SessionViewer = () => {
 						{sessionInfo.sourceType}
 					</div>
 					<div className="flex items-center gap-4">
-						<div className="w-44 text-gray-1550">{t("connectionName")}</div>
-					</div>
-					<div className="flex items-center gap-4">
 						<div className="w-44 text-gray-1550">{t("entrypoint")}</div>
 						<div className="inline">
 							<div className="inline">{sessionInfo.entrypoint.path}</div>

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -193,10 +193,12 @@ export const SessionViewer = () => {
 						<div className="leading-6">{t("sessionId")}</div>
 						<CopyButton className="p-0" size="xs" text={sessionInfo.sessionId} />
 					</div>
-					<div className="flex items-center justify-end gap-4">
-						<div className="leading-6">{t("eventId")}</div>
-						<CopyButton className="p-0" size="xs" text={sessionInfo.eventId} />
-					</div>
+					{sessionInfo.eventId ? (
+						<div className="flex items-center justify-end gap-4">
+							<div className="leading-6">{t("eventId")}</div>
+							<CopyButton className="p-0" size="xs" text={sessionInfo.eventId} />
+						</div>
+					) : null}
 					<div className="flex items-center justify-end gap-4">
 						<div className="leading-6">{t("buildId")}</div>
 						<CopyButton className="p-0" size="xs" text={sessionInfo.buildId} />

--- a/src/locales/en/deployments/translation.json
+++ b/src/locales/en/deployments/translation.json
@@ -111,6 +111,7 @@
 			},
 			"trigger": "Trigger",
 			"source": "Source",
+			"sourceType": "Source Type",
 			"entrypoint": "Entrypoint",
 			"manualRun": "Manual Run",
 			"eventId": "Event ID",

--- a/src/locales/en/services/translation.json
+++ b/src/locales/en/services/translation.json
@@ -88,12 +88,10 @@
 		"deactivateFailed": "Deployment deactivation failed - deployment: {{deploymentId}}, error: {{error}}",
 		"createFailed": "Deployment creation failed - build: {{buildId}}, environment: {{envId}}, error: {{error}}"
 	},
-	"sessionTriggerSource": "Trigger {{triggerName}}",
-	"sessionConnectionSource": "Trigger {{connectionName}}",
-	"connection": "Connection - {{connectionName}}",
 	"convertWrappedJsonError": "Error parsing JSON for key '{{key}}': {{error}} in parseNestedJson function",
 	"accountFetchErrorExtended": "Error occurred during the account fetch, error: {{error}}",
 	"deploymentCreatedSuccessfully": "Deployment created with id: {{deploymentId}}",
-	"failedFetchingLogRecordsBySessionId": "Failed to fetch log records by session ID: {{sessionId}}, error: {{error}}, page token: {{pageToken}}, page size: {{pageSize}}, log type: {{logType}}"
+	"failedFetchingLogRecordsBySessionId": "Failed to fetch log records by session ID: {{sessionId}}, error: {{error}}, page token: {{pageToken}}, page size: {{pageSize}}, log type: {{logType}}",
+	"connection": "Connection"
 
 }

--- a/src/models/event.model.ts
+++ b/src/models/event.model.ts
@@ -45,7 +45,6 @@ export const convertEventProtoToModel = async (protoEvent: ProtoEvent): Promise<
 			});
 		sourceType = connection?.name
 			? i18n.t("connection", {
-					connectionName: connection?.name,
 					ns: "services",
 				})
 			: i18n.t("unknownSourceForSessionModel", {

--- a/src/services/sessions.service.ts
+++ b/src/services/sessions.service.ts
@@ -87,12 +87,6 @@ export class SessionsService {
 			const { session } = await sessionsClient.get({ sessionId, jsonValues: true });
 
 			if (!session?.eventId) {
-				const errorMessage = i18n.t("sessionMissingEventExtended", {
-					sessionId,
-					ns: "services",
-				});
-				LoggerService.error(namespaces.sessionsService, errorMessage);
-
 				const sessionConverted = convertSessionProtoToViewerModel(session!);
 
 				return {


### PR DESCRIPTION
## Description
1. Hide fields if there is no content - no event ID or no source (if we are running the session manually)
2. Divide and display the source (webhook/scheduler/connection) and its name separated
3. Don't log an error when the session has no event.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-781/improve-session-information-for-session-viewer

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
