### PR TITLE
refactor: move all 'more information' links above the 'save' button in connections forms

### DIFF
--- a/src/components/organisms/connections/integrations/asana/add.tsx
+++ b/src/components/organisms/connections/integrations/asana/add.tsx
@@ -48,18 +48,6 @@ export const AsanaIntegrationAddForm = ({
 				<ErrorMessage>{errors.pat?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<Link
 					className="group inline-flex items-center gap-2.5 text-green-800"
@@ -71,6 +59,18 @@ export const AsanaIntegrationAddForm = ({
 					<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
 				</Link>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/asana/edit.tsx
+++ b/src/components/organisms/connections/integrations/asana/edit.tsx
@@ -37,18 +37,6 @@ export const AsanaIntegrationEditForm = () => {
 				<ErrorMessage>{errors.pat?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<Link
 					className="group inline-flex items-center gap-2.5 text-green-800"
@@ -60,6 +48,18 @@ export const AsanaIntegrationEditForm = () => {
 					<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
 				</Link>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/confluence/authMethods/apiToken.tsx
+++ b/src/components/organisms/connections/integrations/confluence/authMethods/apiToken.tsx
@@ -115,17 +115,6 @@ export const ConfluenceApiTokenForm = ({
 				<ErrorMessage>{errors.email?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoConfluenceLinks.map(({ text, url }, index) => (
@@ -142,6 +131,18 @@ export const ConfluenceApiTokenForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/discord/add.tsx
+++ b/src/components/organisms/connections/integrations/discord/add.tsx
@@ -48,18 +48,6 @@ export const DiscordIntegrationAddForm = ({
 				<ErrorMessage>{errors.botToken?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<Link
 					className="group inline-flex items-center gap-2.5 text-green-800"
@@ -71,6 +59,18 @@ export const DiscordIntegrationAddForm = ({
 					<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
 				</Link>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/discord/edit.tsx
+++ b/src/components/organisms/connections/integrations/discord/edit.tsx
@@ -37,18 +37,6 @@ export const DiscordIntegrationEditForm = () => {
 				<ErrorMessage>{errors.botToken?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<Link
 					className="group inline-flex items-center gap-2.5 text-green-800"
@@ -60,6 +48,18 @@ export const DiscordIntegrationEditForm = () => {
 					<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
 				</Link>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/github/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/oauth.tsx
@@ -35,6 +35,7 @@ export const OauthForm = () => {
 					</Link>
 				</div>
 			</Accordion>
+
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"

--- a/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
@@ -154,17 +154,7 @@ export const PatForm = ({
 
 				<ErrorMessage>{errors.secret?.message as string}</ErrorMessage>
 			</div>
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 
-				{t("buttons.saveConnection")}
-			</Button>
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoGithubLinks.map(({ text, url }, index) => (
@@ -181,6 +171,18 @@ export const PatForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/google/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/google/authMethods/jsonKey.tsx
@@ -35,18 +35,6 @@ export const JsonKeyGoogleForm = ({
 				<ErrorMessage>{errors.json?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col items-start gap-2">
 					{infoGoogleAccountLinks.map(({ text, url }, index) => (
@@ -63,6 +51,18 @@ export const JsonKeyGoogleForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/google/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/google/authMethods/oauth.tsx
@@ -14,14 +14,6 @@ export const OauthGoogleForm = () => {
 
 	return (
 		<>
-			<Button
-				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
-				type="submit"
-				variant="outline"
-			>
-				{t("buttons.startOAuthFlow")}
-			</Button>
 			<Accordion title={t("information")}>
 				<div className="flex flex-col items-start gap-2">
 					{infoGoogleUserLinks.map(({ text, url }, index) => (
@@ -38,6 +30,15 @@ export const OauthGoogleForm = () => {
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.startOAuthFlow")}
+				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				type="submit"
+				variant="outline"
+			>
+				{t("buttons.startOAuthFlow")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/googleGemini/add.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/add.tsx
@@ -48,18 +48,6 @@ export const GoogleGeminiIntegrationAddForm = ({
 				<ErrorMessage>{errors.key?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					<Link
@@ -83,6 +71,18 @@ export const GoogleGeminiIntegrationAddForm = ({
 					</Link>
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/googleGemini/edit.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/edit.tsx
@@ -37,18 +37,6 @@ export const GoogleGeminiIntegrationEditForm = () => {
 				<ErrorMessage>{errors.key?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					<Link
@@ -72,6 +60,18 @@ export const GoogleGeminiIntegrationEditForm = () => {
 					</Link>
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/googlecalendar/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/authMethods/jsonKey.tsx
@@ -43,18 +43,6 @@ export const JsonKeyGoogleCalendarForm = ({
 				<ErrorMessage>{errors.json?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col items-start gap-2">
 					{infoGoogleAccountLinks.map(({ text, url }, index) => (
@@ -71,6 +59,18 @@ export const JsonKeyGoogleCalendarForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
@@ -23,14 +23,7 @@ export const OauthGoogleCalendarForm = ({ register }: { register: UseFormRegiste
 					placeholder={t("google.placeholders.calendarId")}
 				/>
 			</div>
-			<Button
-				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
-				type="submit"
-				variant="outline"
-			>
-				{t("buttons.startOAuthFlow")}
-			</Button>
+
 			<Accordion title={t("information")}>
 				<div className="flex flex-col items-start gap-2">
 					{infoGoogleUserLinks.map(({ text, url }, index) => (
@@ -47,6 +40,15 @@ export const OauthGoogleCalendarForm = ({ register }: { register: UseFormRegiste
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.startOAuthFlow")}
+				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				type="submit"
+				variant="outline"
+			>
+				{t("buttons.startOAuthFlow")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/googleforms/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/jsonKey.tsx
@@ -43,18 +43,6 @@ export const JsonKeyGoogleFormsForm = ({
 				<ErrorMessage>{errors.json?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col items-start gap-2">
 					{infoGoogleAccountLinks.map(({ text, url }, index) => (
@@ -71,6 +59,18 @@ export const JsonKeyGoogleFormsForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
@@ -23,14 +23,7 @@ export const OauthGoogleFormsForm = ({ register }: { register: UseFormRegister<{
 					placeholder={t("google.placeholders.formId")}
 				/>
 			</div>
-			<Button
-				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
-				type="submit"
-				variant="outline"
-			>
-				{t("buttons.startOAuthFlow")}
-			</Button>
+
 			<Accordion title={t("information")}>
 				<div className="flex flex-col items-start gap-2">
 					{infoGoogleUserLinks.map(({ text, url }, index) => (
@@ -47,6 +40,15 @@ export const OauthGoogleFormsForm = ({ register }: { register: UseFormRegister<{
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.startOAuthFlow")}
+				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				type="submit"
+				variant="outline"
+			>
+				{t("buttons.startOAuthFlow")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/jira/authMethods/apiToken.tsx
+++ b/src/components/organisms/connections/integrations/jira/authMethods/apiToken.tsx
@@ -115,17 +115,6 @@ export const ApiTokenJiraForm = ({
 				<ErrorMessage>{errors.email?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoTwilioLinks.map(({ text, url }, index) => (
@@ -142,6 +131,18 @@ export const ApiTokenJiraForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/openAI/add.tsx
+++ b/src/components/organisms/connections/integrations/openAI/add.tsx
@@ -48,18 +48,6 @@ export const OpenAiIntegrationAddForm = ({
 				<ErrorMessage>{errors.key?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoOpenAiLinks.map(({ text, url }, index) => (
@@ -76,6 +64,18 @@ export const OpenAiIntegrationAddForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/openAI/edit.tsx
+++ b/src/components/organisms/connections/integrations/openAI/edit.tsx
@@ -37,18 +37,6 @@ export const OpenAiIntegrationEditForm = () => {
 				<ErrorMessage>{errors.key?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoOpenAiLinks.map(({ text, url }, index) => (
@@ -65,6 +53,18 @@ export const OpenAiIntegrationEditForm = () => {
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/slack/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/oauth.tsx
@@ -31,6 +31,7 @@ export const OauthForm = () => {
 					))}
 				</div>
 			</Accordion>
+
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-500 hover:text-white"

--- a/src/components/organisms/connections/integrations/slack/authMethods/socket.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/socket.tsx
@@ -84,17 +84,7 @@ export const SocketForm = ({
 
 				<ErrorMessage>{errors.app_token?.message as string}</ErrorMessage>
 			</div>
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="h-4 w-5 fill-white transition" />}
 
-				{t("buttons.saveConnection")}
-			</Button>
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoSlackModeLinks.map(({ text, url }, index) => (
@@ -111,6 +101,18 @@ export const SocketForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="h-4 w-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/twilio/authMethods/apiKey.tsx
+++ b/src/components/organisms/connections/integrations/twilio/authMethods/apiKey.tsx
@@ -113,17 +113,6 @@ export const ApiKeyTwilioForm = ({
 				<ErrorMessage>{errors.api_secret?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoTwilioLinks.map(({ text, url }, index) => (
@@ -140,6 +129,18 @@ export const ApiKeyTwilioForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/twilio/authMethods/authToken.tsx
+++ b/src/components/organisms/connections/integrations/twilio/authMethods/authToken.tsx
@@ -93,18 +93,6 @@ export const AuthTokenTwilioForm = ({
 				<ErrorMessage>{errors.auth_token?.message as string}</ErrorMessage>
 			</div>
 
-			<Button
-				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
-				type="submit"
-				variant="outline"
-			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
-				{t("buttons.saveConnection")}
-			</Button>
-
 			<Accordion title={t("information")}>
 				<div className="flex flex-col gap-2">
 					{infoTwilioLinks.map(({ text, url }, index) => (
@@ -121,6 +109,18 @@ export const AuthTokenTwilioForm = ({
 					))}
 				</div>
 			</Accordion>
+
+			<Button
+				aria-label={t("buttons.saveConnection")}
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
+				disabled={isLoading}
+				type="submit"
+				variant="outline"
+			>
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+
+				{t("buttons.saveConnection")}
+			</Button>
 		</>
 	);
 };


### PR DESCRIPTION
## Description
For OAuth-based connections, this appears above the "Start OAuth Flow" button, but for non-OAuth-based connections it appears below.

Move all "+ More Information" links for all connection types above the button, nothing should be below it anyway - users need to understand that they are useful before clicking the button.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-791/inconsistent-location-of-more-information-in-connection-pages

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
