### PR TITLE
fix: add missing url path in github pat connection configuration

### DIFF
--- a/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
@@ -61,12 +61,12 @@ export const PatForm = ({
 
 		const webhookKey = connectionVariables?.find((variable) => variable.name === "pat_key")?.value;
 		if (webhookKey) {
-			setWebhook(`${apiBaseUrl}/${webhookKey}`);
+			setWebhook(`${apiBaseUrl}/github/webhook/${webhookKey}`);
 
 			return;
 		}
 
-		setWebhook(`${apiBaseUrl}/${randomatic("Aa0", 8)}`);
+		setWebhook(`${apiBaseUrl}/github/webhook/${randomatic("Aa0", 8)}`);
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
## Description
Should be: `{apiBaseUrl}/github/webhook/{webhookKey}`

Instead of: `{apiBaseUrl}/{webhookKey}`

## Linear Ticket
https://linear.app/autokitteh/issue/UI-813/add-missing-url-path-in-github-pat-connection-configuration

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
