### PR TITLE
fix: force fetch connections in connection checker

### DIFF
--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -37,7 +37,7 @@ export const ConnectionsTable = () => {
 	const { resetChecker, setFetchConnectionsCallback } = useConnectionCheckerStore();
 
 	useEffect(() => {
-		setFetchConnectionsCallback(() => fetchConnections(projectId!));
+		setFetchConnectionsCallback(() => fetchConnections(projectId!, true));
 
 		return () => {
 			resetChecker();


### PR DESCRIPTION
## Description
Since we moved the connections to the cache, now we need to force the re-fetch when the connection change it status to OK (meaning when the OAuth process is successfully over).

## Linear Ticket
https://linear.app/autokitteh/issue/UI-916/connection-status-checker-not-working

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
