### PR TITLE
fix: divide info link for gemini connection into two lines

### DIFF
--- a/src/components/organisms/connections/integrations/googleGemini/edit.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/edit.tsx
@@ -50,25 +50,27 @@ export const GoogleGeminiIntegrationEditForm = () => {
 			</Button>
 
 			<Accordion title={t("information")}>
-				<Link
-					className="group inline-flex items-center gap-2.5 text-green-800"
-					target="_blank"
-					to="https://aistudio.google.com/app"
-				>
-					{t("gemini.information.aiStudio")}
+				<div className="flex flex-col gap-2">
+					<Link
+						className="group inline-flex items-center gap-2.5 text-green-800"
+						target="_blank"
+						to="https://aistudio.google.com/app"
+					>
+						{t("gemini.information.aiStudio")}
 
-					<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
-				</Link>
+						<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
+					</Link>
 
-				<Link
-					className="group inline-flex items-center gap-2.5 text-green-800"
-					target="_blank"
-					to="https://aistudio.google.com/app/apikey"
-				>
-					{t("gemini.information.apiKeys")}
+					<Link
+						className="group inline-flex items-center gap-2.5 text-green-800"
+						target="_blank"
+						to="https://aistudio.google.com/app/apikey"
+					>
+						{t("gemini.information.apiKeys")}
 
-					<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
-				</Link>
+						<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
+					</Link>
+				</div>
 			</Accordion>
 		</form>
 	);


### PR DESCRIPTION
## Description
[Missing line break in Google Gemini info links](https://linear.app/autokitteh/issue/UI-701/missing-n-in-google-gemini-info-links)

## Linear Ticket
https://linear.app/autokitteh/issue/UI-701/missing-n-in-google-gemini-info-links

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
