### PR TITLE
fix: prevent loader display in viewer session

### DIFF
--- a/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
@@ -7,7 +7,7 @@ import { useVirtualizedList } from "@src/hooks";
 import { SessionActivity } from "@src/types/models";
 import { cn } from "@src/utilities";
 
-import { Frame, Loader } from "@components/atoms";
+import { Frame } from "@components/atoms";
 import { ActivityRow, SingleActivityInfo } from "@components/organisms/deployments/sessions/tabs/activities";
 
 export const ActivityList = () => {
@@ -18,7 +18,6 @@ export const ActivityList = () => {
 		items: activities,
 		listRef,
 		loadMoreRows,
-		loading,
 		nextPageToken,
 		t,
 	} = useVirtualizedList<SessionActivity>(SessionLogType.Activity, 60);
@@ -57,22 +56,6 @@ export const ActivityList = () => {
 		[activities.length, nextPageToken]
 	);
 
-	if (loading && !activities.length) {
-		return (
-			<Frame className="mr-3 h-4/5 w-full rounded-b-none pb-0 transition">
-				<Loader isCenter size="xl" />
-			</Frame>
-		);
-	}
-
-	if (!activities.length) {
-		return (
-			<Frame className="mr-3 h-4/5 w-full rounded-b-none pb-0 transition">
-				<div className="mt-10 text-center text-xl font-semibold">{t("noActivitiesFound")}</div>
-			</Frame>
-		);
-	}
-
 	return (
 		<Frame className="mr-3 h-4/5 w-full rounded-b-none pb-0 transition">
 			{selectedActivity ? (
@@ -107,6 +90,12 @@ export const ActivityList = () => {
 					</InfiniteLoader>
 				)}
 			</AutoSizer>
+
+			{!activities.length ? (
+				<div className="flex h-full items-center justify-center py-5 text-xl font-semibold">
+					{t("noActivitiesFound")}
+				</div>
+			) : null}
 		</Frame>
 	);
 };

--- a/src/components/organisms/deployments/sessions/tabs/outputs.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/outputs.tsx
@@ -41,7 +41,6 @@ export const SessionOutputs = () => {
 		nextPageToken,
 		t,
 	} = useVirtualizedList<SessionOutput>(SessionLogType.Output);
-
 	const cacheRef = useRef(
 		new CellMeasurerCache({
 			fixedWidth: true,

--- a/src/components/organisms/deployments/sessions/tabs/outputs.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/outputs.tsx
@@ -1,12 +1,10 @@
-import React, { memo, useCallback, useEffect, useRef } from "react";
+import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 
 import { AutoSizer, CellMeasurer, CellMeasurerCache, InfiniteLoader, List, ListRowProps } from "react-virtualized";
 
 import { useVirtualizedList } from "@hooks/useVirtualizedList";
 import { SessionLogType } from "@src/enums";
 import { SessionOutput } from "@src/types/models";
-
-import { Loader } from "@components/atoms";
 
 const OutputRow = memo(({ log, measure }: { log: SessionOutput; measure: () => void }) => {
 	const rowRef = useRef<HTMLDivElement>(null);
@@ -37,10 +35,10 @@ export const SessionOutputs = () => {
 		items: outputs,
 		listRef,
 		loadMoreRows,
-		loading,
 		nextPageToken,
 		t,
 	} = useVirtualizedList<SessionOutput>(SessionLogType.Output);
+	const [isInitialLoad, setIsInitialLoad] = useState(true);
 	const cacheRef = useRef(
 		new CellMeasurerCache({
 			fixedWidth: true,
@@ -54,6 +52,9 @@ export const SessionOutputs = () => {
 		if (listRef.current) {
 			cacheRef.current.clearAll();
 			listRef.current.recomputeRowHeights();
+		}
+		if (isInitialLoad) {
+			setIsInitialLoad(false);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [outputs]);
@@ -91,40 +92,36 @@ export const SessionOutputs = () => {
 
 	return (
 		<div className="scrollbar size-full">
-			{loading && !outputs.length ? (
-				<Loader isCenter size="xl" />
-			) : (
-				<AutoSizer>
-					{({ height, width }) => (
-						<InfiniteLoader
-							isRowLoaded={isRowLoaded}
-							loadMoreRows={loadMoreRows}
-							rowCount={nextPageToken ? outputs.length + 1 : outputs.length}
-							threshold={15}
-						>
-							{({ onRowsRendered, registerChild }) => (
-								<List
-									className="scrollbar"
-									deferredMeasurementCache={cacheRef.current}
-									height={height}
-									onRowsRendered={onRowsRendered}
-									overscanRowCount={10}
-									ref={(ref) => {
-										setListRef(ref);
-										registerChild(ref);
-									}}
-									rowCount={outputs.length}
-									rowHeight={cacheRef.current.rowHeight}
-									rowRenderer={customRowRenderer}
-									width={width}
-								/>
-							)}
-						</InfiniteLoader>
-					)}
-				</AutoSizer>
-			)}
+			<AutoSizer>
+				{({ height, width }) => (
+					<InfiniteLoader
+						isRowLoaded={isRowLoaded}
+						loadMoreRows={loadMoreRows}
+						rowCount={nextPageToken ? outputs.length + 1 : outputs.length}
+						threshold={15}
+					>
+						{({ onRowsRendered, registerChild }) => (
+							<List
+								className="scrollbar"
+								deferredMeasurementCache={cacheRef.current}
+								height={height}
+								onRowsRendered={onRowsRendered}
+								overscanRowCount={10}
+								ref={(ref) => {
+									setListRef(ref);
+									registerChild(ref);
+								}}
+								rowCount={outputs.length}
+								rowHeight={cacheRef.current.rowHeight}
+								rowRenderer={customRowRenderer}
+								width={width}
+							/>
+						)}
+					</InfiniteLoader>
+				)}
+			</AutoSizer>
 
-			{!outputs.length && !loading ? (
+			{!outputs.length ? (
 				<div className="flex h-full items-center justify-center py-5 text-xl font-semibold">
 					{t("noLogsFound")}
 				</div>

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -41,6 +41,7 @@ export const SessionViewer = () => {
 	const [activeTab, setActiveTab] = useState(defaultSessionTab);
 	const [sessionInfo, setSessionInfo] = useState<ViewerSession | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
+	const [isInitialLoad, setIsInitialLoad] = useState(true);
 	const addToast = useToastStore((state) => state.addToast);
 
 	const { reload: reloadOutputs } = useOutputsCacheStore();
@@ -82,6 +83,11 @@ export const SessionViewer = () => {
 		fetchSessionInfo();
 		reloadOutputs(sessionInfo.sessionId, sessionLogRowHeight);
 		reloadActivities(sessionInfo.sessionId, sessionLogRowHeight);
+
+		if (isInitialLoad) {
+			setIsInitialLoad(false);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [sessionInfo, fetchSessionInfo, reloadOutputs, reloadActivities]);
 
 	useEffect(() => {
@@ -143,7 +149,7 @@ export const SessionViewer = () => {
 
 	if (!sessionInfo) return null;
 
-	return isLoading ? (
+	return isLoading && isInitialLoad ? (
 		<Loader size="xl" />
 	) : (
 		<Frame className="overflow-y-auto overflow-x-hidden rounded-l-none pb-3 font-fira-code">

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -80,7 +80,7 @@ export const SessionViewer = () => {
 
 	const fetchSessions = useCallback(async () => {
 		if (!sessionInfo) return;
-		fetchSessionInfo();
+		await fetchSessionInfo();
 		reloadOutputs(sessionInfo.sessionId, sessionLogRowHeight);
 		reloadActivities(sessionInfo.sessionId, sessionLogRowHeight);
 

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -271,9 +271,9 @@ export const SessionViewer = () => {
 						</Tab>
 					))}
 				</div>
-				{loadingOutputs || loadingActivities ? (
+				{!loadingOutputs || !loadingActivities ? (
 					<div>
-						<Loader />
+						<Loader size="sm" />
 					</div>
 				) : null}
 			</div>

--- a/src/hooks/useVirtualizedList.tsx
+++ b/src/hooks/useVirtualizedList.tsx
@@ -94,7 +94,6 @@ export function useVirtualizedList<T extends SessionOutput | SessionActivity>(
 
 	return {
 		items,
-		loading,
 		isRowLoaded,
 		loadMoreRows,
 		cache,

--- a/src/interfaces/hooks/useVirtualizedList.interface.ts
+++ b/src/interfaces/hooks/useVirtualizedList.interface.ts
@@ -2,7 +2,6 @@ import { CellMeasurerCache, List, ListRowProps } from "react-virtualized";
 
 export interface VirtualizedListHookResult<T> {
 	items: T[];
-	loading: boolean;
 	isRowLoaded: (params: { index: number }) => boolean;
 	loadMoreRows: (params: { startIndex: number; stopIndex: number }) => Promise<void>;
 	cache: CellMeasurerCache;

--- a/src/interfaces/store/activitiesAndOutputsCache.store.interface.ts
+++ b/src/interfaces/store/activitiesAndOutputsCache.store.interface.ts
@@ -15,15 +15,15 @@ export interface SessionOutputData {
 export interface ActivitiesStore {
 	sessions: Record<string, SessionActivityData>;
 	loading: boolean;
-	reset: (sessionId: string) => void;
-	reload: (sessionId: string, pageSize: number) => void;
+	isReloading: boolean;
+	reload: (sessionId: string, pageSize: number) => Promise<void>;
 	loadLogs: (sessionId: string, pageSize?: number) => Promise<void>;
 }
 
 export interface OutputsStore {
 	sessions: Record<string, SessionOutputData>;
 	loading: boolean;
-	reset: (sessionId: string) => void;
-	reload: (sessionId: string, pageSize: number) => void;
+	isReloading: boolean;
+	reload: (sessionId: string, pageSize: number) => Promise<void>;
 	loadLogs: (sessionId: string, pageSize?: number) => Promise<void>;
 }


### PR DESCRIPTION
## Description

## Linear Ticket
https://linear.app/autokitteh/issue/UI-854/session-viewer-on-refresh-change-only-status-end-time-duration-logs
## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
