### PR TITLE
fix: login page loading state

### DIFF
--- a/src/components/pages/login.tsx
+++ b/src/components/pages/login.tsx
@@ -1,0 +1,85 @@
+import React, { Suspense, lazy } from "react";
+
+import { Descope } from "@descope/react-sdk";
+
+import { LoginPageProps } from "@src/interfaces/components";
+
+import { AHref, IconSvg } from "@components/atoms";
+
+import { AKRoundLogo } from "@assets/image";
+import { InJustTitle } from "@assets/image/pages/login";
+
+const LoginLogos = lazy(() => import("@assets/image/pages/login/BottomLogos.svg?react"));
+
+const LazyLoginLogos = () => (
+	<Suspense fallback={<div className="absolute bottom-0 right-8 h-36 w-9/12" />}>
+		<IconSvg
+			alt="autokitteh logo with integrations"
+			className="absolute bottom-0 right-8 h-36 w-9/12 object-contain object-bottom"
+			src={LoginLogos}
+		/>
+	</Suspense>
+);
+
+const Login = ({ descopeRenderKey, handleSuccess, t }: LoginPageProps) => {
+	const benefitsList = Object.values(t("rightSide.benefitsList", { returnObjects: true }));
+
+	return (
+		<div className="flex h-screen">
+			<div className="relative flex w-2/3 items-center justify-center rounded-3xl pb-32 pl-16 text-black">
+				<div className="z-10 p-5">
+					<AHref
+						ariaLabel={t("leftSide.logoText")}
+						className="absolute left-4 top-4 flex h-auto items-center"
+						href="https://autokitteh.com/"
+						relationship="noreferrer"
+						target="_blank"
+						title={t("leftSide.logoText")}
+					>
+						<IconSvg className="top-8 size-10" src={AKRoundLogo} />
+						<div className="ml-3 font-averta text-2xl font-bold">{t("leftSide.logoText")}</div>
+					</AHref>
+					<h2 className="mt-16 font-averta text-4xl font-bold">{t("rightSide.titleFirstLine")}</h2>
+					<div className="flex">
+						<IconSvg className="ml-4 mr-2 h-10 w-24" size="3xl" src={InJustTitle} />
+						<h2 className="font-averta text-4xl font-bold">{t("rightSide.titleSecondLine")}</h2>
+					</div>
+					<h3 className="mt-12 max-w-485 font-averta text-2xl font-bold">
+						{t("rightSide.descriptionFirstLine")}
+					</h3>
+					<ul className="ml-4 mt-10 font-averta text-xl font-semibold">
+						{benefitsList?.length
+							? Object.values(benefitsList).map((benefit) => (
+									<li className="mt-2 before:size-1 before:bg-black" key={benefit}>
+										{benefit}
+									</li>
+								))
+							: null}
+					</ul>
+				</div>
+				<LazyLoginLogos />
+			</div>
+			<div className="z-10 flex w-7/12 shrink-0 flex-col items-center justify-center rounded-l-2xl bg-gray-1250 p-8 font-averta text-white">
+				<h1 className="text-center font-averta text-4xl font-semibold">
+					{t("leftSide.welcomeTitle")}
+					<br />
+					{t("leftSide.autokittehGreenTitle")}
+				</h1>
+				<Descope flowId="sign-up-or-in" key={descopeRenderKey} onSuccess={handleSuccess} />
+				<div>
+					{t("leftSide.signupText")}{" "}
+					<AHref
+						className="font-averta text-green-800 hover:text-gray-500"
+						href="https://autokitteh.com/get-a-demo/"
+						relationship="noreferrer"
+						target="_blank"
+					>
+						{t("leftSide.signupLink")}
+					</AHref>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Login;

--- a/src/components/templates/descopeMiddleware.tsx
+++ b/src/components/templates/descopeMiddleware.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode, useCallback, useEffect, useState } from "react";
+import React, { ReactNode, Suspense, lazy, useCallback, useEffect, useState } from "react";
 
-import { Descope, useDescope } from "@descope/react-sdk";
+import { useDescope } from "@descope/react-sdk";
 import axios from "axios";
 import Cookies from "js-cookie";
 import psl from "psl";
@@ -13,10 +13,9 @@ import { useUserStore } from "@store/useUserStore";
 
 import { useToastStore } from "@store";
 
-import { AHref, IconSvg } from "@components/atoms";
+import { Loader } from "@components/atoms";
 
-import { AKRoundLogo } from "@assets/image";
-import { InJustTitle, LoginLogos } from "@assets/image/pages/login";
+const LoginPage = lazy(() => import("../pages/login"));
 
 export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 	const { getLoggedInUser, setLogoutFunction } = useUserStore();
@@ -32,14 +31,11 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 				message: t("errors.logoutFailed", { error: rootDomain.error.message }),
 				type: "error",
 			});
-
 			LoggerService.error(namespaces.ui.loginPage, t("errors.logoutFailed", { error: rootDomain.error.message }));
 
 			return;
 		}
-
 		Cookies.remove(isLoggedInCookie, { domain: getCookieDomain(rootDomain) });
