### PR TITLE
refactor: remove duplicated field (source) from session viewer

### DIFF
--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -174,15 +174,13 @@ export const SessionViewer = () => {
 						<div className="w-32 text-gray-1550">{t("status")}</div>
 						<SessionsTableState sessionState={sessionInfo.state} />
 					</div>
-					{sessionInfo.destinationName ? (
-						<div className="flex items-center gap-4">
-							<div className="w-32 text-gray-1550">{t("source")}</div>
-							{sessionInfo.destinationName}
-						</div>
-					) : null}
 					<div className="flex items-center gap-4">
-						<div className="w-32 text-gray-1550">{t("sourceType")}</div>
-						{sessionInfo.sourceType}
+						<div className="w-32 text-gray-1550">{t("source")}</div>
+						{sessionInfo.sourceType === "Connection" ? (
+							sessionInfo.destinationName
+						) : (
+							<span className="capitalize">{sessionInfo.sourceType}</span>
+						)}
 					</div>
 					<div className="flex items-center gap-4">
 						<div className="w-32 text-gray-1550">{t("entrypoint")}</div>


### PR DESCRIPTION
## Description

1. Remove the source
2. In case of connection, display the connection name and no connection
3. Keep the label Source, remove the label Source Type
![image](https://github.com/user-attachments/assets/ffccbfdf-446f-4d62-82ba-519c60f342bd)

![image](https://github.com/user-attachments/assets/3bd5db4e-50ed-40dd-95d6-58533d097e5b)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-863/session-view-trigger-source-and-trigger-type

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
