### PR TITLE
fix: remove redundant info from atlassian and jira oauth forms 

### DIFF
--- a/src/components/organisms/connections/integrations/confluence/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/confluence/authMethods/oauth.tsx
@@ -24,8 +24,6 @@ export const ConfluenceOauthForm = () => {
 				</Link>
 			</Accordion>
 
-			<p className="mt-2">{t("confluence.clickButtonAuthorize")}</p>
-
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"

--- a/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
@@ -24,8 +24,6 @@ export const OauthJiraForm = () => {
 				</Link>
 			</Accordion>
 
-			<p className="mt-2">{t("jira.clickButtonAuthorize")}</p>
-
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"

--- a/src/locales/en/integrations/translation.json
+++ b/src/locales/en/integrations/translation.json
@@ -112,7 +112,6 @@
 		}
 	},
 	"jira": {
-		"clickButtonAuthorize": "Click the button below to authorize the Atlassian AutoKitteh app",
 		"placeholders": {
 			"baseUrl": "Base URL",
 			"pat": "API Token / Personal Access Token (PAT)",
@@ -127,7 +126,6 @@
 		}
 	},
 	"confluence": {
-		"clickButtonAuthorize": "Click the button below to authorize the Atlassian",
 		"placeholders": {
 			"baseUrl": "Base URL",
 			"pat": "API Token / Personal Access Token (PAT)",


### PR DESCRIPTION
## Description
[Update "more information" links for all integrations and all auth types:](https://linear.app/autokitteh/issue/UI-699/update-more-information-links-for-all-integrations-and-all-auth-types) Also, various (but not all) OAuth connection types include a message between the "More Information" links and the "Start OAuth Flow" button - get rid of these messages.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-699/update-more-information-links-for-all-integrations-and-all-auth-types

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