-
 		window.localStorage.clear();
 		window.location.reload();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -55,7 +51,6 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 		async (event: CustomEvent<any>) => {
 			try {
 				const apiBaseUrl = getApiBaseUrl();
-
 				await axios.get(`${apiBaseUrl}/auth/descope/login?jwt=${event.detail.sessionJwt}`, {
 					withCredentials: true,
 				});
@@ -81,77 +76,14 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 	);
 
 	const isLoggedIn = Cookies.get(isLoggedInCookie);
+
 	if (authBearer || isLoggedIn) {
 		return children;
 	}
 
-	const benefitsList = Object.values(t("rightSide.benefitsList", { returnObjects: true }));
-
 	return (
-		<div className="flex h-screen">
-			<div className="relative flex w-2/3 items-center justify-center rounded-3xl pb-32 pl-16 text-black">
-				<div className="z-10 p-5">
-					<AHref
-						ariaLabel={t("leftSide.logoText")}
-						className="absolute left-4 top-4 flex h-auto items-center"
-						href="https://autokitteh.com/"
-						relationship="noreferrer"
-						target="_blank"
-						title={t("leftSide.logoText")}
-					>
-						<IconSvg className="top-8 size-10" src={AKRoundLogo} />{" "}
-						<div className="ml-3 font-averta text-2xl font-bold">{t("leftSide.logoText")}</div>
-					</AHref>
-					<h2 className="mt-16 font-averta text-4xl font-bold">{t("rightSide.titleFirstLine")}</h2>
-
-					<div className="flex">
-						<IconSvg className="ml-4 mr-2 h-10 w-24" size="3xl" src={InJustTitle} />
-
-						<h2 className="font-averta text-4xl font-bold">{t("rightSide.titleSecondLine")}</h2>
-					</div>
-
-					<h3 className="mt-12 max-w-485 font-averta text-2xl font-bold">
-						{t("rightSide.descriptionFirstLine")}
-					</h3>
-
-					<ul className="ml-4 mt-10 font-averta text-xl font-semibold">
-						{benefitsList?.length
-							? Object.values(benefitsList).map((benefit) => (
-									<li className="mt-2 before:size-1 before:bg-black" key={benefit}>
-										{benefit}
-									</li>
-								))
-							: null}
-					</ul>
-				</div>
-				<IconSvg
-					alt="autokitteh logo with integrations"
-					className="absolute bottom-0 right-8 h-36 w-9/12 object-contain object-bottom"
-					src={LoginLogos}
-				/>
-			</div>
-
-			<div className="z-10 flex w-7/12 shrink-0 flex-col items-center justify-center rounded-l-2xl bg-gray-1250 p-8 font-averta text-white">
-				<h1 className="text-center font-averta text-4xl font-semibold">
-					{t("leftSide.welcomeTitle")}
-					<br />
-					{t("leftSide.autokittehGreenTitle")}
-				</h1>
-
-				<Descope flowId="sign-up-or-in" key={descopeRenderKey} onSuccess={handleSuccess} />
-
-				<div>
-					{t("leftSide.signupText")}{" "}
-					<AHref
-						className="font-averta text-green-800 hover:text-gray-500"
-						href="https://autokitteh.com/get-a-demo/"
-						relationship="noreferrer"
-						target="_blank"
-					>
-						{t("leftSide.signupLink")}
-					</AHref>
-				</div>
-			</div>
-		</div>
+		<Suspense fallback={<Loader isCenter />}>
+			<LoginPage descopeRenderKey={descopeRenderKey} handleSuccess={handleSuccess} t={t} />
+		</Suspense>
 	);
 };

--- a/src/interfaces/components/icon.interface.ts
+++ b/src/interfaces/components/icon.interface.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FunctionComponent, LazyExoticComponent, SVGProps } from "react";
 
 export interface IconProps {
 	alt?: string;
@@ -11,5 +11,5 @@ export interface IconProps {
 }
 
 export interface IconSvgProps extends Omit<IconProps, "src"> {
-	src: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+	src: React.ComponentType<SVGProps<SVGSVGElement>> | LazyExoticComponent<FunctionComponent<SVGProps<SVGSVGElement>>>;
 }

--- a/src/interfaces/components/index.ts
+++ b/src/interfaces/components/index.ts
@@ -44,3 +44,4 @@ export type { CheckboxProps } from "@interfaces/components/checkbox.interface";
 export type { AccordionProps } from "@interfaces/components/accordion.interface";
 export type { BadgeProps } from "@interfaces/components/badge.interface";
 export type { HrefProps } from "@interfaces/components/href.interface";
+export type { LoginPageProps } from "@interfaces/components/loginPage.interface";

--- a/src/interfaces/components/loginPage.interface.ts
+++ b/src/interfaces/components/loginPage.interface.ts
@@ -1,0 +1,5 @@
+export interface LoginPageProps {
+	descopeRenderKey: number;
+	handleSuccess: (event: CustomEvent<any>) => Promise<void>;
+	t: (key: string, options?: any) => string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,8 @@
 			"@interfaces": ["./src/interfaces/index"],
 			"@type/*": ["./src/types/*"],
 			"@type": ["./src/types/index"],
+			"@pages/*": ["./pages/*"],
+			"@pages": ["./pages/index"],
 			"@api": ["./src/api/index"],
 			"@store/*": ["./src/store/*"],
 			"@store": ["./src/store/index"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -117,6 +117,7 @@ export default defineConfig({
 			"@interfaces": path.resolve(__dirname, "./src/interfaces"),
 			"@locales": path.resolve(__dirname, "./src/locales"),
 			"@models": path.resolve(__dirname, "./src/models"),
+			"@pages": path.resolve(__dirname, "./pages"),
 			"@routing": path.resolve(__dirname, "./src/routing"),
 			"@services": path.resolve(__dirname, "./src/services"),
 			"@store": path.resolve(__dirname, "./src/store"),


### PR DESCRIPTION
## Description
In order to avoid seeing the content of the app before login, and also to avoid loading the heavy images of the logos on the bottom of the login page - use lazy load and suspense 

## Linear Ticket
https://linear.app/autokitteh/issue/UI-825/lazy-load-of-the-login-page

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
