### PR TITLE
feat(UI-956): functions select in manual run

### DIFF
--- a/src/components/organisms/deployments/table.tsx
+++ b/src/components/organisms/deployments/table.tsx
@@ -3,10 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
-import { BuildsService } from "@services";
-import { DeploymentStateVariant } from "@src/enums";
-import { useCacheStore, useManualRunStore, useToastStore } from "@src/store/";
-import { convertBuildRuntimesToViewTriggers } from "@src/utilities";
+import { useCacheStore } from "@src/store/";
 
 import { Frame, Loader } from "@components/atoms";
 import { RefreshButton } from "@components/molecules";
@@ -14,7 +11,6 @@ import { DeploymentsTableContent } from "@components/organisms/deployments";
 
 export const DeploymentsTable = () => {
 	const { t } = useTranslation("deployments", { keyPrefix: "history" });
-	const addToast = useToastStore((state) => state.addToast);
 	const { projectId } = useParams();
 	const {
 		deployments,
@@ -30,53 +26,6 @@ export const DeploymentsTable = () => {
 		fetchDeployments(projectId!, true);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [projectId]);
-
-	const { lastDeploymentStore, updateManualRunConfiguration } = useManualRunStore((state) => ({
-		lastDeploymentStore: state.projectManualRun[projectId!]?.lastDeployment,
-		entrypointFunction: state.projectManualRun[projectId!]?.entrypointFunction,
-		updateManualRunConfiguration: state.updateManualRunConfiguration,
-		saveAndExecuteManualRun: state.saveAndExecuteManualRun,
-	}));
-
-	const loadSingleshotArgs = async () => {
-		if (!deployments?.length || deployments[0].state !== DeploymentStateVariant.active) {
-			updateManualRunConfiguration(projectId!, { isManualRunEnabled: false });
-
-			return;
-		}
-
-		const lastDeployment = deployments[0];
-
-		if (lastDeployment.buildId === lastDeploymentStore?.buildId) {
-			updateManualRunConfiguration(projectId!, { isManualRunEnabled: true });
-
-			return;
-		}
-
-		const { data: buildDescription, error: buildDescriptionError } = await BuildsService.getBuildDescription(
-			lastDeployment.buildId
-		);
-
-		if (buildDescriptionError) {
-			addToast({
-				message: t("buildInformationForSingleshotNotLoaded"),
-				type: "error",
-			});
-
-			return;
-		}
-		const buildInfo = JSON.parse(buildDescription!);
-		const files = convertBuildRuntimesToViewTriggers(buildInfo.runtimes);
-
-		if (!Object.keys(files).length) return;
-
-		updateManualRunConfiguration(projectId!, { files, lastDeployment, isManualRunEnabled: true });
-	};
-
-	useEffect(() => {
-		loadSingleshotArgs();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [deployments]);
 
 	return (
 		<Frame className="my-1.5 flex-1 bg-gray-1100">

--- a/src/components/organisms/deployments/table.tsx
+++ b/src/components/organisms/deployments/table.tsx
@@ -68,7 +68,7 @@ export const DeploymentsTable = () => {
 		const buildInfo = JSON.parse(buildDescription!);
 		const files = convertBuildRuntimesToViewTriggers(buildInfo.runtimes);
 
-		if (!Object.values(files).length) return;
+		if (!Object.keys(files).length) return;
 
 		updateManualRunConfiguration(projectId!, { files, lastDeployment, isManualRunEnabled: true });
 	};

--- a/src/components/organisms/topbar/project/buttons.tsx
+++ b/src/components/organisms/topbar/project/buttons.tsx
@@ -7,7 +7,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { ModalName, TopbarButton } from "@enums/components";
 import { LoggerService, ProjectsService } from "@services";
 import { namespaces } from "@src/constants";
-import { useCacheStore, useConnectionCheckerStore, useModalStore, useProjectStore, useToastStore } from "@src/store";
+import {
+	useCacheStore,
+	useConnectionCheckerStore,
+	useManualRunStore,
+	useModalStore,
+	useProjectStore,
+	useToastStore,
+} from "@src/store";
 
 import { Button, IconSvg, Loader, Spinner } from "@components/atoms";
 import { DropdownButton } from "@components/molecules";
@@ -24,6 +31,7 @@ export const ProjectTopbarButtons = () => {
 	const navigate = useNavigate();
 	const { closeModal, openModal } = useModalStore();
 	const { fetchDeployments, fetchResources, isValid, projectValidationState } = useCacheStore();
+	const { fetchManualRunConfiguration } = useManualRunStore();
 	const projectValidationErrors = Object.values(projectValidationState).filter((error) => error.message !== "");
 	const projectErrors = isValid ? "" : Object.values(projectValidationErrors).join(", ");
 	const { resetChecker } = useConnectionCheckerStore();
@@ -78,7 +86,8 @@ export const ProjectTopbarButtons = () => {
 
 				return;
 			}
-			fetchDeployments(projectId!, true);
+			await fetchDeployments(projectId!, true);
+			await fetchManualRunConfiguration(projectId!);
 			addToast({
 				message: t("topbar.deployedProjectSuccess"),
 				type: "success",

--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Controller, FormProvider, useForm } from "react-hook-form";
+import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
@@ -13,6 +13,7 @@ import { manualRunSchema } from "@validations";
 
 import { Button, ErrorMessage, IconSvg, Spinner, Typography } from "@components/atoms";
 import { Drawer, Select } from "@components/molecules";
+import { SelectCreatable } from "@components/molecules/select";
 import { ManualRunParamsForm, ManualRunSuccessToastMessage } from "@components/organisms/topbar/project";
 
 import { RunIcon } from "@assets/image/icons";
@@ -117,6 +118,13 @@ export const ManualRunSettingsDrawer = () => {
 		closeDrawer(DrawerName.projectManualRunSettings);
 	};
 
+	const entrypointFunctionValue = useWatch({ control, name: "entrypointFunction" });
+	const onEntrypointCreate = (value: string) => {
+		const newFunction = { label: value, value };
+		setFileFunctions((prev) => [...prev, newFunction]);
+		setValue("entrypointFunction", newFunction);
+	};
+
 	return (
 		<Drawer className="p-10" name={DrawerName.projectManualRunSettings} variant="dark">
 			<FormProvider {...methods}>
@@ -178,7 +186,7 @@ export const ManualRunSettingsDrawer = () => {
 							control={control}
 							name="entrypointFunction"
 							render={({ field }) => (
-								<Select
+								<SelectCreatable
 									{...field}
 									aria-label={t("placeholders.selectEntrypoint")}
 									dataTestid="select-function"
@@ -189,9 +197,10 @@ export const ManualRunSettingsDrawer = () => {
 										field.onChange(selected);
 										updateManualRunConfiguration(projectId!, { entrypointFunction: selected! });
 									}}
+									onCreateOption={onEntrypointCreate}
 									options={fileFunctions}
 									placeholder={t("placeholders.selectEntrypoint")}
-									value={field.value}
+									value={entrypointFunctionValue}
 								/>
 							)}
 						/>

--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -11,7 +11,7 @@ import { DrawerName } from "@src/enums/components";
 import { useCacheStore, useDrawerStore, useManualRunStore, useToastStore } from "@src/store";
 import { manualRunSchema } from "@validations";
 
-import { Button, ErrorMessage, IconSvg, Input, Spinner, Typography } from "@components/atoms";
+import { Button, ErrorMessage, IconSvg, Spinner, Typography } from "@components/atoms";
 import { Drawer, Select } from "@components/molecules";
 import { ManualRunParamsForm, ManualRunSuccessToastMessage } from "@components/organisms/topbar/project";
 
@@ -32,7 +32,7 @@ export const ManualRunSettingsDrawer = () => {
 		saveAndExecuteManualRun: state.saveAndExecuteManualRun,
 	}));
 
-	const { entrypointFunction, fileOptions, filePath, lastDeployment, params } = projectManualRun || {};
+	const { entrypointFunction, fileOptions, filePath, files, lastDeployment, params } = projectManualRun || {};
 
 	const methods = useForm({
 		resolver: zodResolver(manualRunSchema),
@@ -44,6 +44,8 @@ export const ManualRunSettingsDrawer = () => {
 		mode: "onChange",
 	});
 
+	const [fileFunctions, setFileFunctions] = useState<{ label: string; value: string }[]>([]);
+
 	const {
 		control,
 		formState: { errors, isValid },
@@ -53,9 +55,16 @@ export const ManualRunSettingsDrawer = () => {
 	} = methods;
 
 	useEffect(() => {
-		if (filePath) {
-			setValue("filePath", filePath);
-		}
+		if (!filePath) return;
+		setValue("filePath", filePath);
+
+		if (!files && filePath.value) return;
+		const processedFileFunctions =
+			files[filePath.value]?.map((fileFunction) => ({
+				label: fileFunction,
+				value: fileFunction,
+			})) || [];
+		setFileFunctions(processedFileFunctions);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [filePath]);
 
@@ -167,7 +176,7 @@ export const ManualRunSettingsDrawer = () => {
 					<div className="relative mt-3">
 						<Controller
 							control={control}
-							name="filePath"
+							name="entrypointFunction"
 							render={({ field }) => (
 								<Select
 									{...field}
@@ -179,15 +188,15 @@ export const ManualRunSettingsDrawer = () => {
 									noOptionsLabel={t("noFilesAvailable")}
 									onChange={(selected) => {
 										field.onChange(selected);
-										updateManualRunConfiguration(projectId!, { filePath: selected! });
+										updateManualRunConfiguration(projectId!, { entrypointFunction: selected! });
 									}}
-									options={fileOptions}
+									options={fileFunctions}
 									placeholder={t("placeholders.selectFile")}
 									value={field.value}
 								/>
 							)}
 						/>
-						<Controller
+						{/* <Controller
 							control={control}
 							name="entrypointFunction"
 							render={({ field }) => (
@@ -205,7 +214,7 @@ export const ManualRunSettingsDrawer = () => {
 									}}
 								/>
 							)}
-						/>
+						/> */}
 
 						<ErrorMessage className="relative">{errors.entrypointFunction?.message as string}</ErrorMessage>
 					</div>

--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -80,7 +80,7 @@ export const ManualRunSettingsDrawer = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [params]);
 
-	const handleMunaualRun = () => {
+	const handleManualRun = () => {
 		setTimeout(() => {
 			fetchDeployments(projectId!, true);
 		}, 100);
@@ -94,7 +94,7 @@ export const ManualRunSettingsDrawer = () => {
 
 		const { data: sessionId, error } = await saveAndExecuteManualRun(projectId, params);
 		setSendingManualRun(false);
-		handleMunaualRun();
+		handleManualRun();
 		if (error) {
 			addToast({
 				message: t("executionFailed"),
@@ -196,26 +196,6 @@ export const ManualRunSettingsDrawer = () => {
 								/>
 							)}
 						/>
-						{/* <Controller
-							control={control}
-							name="entrypointFunction"
-							render={({ field }) => (
-								<Input
-									{...field}
-									aria-label={t("placeholders.selectEntrypoint")}
-									isError={!!errors.entrypointFunction}
-									isRequired
-									label={t("placeholders.entrypoint")}
-									onChange={(event) => {
-										field.onChange(event);
-										updateManualRunConfiguration(projectId!, {
-											entrypointFunction: event.target.value,
-										});
-									}}
-								/>
-							)}
-						/> */}
-
 						<ErrorMessage className="relative">{errors.entrypointFunction?.message as string}</ErrorMessage>
 					</div>
 				</form>

--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -167,6 +167,28 @@ export const ManualRunSettingsDrawer = () => {
 					<div className="relative mt-3">
 						<Controller
 							control={control}
+							name="filePath"
+							render={({ field }) => (
+								<Select
+									{...field}
+									aria-label={t("placeholders.selectFile")}
+									dataTestid="select-file"
+									disabled={!fileOptions.length}
+									isError={!!errors.filePath}
+									label={t("placeholders.file")}
+									noOptionsLabel={t("noFilesAvailable")}
+									onChange={(selected) => {
+										field.onChange(selected);
+										updateManualRunConfiguration(projectId!, { filePath: selected! });
+									}}
+									options={fileOptions}
+									placeholder={t("placeholders.selectFile")}
+									value={field.value}
+								/>
+							)}
+						/>
+						<Controller
+							control={control}
 							name="entrypointFunction"
 							render={({ field }) => (
 								<Input

--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -180,18 +180,17 @@ export const ManualRunSettingsDrawer = () => {
 							render={({ field }) => (
 								<Select
 									{...field}
-									aria-label={t("placeholders.selectFile")}
-									dataTestid="select-file"
-									disabled={!fileOptions.length}
-									isError={!!errors.filePath}
-									label={t("placeholders.file")}
-									noOptionsLabel={t("noFilesAvailable")}
+									aria-label={t("placeholders.selectEntrypoint")}
+									dataTestid="select-function"
+									isError={!!errors.entrypointFunction}
+									label={t("placeholders.entrypoint")}
+									noOptionsLabel={t("noFunctionsAvailable")}
 									onChange={(selected) => {
 										field.onChange(selected);
 										updateManualRunConfiguration(projectId!, { entrypointFunction: selected! });
 									}}
 									options={fileFunctions}
-									placeholder={t("placeholders.selectFile")}
+									placeholder={t("placeholders.selectEntrypoint")}
 									value={field.value}
 								/>
 							)}

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { defaultProjectTab, projectTabs } from "@constants/project.constants";
-import { useCacheStore, useProjectStore } from "@src/store";
+import { useCacheStore, useManualRunStore, useProjectStore } from "@src/store";
 import { calculatePathDepth, cn } from "@utilities";
 
 import { IconSvg, PageTitle, Tab } from "@components/atoms";
@@ -16,6 +16,7 @@ export const Project = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const { currentProjectId, initCache, projectValidationState } = useCacheStore();
+	const { fetchManualRunConfiguration } = useManualRunStore();
 	const { t } = useTranslation("global", { keyPrefix: "pageTitles" });
 	const [pageTitle, setPageTitle] = useState<string>(t("base"));
 	const { projectId } = useParams();
@@ -24,6 +25,7 @@ export const Project = () => {
 	const loadProject = async (projectId: string) => {
 		if (currentProjectId === projectId) return;
 		await initCache(projectId, true);
+		fetchManualRunConfiguration(projectId!);
 		const { data: project } = await getProject(projectId!);
 		if (!project?.name) {
 			setPageTitle(t("base"));

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -25,7 +25,7 @@ export const Project = () => {
 	const loadProject = async (projectId: string) => {
 		if (currentProjectId === projectId) return;
 		await initCache(projectId, true);
-		fetchManualRunConfiguration(projectId!);
+		fetchManualRunConfiguration(projectId);
 		const { data: project } = await getProject(projectId!);
 		if (!project?.name) {
 			setPageTitle(t("base"));

--- a/src/interfaces/models/index.ts
+++ b/src/interfaces/models/index.ts
@@ -8,4 +8,5 @@ export type {
 	SessionOutput,
 	SessionActivity,
 	ViewerSession,
+	BuildRuntimeExport,
 } from "@src/interfaces/models/session.interface";

--- a/src/interfaces/models/session.interface.ts
+++ b/src/interfaces/models/session.interface.ts
@@ -11,6 +11,10 @@ export interface SessionEntrypoint {
 export interface EntrypointTrigger extends SessionEntrypoint {
 	symbol: string;
 }
+export interface BuildRuntimeExport extends SessionEntrypoint {
+	symbol: string;
+	location: SessionEntrypoint;
+}
 
 interface BaseSession {
 	createdAt: Date;

--- a/src/interfaces/store/manualRunStore.interface.ts
+++ b/src/interfaces/store/manualRunStore.interface.ts
@@ -20,4 +20,5 @@ export interface ManualRunStore {
 	};
 	updateManualRunConfiguration: (projectId: string, updates: Partial<ManualProjectData>) => void;
 	saveAndExecuteManualRun: (projectId: string, params?: { key: string; value: string }[]) => ServiceResponse<string>;
+	fetchManualRunConfiguration: (projectId: string) => void;
 }

--- a/src/interfaces/store/manualRunStore.interface.ts
+++ b/src/interfaces/store/manualRunStore.interface.ts
@@ -6,7 +6,7 @@ export interface ManualProjectData {
 	files: Record<string, string[]>;
 	fileOptions: { label: string; value: string }[];
 	filePath: { label: string; value: string };
-	entrypointFunction: string;
+	entrypointFunction: { label: string; value: string };
 	params: { key: string; value: string }[];
 	isJson: boolean;
 	lastDeployment?: Deployment;

--- a/src/interfaces/store/manualRunStore.interface.ts
+++ b/src/interfaces/store/manualRunStore.interface.ts
@@ -3,7 +3,7 @@ import { ServiceResponse } from "@src/types";
 import { Deployment } from "@src/types/models";
 
 export interface ManualProjectData {
-	files: string[];
+	files: Record<string, string[]>;
 	fileOptions: { label: string; value: string }[];
 	filePath: { label: string; value: string };
 	entrypointFunction: string;

--- a/src/locales/en/deployments/translation.json
+++ b/src/locales/en/deployments/translation.json
@@ -41,7 +41,7 @@
 			"placeholders": {
 				"selectFile": "Select file",
 				"file": "File",
-				"selectEntrypoint": "Select entrypoint function",
+				"selectEntrypoint": "Select entrypoint",
 				"entrypoint": "Entrypoint",
 				"key": "Key",
 				"value": "Value",

--- a/src/locales/en/validations/translation.json
+++ b/src/locales/en/validations/translation.json
@@ -3,7 +3,7 @@
     "cronExpressionsFormat": "The cron schedule expression must match the required format",
     "extensionIsRequired": "File extension is required",
     "fileNameIsRequired": "File name is required",
-    "functionNameIsRequired": "Function name is required",
+    "functionNameIsRequired": "Entrypoint is required",
     "manualRun":{
         "valueIsRequired": "Value is required",
         "keyIsRequired": "Key is required",

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -33,15 +33,18 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 			};
 
 			if (files) {
-				const fileOptions = files.map((file) => ({
+				const fileOptions = Object.keys(files).map((file) => ({
 					label: file,
 					value: file,
 				}));
+
+				const entrypointFromFirstFile = files[Object.keys(files)?.[0]]?.[0] || "";
+
 				Object.assign(projectData, {
 					files,
 					fileOptions,
 					filePath: fileOptions[0],
-					entrypointFunction: "",
+					entrypointFunction: entrypointFromFirstFile,
 					params: [],
 				});
 			}

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -13,7 +13,7 @@ const defaultManualRunState = {
 	files: [],
 	fileOptions: [],
 	filePath: { label: "", value: "" },
-	entrypointFunction: "",
+	entrypointFunction: { label: "", value: "" },
 	params: [],
 	isManualRunEnabled: false,
 	isJson: false,
@@ -44,7 +44,7 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 					files,
 					fileOptions,
 					filePath: fileOptions[0],
-					entrypointFunction: entrypointFromFirstFile,
+					entrypointFunction: { label: entrypointFromFirstFile, value: entrypointFromFirstFile },
 					params: [],
 				});
 			}
@@ -90,7 +90,7 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 				col: 0,
 				row: 0,
 				path: project.filePath.value,
-				name: project.entrypointFunction,
+				name: project.entrypointFunction.value,
 			},
 			jsonInputs,
 		};

--- a/src/types/models/buildInfoRuntimes.type.ts
+++ b/src/types/models/buildInfoRuntimes.type.ts
@@ -1,9 +1,9 @@
-import { EntrypointTrigger } from "@src/interfaces/models/session.interface";
+import { BuildRuntimeExport } from "@src/interfaces/models/session.interface";
 
 export type BuildInfoRuntimes = {
 	artifact: {
 		compiled_data: string;
-		exports: EntrypointTrigger[];
+		exports: BuildRuntimeExport[];
 	};
 	info: {
 		name: string;

--- a/src/validations/manualRun.schema.ts
+++ b/src/validations/manualRun.schema.ts
@@ -14,7 +14,9 @@ i18n.on("initialized", () => {
 		filePath: selectSchema.refine((value) => value.label, {
 			message: i18n.t("fileNameIsRequired", { ns: "validations" }),
 		}),
-		entrypointFunction: z.string().min(1, i18n.t("functionNameIsRequired", { ns: "validations" })),
+		entrypointFunction: selectSchema.refine((value) => value.label, {
+			message: i18n.t("functionNameIsRequired", { ns: "validations" }),
+		}),
 		params: z
 			.array(
 				z.object({


### PR DESCRIPTION
## Description
**Single-shot and triggers missing entry-point function names in buildInfo runtimes exports**
Instead of clear text - display a dropdown with all functions coming from the build info (BuildService.Describe function).

## Linear Ticket
https://linear.app/autokitteh/issue/UI-956/manual-run-add-the-ability-to-select-function-out-of-a-dropdown

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
