### PR TITLE
fix: sort integrations in add or edit connection page

### DIFF
--- a/src/constants/lists/connections/options.constants.ts
+++ b/src/constants/lists/connections/options.constants.ts
@@ -1,8 +1,10 @@
 import { ConnectionAuthType } from "@enums";
 import { SelectOption } from "@interfaces/components";
 import { IntegrationsMap } from "@src/enums/components/connection.enum";
+import { sortIntegrationsMapByLabel } from "@src/utilities";
 
-export const integrationTypes: SelectOption[] = Object.values(IntegrationsMap);
+const sortedIntegrationsMap = sortIntegrationsMapByLabel(IntegrationsMap);
+export const integrationTypes: SelectOption[] = Object.values(sortedIntegrationsMap);
 
 export const integrationIcons: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>> = Object.fromEntries(
 	Object.entries(IntegrationsMap)

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -19,3 +19,4 @@ export { stripGoogleConnectionName } from "@utilities/stripGoogleConnectionName.
 export { convertPythonStringToJSON } from "@utilities/pythonStringToJson.utils";
 export { convertBuildRuntimesToViewTriggers } from "@utilities/convertBuildRuntimesToViewTriggers.utils";
 export { parseNestedJson } from "@src/utilities/convertWrappedJson.utils";
+export { sortIntegrationsMapByLabel } from "@utilities/sortIntegrationsMap.utils";

--- a/src/utilities/sortIntegrationsMap.utils.ts
+++ b/src/utilities/sortIntegrationsMap.utils.ts
@@ -1,0 +1,12 @@
+import { Integrations, IntegrationsMap } from "@src/enums/components/connection.enum";
+import { IntegrationSelectOption } from "@src/interfaces/components/forms";
+
+export const sortIntegrationsMapByLabel = (
+	map: typeof IntegrationsMap
+): Record<Integrations, IntegrationSelectOption> => {
+	const entries = Object.entries(map);
+	const sortedEntries = entries.sort((a, b) => a[1].label.localeCompare(b[1].label));
+	const sortedMap = Object.fromEntries(sortedEntries);
+
+	return sortedMap as Record<Integrations, IntegrationSelectOption>;
+};


### PR DESCRIPTION
## Description
[Sort integrations when selecting for a new connection](https://linear.app/autokitteh/issue/UI-692/sort-integrations-when-selecting-for-a-new-connection): The list needs to be sorted alphanumerically by the display name of the integrations

## Linear Ticket
https://linear.app/autokitteh/issue/UI-692/sort-integrations-when-selecting-for-a-new-connection

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
