### PR TITLE
refactor: save manual run configuration state when we move between deployments

### DIFF
--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -54,7 +54,6 @@ export const ManualRunSettingsDrawer = ({ onRun }: { onRun: () => void }) => {
 	useEffect(() => {
 		if (filePath) {
 			setValue("filePath", filePath);
-			setValue("params", []);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [filePath]);

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -7,9 +7,9 @@ import { createWithEqualityFn as create } from "zustand/traditional";
 
 import { StoreName } from "@enums";
 import { SessionsService } from "@services";
-import { ManualProjectData, ManualRunStore } from "@src/interfaces/store";
+import { ManualRunStore } from "@src/interfaces/store";
 
-const createDefaultProjectState = (): ManualProjectData => ({
+const defaultManualRunState = {
 	files: [],
 	fileOptions: [],
 	filePath: { label: "", value: "" },
@@ -17,7 +17,7 @@ const createDefaultProjectState = (): ManualProjectData => ({
 	params: [],
 	isManualRunEnabled: false,
 	isJson: false,
-});
+};
 
 const store: StateCreator<ManualRunStore> = (set, get) => ({
 	projectManualRun: {},
@@ -28,7 +28,7 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 	) => {
 		set((state) => {
 			const projectData = {
-				...createDefaultProjectState(),
+				...defaultManualRunState,
 				...state.projectManualRun[projectId],
 			};
 

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -19,12 +19,6 @@ const createDefaultProjectState = (): ManualProjectData => ({
 	isJson: false,
 });
 
-const createFileOptions = (files: string[]): { label: string; value: string }[] =>
-	files.map((file) => ({
-		label: file,
-		value: file,
-	}));
-
 const store: StateCreator<ManualRunStore> = (set, get) => ({
 	projectManualRun: {},
 
@@ -39,7 +33,10 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 			};
 
 			if (files) {
-				const fileOptions = createFileOptions(files);
+				const fileOptions = files.map((file) => ({
+					label: file,
+					value: file,
+				}));
 				Object.assign(projectData, {
 					files,
 					fileOptions,


### PR DESCRIPTION
## Description
Save the manual run configuration state when we move between deployments and when the user changes the file of the manual run.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-871/the-run-paramters-should-be-saved-between-deployments-so-the-user

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
