### PR TITLE
fix: display correct return value in activity viewer per session

### DIFF
--- a/src/components/organisms/deployments/sessions/tabs/activities/singleActivityInfo.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/singleActivityInfo.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import JsonView from "@uiw/react-json-view";
-import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
 import { useTranslation } from "react-i18next";
 
 import { SessionActivity } from "@src/interfaces/models";
@@ -87,34 +85,6 @@ export const SingleActivityInfo = ({
 
 					<div className="mb-4 mt-8 font-bold">{t("returnValues")}</div>
 
-					{!activity.returnStringValue &&
-					!activity.returnBytesValue &&
-					!Object.keys(activity.returnJSONValue || {}).length ? (
-						<div>{t("noReturnValuesFound")}</div>
-					) : null}
-
-					{activity.returnBytesValue ? (
-						<Accordion
-							className="mb-4"
-							title={<div className="font-bold underline">{t("returnValues")}</div>}
-						>
-							<pre className="whitespace-pre-wrap">{activity.returnBytesValue}</pre>
-						</Accordion>
-					) : null}
-
-					{Object.keys(activity.returnJSONValue || {}).length ? (
-						<Accordion
-							className="mb-4"
-							title={<div className="font-bold underline">{t("returnValues")}</div>}
-						>
-							<JsonView
-								className="scrollbar mt-2 max-h-72 overflow-auto"
-								style={githubDarkTheme}
-								value={activity.returnJSONValue}
-							/>
-						</Accordion>
-					) : null}
-
 					{activity.returnStringValue ? (
 						<Accordion
 							className="mb-4"
@@ -122,7 +92,9 @@ export const SingleActivityInfo = ({
 						>
 							<pre className="w-4/5 whitespace-pre-wrap break-words">{activity.returnStringValue}</pre>
 						</Accordion>
-					) : null}
+					) : (
+						<div>{t("noReturnValuesFound")}</div>
+					)}
 				</div>
 			</div>
 		</div>

--- a/src/constants/namespaces.logger.constants.ts
+++ b/src/constants/namespaces.logger.constants.ts
@@ -48,4 +48,7 @@ export const namespaces = {
 	utilities: {
 		fetchAndExtract: "Fetch and Extract",
 	},
+	models: {
+		activity: "Activity Model",
+	},
 };

--- a/src/locales/en/errors/translation.json
+++ b/src/locales/en/errors/translation.json
@@ -38,6 +38,7 @@
 	"sessionLogMissingOnErrorType": "Session History - No error",
 	"sessionLogRecordMultipleProps": "More than one session log record type found: {{props}}",
 	"sessionLogRecordTypeNotFound": "Session log record type not found: {{props}}",
+	"sessionLogRecordActivtyErrorConvert": "Session log record activity error convert failed, error: {{error}}",
 	"sessionsFetchError": "Couldn't fetch the sessions details",
 	"sessionsFetchErrorExtended": "Couldn't fetch the sessions details, error message: {{error}}",
 	"triggerFailedExtended": "Trigger failed, ID: {{triggerId}}, error message: {{error}}",


### PR DESCRIPTION
## Description
Display correct return value in session viewer - Display a proper JSON instead of the current string.
Currently, the returned values per session activity are not readable, here is an example:
```
Y2NvcHlfcmVnCl9yZWNvbnN0cnVjdG9yCnAwCihjcmVxdWVzdHMubW9kZWxzClJlc3BvbnNlCnAxCmNfX2J1aWx0aW5fXwpvYmplY3QKcDIKTnRwMwpScDQKKGRwNQpWX2NvbnRlbnQKcDYKY19jb2RlY3MKZW5jb2RlCnA3CihWe1x1MDAwYSAgImFyZ3MiOiB7XHUwMDBhICAgICJpIjogIjI2IiwgXHUwMDBhICAgICJtZXNzYWdlIjogImhlbGxvIiwgXHUwMDBhICAgICJuYW1lIjogIndvcmxkIiwgXHUwMDBhICAgICJ4IjogIjUyIiwgXHUwMDBhICAgICJ5IjogIjAiXHUwMDBhICB9LCBcdTAwMGEgICJoZWFkZXJzIjoge1x1MDAwYSAgICAiQWNjZXB0IjogIiovKiIsIFx1MDAwYSAgICAiQWNjZXB0LUVuY29kaW5nIjogImd6aXAsIGRlZmxhdGUiLCBcdTAwMGEgICAgIkhvc3QiOiAiaHR0cGJpbi5vcmciLCBcdTAwMGEgICAgIlVzZXItQWdlbnQiOiAicHl0aG9uLXJlcXVlc3RzLzIuMzIuMyIsIFx1MDAwYSAgICAiWC1BbXpuLVRyYWNlLUlkIjogIlJvb3Q9MS02NmYxNTRkMC01Y2I4OTUwMTYxZGMyODU0NzFhYmYyYjkiXHUwMDBhICB9LCBcdTAwMGEgICJvcmlnaW4iOiAiNjIuMC4xMzQuNDAiLCBcdTAwMGEgICJ1cmwiOiAiaHR0cDovL2h0dHBiaW4ub3JnL2dldD9pPTI2Jng9NTImeT0wJm1lc3NhZ2U9aGVsbG8mbmFtZT13b3JsZCJcdTAwMGF9XHUwMDBhCnA4ClZsYXRpbjEKcDkKdHAxMApScDExCnNWc3RhdHVzX2NvZGUKcDEyCkkyMDAKc1ZoZWFkZXJzCnAxMwpnMAooY3JlcXVlc3RzLnN0cnVjdHVyZXMKQ2FzZUluc2Vuc2l0aXZlRGljdApwMTQKZzIKTnRwMTUKUnAxNgooZHAxNwpWX3N0b3JlCnAxOApjY29sbGVjdGlvbnMKT3JkZXJlZERpY3QKcDE5Cih0UnAyMApWZGF0ZQpwMjEKKFZEYXRlCnAyMgpWTW9uLCAyMyBTZXAgMjAyNCAxMTo0NToyMCBHTVQKcDIzCnRwMjQKc1Zjb250ZW50LXR5cGUKcDI1CihWQ29udGVudC1UeXBlCnAyNgpWYXBwbGljYXRpb24vanNvbgpwMjcKdHAyOApzVmNvbnRlbnQtbGVuZ3RoCnAyOQooVkNvbnRlbnQtTGVuZ3RoCnAzMApWNDM4CnAzMQp0cDMyCnNWY29ubmVjdGlvbgpwMzMKKFZDb25uZWN0aW9uCnAzNApWa2VlcC1hbGl2ZQpwMzUKdHAzNgpzVnNlcnZlcgpwMzcKKFZTZXJ2ZXIKcDM4ClZndW5pY29ybi8xOS45LjAKcDM5CnRwNDAKc1ZhY2Nlc3MtY29udHJvbC1hbGxvdy1vcmlnaW4KcDQxCihWQWNjZXNzLUNvbnRyb2wtQWxsb3ctT3JpZ2luCnA0MgpWKgpwNDMKdHA0NApzVmFjY2Vzcy1jb250cm9sLWFsbG93LWNyZWRlbnRpYWxzCnA0NQooVkFjY2Vzcy1Db250cm9sLUFsbG93LUNyZWRlbnRpYWxzCnA0NgpWdHJ1ZQpwNDcKdHA0OApzc2JzVnVybApwNDkKVmh0dHA6Ly9odHRwYmluLm9yZy9nZXQ/aT0yNiZ4PTUyJnk9MCZtZXNzYWdlPWhlbGxvJm5hbWU9d29ybGQKcDUwCnNWaGlzdG9yeQpwNTEKKGxwNTIKc1ZlbmNvZGluZwpwNTMKVnV0Zi04CnA1NApzVnJlYXNvbgpwNTUKVk9LCnA1NgpzVmNvb2tpZXMKcDU3CmcwCihjcmVxdWVzdHMuY29va2llcwpSZXF1ZXN0c0Nvb2tpZUphcgpwNTgKZzIKTnRwNTkKUnA2MAooZHA2MQpWX3BvbGljeQpwNjIKZzAKKGNjb29raWVsaWIKRGVmYXVsdENvb2tpZVBvbGljeQpwNjMKZzIKTnRwNjQKUnA2NQooZHA2NgpWbmV0c2NhcGUKcDY3CkkwMQpzVnJmYzI5NjUKcDY4CkkwMApzVnJmYzIxMDlfYXNfbmV0c2NhcGUKcDY5Ck5zVmhpZGVfY29va2llMgpwNzAKSTAwCnNWc3RyaWN0X2RvbWFpbgpwNzEKSTAwCnNWc3RyaWN0X3JmYzI5NjVfdW52ZXJpZmlhYmxlCnA3MgpJMDEKc1ZzdHJpY3RfbnNfdW52ZXJpZmlhYmxlCnA3MwpJMDAKc1ZzdHJpY3RfbnNfZG9tYWluCnA3NApJMApzVnN0cmljdF9uc19zZXRfaW5pdGlhbF9kb2xsYXIKcDc1CkkwMApzVnN0cmljdF9uc19zZXRfcGF0aApwNzYKSTAwCnNWc2VjdXJlX3Byb3RvY29scwpwNzcKKFZodHRwcwpwNzgKVndzcwpwNzkKdHA4MApzVl9ibG9ja2VkX2RvbWFpbnMKcDgxCih0c1ZfYWxsb3dlZF9kb21haW5zCnA4MgpOc1Zfbm93CnA4MwpJMTcyNzA5MTkyMApzYnNWX2Nvb2tpZXMKcDg0CihkcDg1CnNnODMKSTE3MjcwOTE5MjAKc2JzVmVsYXBzZWQKcDg2CmNkYXRldGltZQp0aW1lZGVsdGEKcDg3CihJMApJMApJMzMwMzk5CnRwODgKUnA4OQpzVnJlcXVlc3QKcDkwCmcwCihjcmVxdWVzdHMubW9kZWxzClByZXBhcmVkUmVxdWVzdApwOTEKZzIKTnRwOTIKUnA5MwooZHA5NApWbWV0aG9kCnA5NQpWR0VUCnA5NgpzZzQ5Cmc1MApzZzEzCmcwCihnMTQKZzIKTnRwOTcKUnA5OAooZHA5OQpnMTgKZzE5Cih0UnAxMDAKVnVzZXItYWdlbnQKcDEwMQooVlVzZXItQWdlbnQKcDEwMgpWcHl0aG9uLXJlcXVlc3RzLzIuMzIuMwpwMTAzCnRwMTA0CnNWYWNjZXB0LWVuY29kaW5nCnAxMDUKKFZBY2NlcHQtRW5jb2RpbmcKcDEwNgpWZ3ppcCwgZGVmbGF0ZQpwMTA3CnRwMTA4CnNWYWNjZXB0CnAxMDkKKFZBY2NlcHQKcDExMApWKi8qCnAxMTEKdHAxMTIKc1Zjb25uZWN0aW9uCnAxMTMKKFZDb25uZWN0aW9uCnAxMTQKVmtlZXAtYWxpdmUKcDExNQp0cDExNgpzc2JzZzg0CmcwCihnNTgKZzIKTnRwMTE3ClJwMTE4CihkcDExOQpnNjIKZzAKKGc2MwpnMgpOdHAxMjAKUnAxMjEKKGRwMTIyCmc2NwpJMDEKc2c2OApJMDAKc2c2OQpOc2c3MApJMDAKc2c3MQpJMDAKc2c3MgpJMDEKc2c3MwpJMDAKc2c3NApJMApzZzc1CkkwMApzZzc2CkkwMApzZzc3Cmc4MApzZzgxCih0c2c4MgpOc2c4MwpJMTcyNzA5MTkyMApzYnNnODQKKGRwMTIzCnNnODMKSTE3MjcwOTE5MjAKc2JzVmJvZHkKcDEyNApOc1Zob29rcwpwMTI1CihkcDEyNgpWcmVzcG9uc2UKcDEyNwoobHAxMjgKc3NWX2JvZHlfcG9zaXRpb24KcDEyOQpOc2JzYi4=
```

It's a really really really long string with non-readable content.
![image](https://github.com/user-attachments/assets/015f56fe-3e20-401f-9d90-9c01f209c51d)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-634/display-correct-return-value-in-session-viewer

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
