### PR TITLE
ci: remove hash of the release from the slack message

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -56,7 +56,6 @@ export default {
 						"and it's purr-fectly packed with features!\n\n \n\n" +
 						":yasss_cat: What's New:\n" +
 						"$release_notes	\n\n" +
-						"File Hash (SHA256): ${process.env.SHA256}\n\n" +
 						"Let's make some paw-some progress!\n\n" +
 						"*Happy Coding, Furr-iends!* " +
 						":cat-roomba-exceptionally-fast: " +


### PR DESCRIPTION
## Description
Remove redundant release hash from slack message.

## Linear Ticket

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [x] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
