### PR TITLE
fix: align local time and date formats

### DIFF
--- a/src/components/organisms/deployments/sessions/tableRow.tsx
+++ b/src/components/organisms/deployments/sessions/tableRow.tsx
@@ -89,7 +89,7 @@ export const SessionsTableRow = memo(
 				onClick={() => openSessionLog(session.sessionId)}
 				style={{ ...style }}
 			>
-				<Td className="w-56">{moment(session.createdAt).utc().format("YYYY-MM-DD HH:mm:ss")}</Td>
+				<Td className="w-56">{moment(session.createdAt).local().format("YYYY-MM-DD HH:mm:ss")}</Td>
 
 				<Td className="w-32">
 					<SessionsTableState sessionState={session.state} />

--- a/src/components/organisms/deployments/sessions/tableRow.tsx
+++ b/src/components/organisms/deployments/sessions/tableRow.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { SessionState } from "@enums";
 import { SessionsTableRowProps } from "@interfaces/components";
 import { LoggerService, SessionsService } from "@services";
-import { namespaces } from "@src/constants";
+import { dateTimeFormat, namespaces } from "@src/constants";
 import { cn } from "@utilities";
 
 import { useToastStore } from "@store";
@@ -89,7 +89,7 @@ export const SessionsTableRow = memo(
 				onClick={() => openSessionLog(session.sessionId)}
 				style={{ ...style }}
 			>
-				<Td className="w-56">{moment(session.createdAt).local().format("YYYY-MM-DD HH:mm:ss")}</Td>
+				<Td className="w-56">{moment(session.createdAt).local().format(dateTimeFormat)}</Td>
 
 				<Td className="w-32">
 					<SessionsTableState sessionState={session.state} />

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -7,7 +7,14 @@ import { useTranslation } from "react-i18next";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
 import ReactTimeAgo from "react-time-ago";
 
-import { defaultSessionTab, namespaces, sessionLogRowHeight, sessionTabs } from "@constants";
+import {
+	dateTimeFormat,
+	defaultSessionTab,
+	namespaces,
+	sessionLogRowHeight,
+	sessionTabs,
+	timeFormat,
+} from "@constants";
 import { LoggerService } from "@services/index";
 import { SessionsService } from "@services/sessions.service";
 import { SessionState } from "@src/enums";
@@ -111,10 +118,10 @@ export const SessionViewer = () => {
 		const isCompleted = state === SessionState.completed || state === SessionState.error;
 
 		return {
-			createdAt: moment(createdAt).local().format("MM.DD.YY  HH:mm"),
-			startTime: moment(createdAt).local().format("HH:mm:ss"),
+			createdAt: moment(createdAt).local().format(dateTimeFormat),
+			startTime: moment(createdAt).local().format(timeFormat),
 			endTime: isCompleted ? (
-				moment(updatedAt).local().format("HH:mm:ss")
+				moment(updatedAt).local().format(timeFormat)
 			) : (
 				<SessionsTableState sessionState={state} />
 			),
@@ -178,11 +185,11 @@ export const SessionViewer = () => {
 							Time:
 						</div>
 						<div className="flex flex-row items-center">
-							{moment(sessionInfo.createdAt).local().format("HH:mm:ss")}
+							{moment(sessionInfo.createdAt).local().format(timeFormat)}
 							<IconSvg className="mx-2 fill-white" size="sm" src={ArrowRightIcon} />
 							{sessionInfo.state === SessionState.completed ||
 							sessionInfo.state === SessionState.error ? (
-								<div title="End Time">{moment(sessionInfo.updatedAt).local().format("HH:mm:ss")}</div>
+								<div title="End Time">{moment(sessionInfo.updatedAt).local().format(timeFormat)}</div>
 							) : (
 								<SessionsTableState sessionState={sessionInfo.state} />
 							)}

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -111,9 +111,13 @@ export const SessionViewer = () => {
 		const isCompleted = state === SessionState.completed || state === SessionState.error;
 
 		return {
-			createdAt: moment(createdAt).format("MM.DD.YY  HH:mm"),
-			startTime: moment(createdAt).format("HH:mm:ss"),
-			endTime: isCompleted ? moment(updatedAt).format("HH:mm:ss") : <SessionsTableState sessionState={state} />,
+			createdAt: moment(createdAt).local().format("MM.DD.YY  HH:mm"),
+			startTime: moment(createdAt).local().format("HH:mm:ss"),
+			endTime: isCompleted ? (
+				moment(updatedAt).local().format("HH:mm:ss")
+			) : (
+				<SessionsTableState sessionState={state} />
+			),
 			duration: isCompleted ? (
 				formatTimeDifference(updatedAt, createdAt)
 			) : (
@@ -174,11 +178,11 @@ export const SessionViewer = () => {
 							Time:
 						</div>
 						<div className="flex flex-row items-center">
-							{moment(sessionInfo.createdAt).format("HH:mm:ss")}
+							{moment(sessionInfo.createdAt).local().format("HH:mm:ss")}
 							<IconSvg className="mx-2 fill-white" size="sm" src={ArrowRightIcon} />
 							{sessionInfo.state === SessionState.completed ||
 							sessionInfo.state === SessionState.error ? (
-								<div title="End Time">{moment(sessionInfo.updatedAt).format("HH:mm:ss")}</div>
+								<div title="End Time">{moment(sessionInfo.updatedAt).local().format("HH:mm:ss")}</div>
 							) : (
 								<SessionsTableState sessionState={sessionInfo.state} />
 							)}

--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -156,7 +156,7 @@ export const DeploymentsTableContent = ({
 							key={deploymentId}
 							onClick={() => navigate(`${deploymentId}/sessions`)}
 						>
-							<Td className="font-semibold">{moment(createdAt).format(dateTimeFormat)}</Td>
+							<Td className="font-semibold">{moment(createdAt).local().format(dateTimeFormat)}</Td>
 
 							<Td>
 								<DeploymentSessionStats sessionStats={sessionStats} />

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -6,7 +6,7 @@ import moment from "moment";
 import { useTranslation } from "react-i18next";
 import { useLocation, useParams } from "react-router-dom";
 
-import { monacoLanguages, namespaces } from "@constants";
+import { dateTimeFormat, monacoLanguages, namespaces } from "@constants";
 import { LoggerService } from "@services";
 import { useToastStore } from "@src/store";
 import { cn } from "@utilities";
@@ -131,7 +131,7 @@ export const EditorTabs = () => {
 		try {
 			await saveFile(activeEditorFileName, newContent);
 			setContent(newContent);
-			setLastSaved(moment().local().format("YYYY-MM-DD HH:mm:ss"));
+			setLastSaved(moment().local().format(dateTimeFormat));
 		} catch (error) {
 			addToast({
 				message: tErrors("codeSaveFailed"),

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -131,7 +131,7 @@ export const EditorTabs = () => {
 		try {
 			await saveFile(activeEditorFileName, newContent);
 			setContent(newContent);
-			setLastSaved(moment().utc().format("YYYY-MM-DD HH:mm:ss"));
+			setLastSaved(moment().local().format("YYYY-MM-DD HH:mm:ss"));
 		} catch (error) {
 			addToast({
 				message: tErrors("codeSaveFailed"),

--- a/src/constants/global.constants.ts
+++ b/src/constants/global.constants.ts
@@ -13,7 +13,8 @@ export const maxLogs = 20;
 export const fileSizeUploadLimit = 50 * 1024; // 50KB
 export const apiRequestTimeout = isDevelopment ? 1000 * 60 : 5000;
 
-export const dateTimeFormat = "MM-DD-YYYY HH:mm:ss";
+export const dateTimeFormat = "YYYY-DD-MM HH:mm:ss";
+export const timeFormat = "HH:mm:ss";
 
 export const supportedProgrammingLanguages = [".py", ".star"];
 export const allowedManualRunExtensions = ["python", "starlark"];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,6 +15,7 @@ export {
 	dateTimeFormat,
 	supportedProgrammingLanguages,
 	allowedManualRunExtensions,
+	timeFormat,
 } from "@constants/global.constants";
 export { menuItems } from "@constants/menuItems.constants";
 export { defalutFileExtension, monacoLanguages } from "@constants/monacoLanguages.constants.ts";

--- a/src/models/sessionLogRecord.model.ts
+++ b/src/models/sessionLogRecord.model.ts
@@ -3,7 +3,7 @@ import moment from "moment";
 
 import { SessionLogRecord as ProtoSessionLogRecord } from "@ak-proto-ts/sessions/v1/session_pb";
 import { Value } from "@ak-proto-ts/values/v1/values_pb";
-import { namespaces } from "@constants";
+import { dateTimeFormat, namespaces } from "@constants";
 import { SessionLogRecordType, SessionStateType } from "@enums";
 import { convertErrorProtoToModel } from "@models/error.model";
 import { LoggerService } from "@services";
@@ -175,7 +175,7 @@ export const convertSessionLogProtoToViewerOutput = (logRecords: ProtoSessionLog
 			) {
 				return undefined;
 			}
-			const formattedDateTime = moment(record.dateTime).local().format("MM-DD-YYYY HH:mm:ss");
+			const formattedDateTime = moment(record.dateTime).local().format(dateTimeFormat);
 
 			const output: SessionOutput = {
 				print: record.logs || "",

--- a/src/models/sessionLogRecord.model.ts
+++ b/src/models/sessionLogRecord.model.ts
@@ -175,7 +175,7 @@ export const convertSessionLogProtoToViewerOutput = (logRecords: ProtoSessionLog
 			) {
 				return undefined;
 			}
-			const formattedDateTime = moment(record.dateTime).format("MM-DD-YYYY HH:mm:ss");
+			const formattedDateTime = moment(record.dateTime).local().format("MM-DD-YYYY HH:mm:ss");
 
 			const output: SessionOutput = {
 				print: record.logs || "",

--- a/src/services/logger.service.ts
+++ b/src/services/logger.service.ts
@@ -28,7 +28,7 @@ export class LoggerService {
 	}
 
 	private static output(namespace: string, message: string, level: LoggerLevel = LoggerLevel.info): void {
-		const timestamp = moment().utc().format("YYYY-MM-DD HH:mm:ss");
+		const timestamp = moment().utc().local().format("YYYY-MM-DD HH:mm:ss");
 		const formattedMessage = `[${namespace}] [${level}] ${message}`;
 
 		switch (level) {

--- a/src/services/logger.service.ts
+++ b/src/services/logger.service.ts
@@ -1,6 +1,7 @@
 import moment from "moment";
 
 import { LoggerLevel } from "@enums";
+import { dateTimeFormat } from "@src/constants";
 
 import { useLoggerStore } from "@store";
 
@@ -28,7 +29,7 @@ export class LoggerService {
 	}
 
 	private static output(namespace: string, message: string, level: LoggerLevel = LoggerLevel.info): void {
-		const timestamp = moment().utc().local().format("YYYY-MM-DD HH:mm:ss");
+		const timestamp = moment().utc().local().format(dateTimeFormat);
 		const formattedMessage = `[${namespace}] [${level}] ${message}`;
 
 		switch (level) {


### PR DESCRIPTION
## Description
![image](https://github.com/user-attachments/assets/90f68c14-64b0-463e-b493-888847241f1b)
**Sessions table on the left:**
"Start time" is in UTC, should be local time like everywhere else
**Session log on the right:**
Date at the top: "mm.dd.yy" is a valid choice, but common only in the US. A much better one is what you already use in the left sessions table: "yyyy-mm-dd"

Time at the top: specify seconds (":ss") like everywhere else, not just "hh:mm"

## Linear Ticket
https://linear.app/autokitteh/issue/UI-789/inconsistent-time-in-session-page

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
