### PR TITLE
fix: change project build info message

### DIFF
--- a/src/locales/en/projects/translation.json
+++ b/src/locales/en/projects/translation.json
@@ -1,10 +1,10 @@
 {
     "topbar": {
-        "buildProjectSuccessExtended": "Project build completed successfully, error: {{error}}",
-        "buildProjectSuccess": "Project build completed successfully",
         "deleteProjectSuccess": "Project deletion completed successfully",
         "deleteProjectSuccessExtended": "Project deletion completed successfully, project name: {{projectName}}, project ID: {{projectId}}",
         "exportProjectFailed": "Couldn't export project",
+        "buildProjectSuccess": "Project build completed successfully",
+        "buildProjectSuccessExtended": "Project build completed successfully, build ID: {{buildId}}",
         "buttons": {
             "ariaBuildProject": "Build project",
             "ariaDeployProject": "Deploy project",


### PR DESCRIPTION
## Description
Fix the info message for a successful project build - {{buildId}} instead of {{error}}:

https://github.com/user-attachments/assets/4563adb9-2687-41b1-997f-c859231da599

## Linear Ticket
https://linear.app/autokitteh/issue/UI-795/project-build-error

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
