### PR TITLE
fix: fix 'cannot read project name' on project load

### DIFF
--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -25,6 +25,8 @@ export const Project = () => {
 		const { data: project } = await getProject(projectId!);
 		if (!project?.name) {
 			setPageTitle(t("base"));
+
+			return;
 		}
 		setPageTitle(t("template", { page: project!.name }));
 	};


### PR DESCRIPTION
## Description
Fix following error: [Link](https://autokitteh.sentry.io/issues/5993673961/?project=4508127205982208&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1)

Caused by missing `return` in the `if` statement:
![image](https://github.com/user-attachments/assets/fafea1fe-1243-490c-9ddb-a45892a0dc91)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-799/fix-cannot-read-project-name-on-project-load

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
