### PR TITLE
fix: display multiline logs in session viewer

### DIFF
--- a/src/components/organisms/deployments/sessions/tabs/outputs.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/outputs.tsx
@@ -23,7 +23,7 @@ const OutputRow = memo(({ log, measure }: { log: SessionOutput; measure: () => v
 		<div className="mb-1" ref={rowRef}>
 			<div className="flex font-fira-code">
 				<div className="mr-5 whitespace-nowrap text-gray-1550">[{log.time}]: </div>
-				<div className="w-full whitespace-pre">{log.print}</div>
+				<div className="w-full whitespace-pre-wrap">{log.print}</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Description
Long logs displayed only until the end of the screen, even if the line is long:
![image](https://github.com/user-attachments/assets/7e2beb59-680a-41f1-8968-f0201804f1ee)

After the fix:
![image](https://github.com/user-attachments/assets/0fed8502-1636-4ffd-8bc7-a45039bfaf53)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-873/multiline-logs-not-displayed-correctly

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
