### PR TITLE
fix: activity display completed instead of error

### DIFF
--- a/src/models/activity.model.ts
+++ b/src/models/activity.model.ts
@@ -48,11 +48,8 @@ export function convertSessionLogRecordsProtoToActivitiesModel(
 		}
 
 		if (callAttemptComplete && currentActivity) {
-			if (callAttemptComplete.result?.error) {
-				currentActivity.status = "error" as keyof ActivityState;
-			} else {
-				currentActivity.status = "completed" as keyof ActivityState;
-			}
+			currentActivity.status = (callAttemptComplete.result?.error ? "error" : "completed") as keyof ActivityState;
+
 			currentActivity.endTime = convertTimestampToDate(callAttemptComplete.completedAt);
 
 			const convertedValue = convertValue(callAttemptComplete.result?.value);

--- a/src/models/activity.model.ts
+++ b/src/models/activity.model.ts
@@ -48,7 +48,11 @@ export function convertSessionLogRecordsProtoToActivitiesModel(
 		}
 
 		if (callAttemptComplete && currentActivity) {
-			currentActivity.status = "completed" as keyof ActivityState;
+			if (callAttemptComplete.result?.error) {
+				currentActivity.status = "error" as keyof ActivityState;
+			} else {
+				currentActivity.status = "completed" as keyof ActivityState;
+			}
 			currentActivity.endTime = convertTimestampToDate(callAttemptComplete.completedAt);
 
 			const convertedValue = convertValue(callAttemptComplete.result?.value);


### PR DESCRIPTION
## Description
When activity results in an error, UI still display a green "completed"
![image](https://github.com/user-attachments/assets/d6a0ad41-b476-4cb6-9200-16d38c8cd497)
in this case there was an error, looking at the session log record you can see it:

## Linear Ticket
https://linear.app/autokitteh/issue/UI-776/when-activity-results-in-an-error-ui-still-display-a-green-completed

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
