### PR TITLE
feat(UI-952): create new project - open creation modal like in templates

### DIFF
--- a/e2e/pages/dashboard.ts
+++ b/e2e/pages/dashboard.ts
@@ -12,6 +12,8 @@ export class DashboardPage {
 		await this.page.goto("/");
 		await this.createButton.hover();
 		await this.createButton.click();
+		await this.page.getByPlaceholder("Enter project name").fill(randomatic("Aa", 8));
+		await this.page.getByRole("button", { name: "Create", exact: true }).click();
 		await this.page.getByRole("cell", { name: "program.py" }).isVisible();
 		await this.page.getByRole("tab", { name: "PROGRAM.PY" }).isVisible();
 		await this.page.getByText('print("Hello World!")').isVisible();

--- a/src/components/molecules/menu/menu.tsx
+++ b/src/components/molecules/menu/menu.tsx
@@ -2,28 +2,24 @@ import React, { useEffect, useState } from "react";
 
 import { AnimatePresence, motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
-import { ModalName, SidebarHrefMenu } from "@enums/components";
+import { ModalName } from "@enums/components";
 import { MenuProps, SubmenuInfo } from "@interfaces/components";
-import { defaultProjectFile } from "@src/constants";
 import { Project } from "@type/models";
 import { cn } from "@utilities";
 
-import { useModalStore, useProjectStore, useToastStore } from "@store";
+import { useModalStore, useProjectStore } from "@store";
 
-import { Button, IconSvg, Loader } from "@components/atoms";
+import { Button, IconSvg } from "@components/atoms";
 
 import { NewProject, ProjectsIcon } from "@assets/image";
 
 export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: MenuProps) => {
 	const { t } = useTranslation(["menu", "errors"]);
-	const navigate = useNavigate();
 	const location = useLocation();
-	const { createProject, getProjectsList, projectsList } = useProjectStore();
-	const addToast = useToastStore((state) => state.addToast);
+	const { getProjectsList, projectsList } = useProjectStore();
 	const [sortedProjectsList, setSortedProjectsList] = useState<Project[]>([]);
-	const [isCreatingProject, setIsCreatingProject] = useState(false);
 	const { openModal } = useModalStore();
 
 	useEffect(() => {
@@ -34,27 +30,6 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 	const animateVariant = {
 		hidden: { opacity: 0, width: 0 },
 		visible: { opacity: 1, transition: { duration: 0.35, ease: "easeOut" }, width: "auto" },
-	};
-
-	const handleCreateProject = async () => {
-		setIsCreatingProject(true);
-		const { data, error } = await createProject(true);
-		setIsCreatingProject(false);
-
-		if (error) {
-			addToast({
-				message: (error as Error).message,
-				type: "error",
-			});
-
-			return;
-		}
-
-		const projectId = data!.projectId;
-
-		navigate(`/${SidebarHrefMenu.projects}/${projectId}/code`, {
-			state: { fileToOpen: defaultProjectFile },
-		});
 	};
 
 	useEffect(() => {
@@ -84,8 +59,6 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 			"bg-gray-1100 hover:bg-gray-1100": isButtonActive(href) && !isOpen,
 		});
 
-	const openNewProjectModal = () => openModal(ModalName.newProject);
-
 	return (
 		<nav aria-label="Main navigation" className={cn(className, "flex flex-col gap-4")}>
 			<ul className="ml-0 flex flex-col gap-2">
@@ -93,16 +66,11 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 					<Button
 						ariaLabel={t("newProject")}
 						className="w-full gap-1.5 p-0.5 pl-1 hover:bg-green-200 disabled:opacity-100"
-						disabled={isCreatingProject}
-						onClick={openNewProjectModal}
+						onClick={() => openModal(ModalName.newProject)}
 						title={t("newProject")}
 					>
 						<div className="flex size-9 items-center justify-center">
-							{isCreatingProject ? (
-								<Loader className="ml-1 before:size-3 after:size-3" isCenter />
-							) : (
-								<IconSvg alt={t("newProject")} size="xl" src={NewProject} />
-							)}
+							<IconSvg alt={t("newProject")} size="xl" src={NewProject} />
 						</div>
 
 						<AnimatePresence>

--- a/src/components/molecules/menu/menu.tsx
+++ b/src/components/molecules/menu/menu.tsx
@@ -4,13 +4,13 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
-import { SidebarHrefMenu } from "@enums/components";
+import { ModalName, SidebarHrefMenu } from "@enums/components";
 import { MenuProps, SubmenuInfo } from "@interfaces/components";
 import { defaultProjectFile } from "@src/constants";
 import { Project } from "@type/models";
 import { cn } from "@utilities";
 
-import { useProjectStore, useToastStore } from "@store";
+import { useModalStore, useProjectStore, useToastStore } from "@store";
 
 import { Button, IconSvg, Loader } from "@components/atoms";
 
@@ -24,6 +24,7 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 	const addToast = useToastStore((state) => state.addToast);
 	const [sortedProjectsList, setSortedProjectsList] = useState<Project[]>([]);
 	const [isCreatingProject, setIsCreatingProject] = useState(false);
+	const { openModal } = useModalStore();
 
 	useEffect(() => {
 		const sortedProjects = projectsList.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -83,6 +84,8 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 			"bg-gray-1100 hover:bg-gray-1100": isButtonActive(href) && !isOpen,
 		});
 
+	const openNewProjectModal = () => openModal(ModalName.newProject);
+
 	return (
 		<nav aria-label="Main navigation" className={cn(className, "flex flex-col gap-4")}>
 			<ul className="ml-0 flex flex-col gap-2">
@@ -91,7 +94,7 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 						ariaLabel={t("newProject")}
 						className="w-full gap-1.5 p-0.5 pl-1 hover:bg-green-200 disabled:opacity-100"
 						disabled={isCreatingProject}
-						onClick={handleCreateProject}
+						onClick={openNewProjectModal}
 						title={t("newProject")}
 					>
 						<div className="flex size-9 items-center justify-center">

--- a/src/components/organisms/dashboard/projectsTable.tsx
+++ b/src/components/organisms/dashboard/projectsTable.tsx
@@ -1,15 +1,15 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
-import { SidebarHrefMenu } from "@src/enums/components";
+import { ModalName } from "@src/enums/components";
 import { Project } from "@type/models";
 
 import { useSort } from "@hooks";
-import { useProjectStore, useToastStore } from "@store";
+import { useModalStore, useProjectStore } from "@store";
 
-import { Button, IconSvg, Spinner, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
+import { Button, IconSvg, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import { SortButton } from "@components/molecules";
 
 import { OrStartFromTemplateImage } from "@assets/image";
@@ -17,28 +17,12 @@ import { ArrowStartTemplateIcon, PlusAccordionIcon } from "@assets/image/icons";
 
 export const DashboardProjectsTable = () => {
 	const { t } = useTranslation("dashboard", { keyPrefix: "projects" });
-	const { createProject, projectsList } = useProjectStore();
+	const { projectsList } = useProjectStore();
 	const navigate = useNavigate();
-	const [creatingProject, setCreatingProject] = useState(false);
-	const addToast = useToastStore((state) => state.addToast);
 
 	const { items: sortedProjects, requestSort, sortConfig } = useSort<Project>(projectsList, "name");
 
-	const handleCreateProjectClick = async () => {
-		setCreatingProject(true);
-		const { data, error } = await createProject(true);
-		setCreatingProject(false);
-		if (error) {
-			addToast({
-				message: (error as Error).message,
-				type: "error",
-			});
-
-			return;
-		}
-
-		navigate(`/${SidebarHrefMenu.projects}/${data?.projectId}`);
-	};
+	const { openModal } = useModalStore();
 
 	return (
 		<div className="z-10 h-2/3 select-none pt-10">
@@ -73,11 +57,10 @@ export const DashboardProjectsTable = () => {
 			<div className="mt-10 flex flex-col items-center justify-center">
 				<Button
 					className="gap-2.5 whitespace-nowrap rounded-full border border-gray-750 py-2.5 pl-3 pr-4 font-averta text-base font-semibold"
-					disabled={creatingProject}
-					onClick={handleCreateProjectClick}
+					onClick={() => openModal(ModalName.newProject)}
 					variant="filled"
 				>
-					<IconSvg className="fill-white" size="lg" src={!creatingProject ? PlusAccordionIcon : Spinner} />
+					<IconSvg className="fill-white" size="lg" src={PlusAccordionIcon} />
 
 					{t("buttons.startNewProject")}
 				</Button>

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -4,6 +4,7 @@ export { DeploymentsTable } from "@components/organisms/deployments/table";
 export { EditorTabs } from "@components/organisms/editorTabs";
 export { EventsTable, EventViewer } from "@components/organisms/events";
 export { IntroMainBlock } from "@components/organisms/introMainBlock";
+export { NewProjectModal } from "@components/organisms/newProjectModal";
 export { Sidebar } from "@components/organisms/sidebar/sidebar";
 export { SplitFrame } from "@components/organisms/splitFrame";
 export { SystemLog } from "@components/organisms/systemLog";

--- a/src/components/organisms/newProjectModal.tsx
+++ b/src/components/organisms/newProjectModal.tsx
@@ -20,6 +20,7 @@ export const NewProjectModal = () => {
 	const { createProject } = useProjectStore();
 	const projectNamesSet = useMemo(() => new Set(projectsList.map((project) => project.name)), [projectsList]);
 	const navigate = useNavigate();
+	const [responseError, setResponseError] = useState("");
 
 	const {
 		formState: { errors },
@@ -55,6 +56,8 @@ export const NewProjectModal = () => {
 				type: "error",
 			});
 
+			setResponseError(t("errorCreatingProject"));
+
 			return;
 		}
 		closeModal(ModalName.newProject);
@@ -83,6 +86,7 @@ export const NewProjectModal = () => {
 				{errors.projectName ? (
 					<ErrorMessage className="relative mt-0.5">{errors.projectName.message}</ErrorMessage>
 				) : null}
+				{responseError ? <ErrorMessage className="relative mt-0.5">{responseError}</ErrorMessage> : null}
 
 				<div className="mt-8 flex w-full justify-end gap-2">
 					<Button

--- a/src/components/organisms/newProjectModal.tsx
+++ b/src/components/organisms/newProjectModal.tsx
@@ -15,9 +15,8 @@ export const NewProjectModal = () => {
 	const { t } = useTranslation("modals", { keyPrefix: "newProject" });
 	const [isCreating, setIsCreating] = useState(false);
 	const { closeModal } = useModalStore();
-	const { projectsList } = useProjectStore();
+	const { createProject, projectsList } = useProjectStore();
 	const addToast = useToastStore((state) => state.addToast);
-	const { createProject } = useProjectStore();
 	const projectNamesSet = useMemo(() => new Set(projectsList.map((project) => project.name)), [projectsList]);
 	const navigate = useNavigate();
 	const [responseError, setResponseError] = useState("");
@@ -75,7 +74,7 @@ export const NewProjectModal = () => {
 				</div>
 				<Input
 					label={t("projectName")}
-					placeholder="Enter project name"
+					placeholder={t("inputPlaceholder")}
 					variant="light"
 					{...register("projectName", {
 						required: t("nameRequired"),

--- a/src/components/organisms/newProjectModal.tsx
+++ b/src/components/organisms/newProjectModal.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { ModalName } from "@enums/components";
+import {
+	HiddenIntegrationsForTemplates,
+	IntegrationForTemplates,
+	Integrations,
+	IntegrationsMap,
+} from "@src/enums/components/connection.enum";
+import { useModalStore, useProjectStore } from "@src/store";
+import { fetchFileContent } from "@src/utilities";
+
+import { Button, ErrorMessage, IconSvg, Input, Loader, Status, Typography } from "@components/atoms";
+import { Accordion, Modal } from "@components/molecules";
+
+import { PipeCircleIcon, ReadmeIcon } from "@assets/image/icons";
+import "github-markdown-css/github-markdown-light.css";
+
+export const NewProjectModal = () => {
+	const { t } = useTranslation("modals", { keyPrefix: "newProject" });
+	const [isCreating, setIsCreating] = useState(false);
+	const { closeModal } = useModalStore();
+	const { projectsList } = useProjectStore();
+
+	const projectNamesSet = useMemo(() => new Set(projectsList.map((project) => project.name)), [projectsList]);
+
+	const {
+		formState: { errors },
+		handleSubmit,
+		register,
+	} = useForm<{ projectName: string }>({
+		mode: "onChange",
+		defaultValues: {
+			projectName: "",
+		},
+	});
+
+	const validateProjectName = (value: string) => {
+		if (projectNamesSet.has(value)) {
+			return t("nameTaken");
+		}
+		if (!new RegExp("^[a-zA-Z_][\\w]*$").test(value)) {
+			return t("invalidName");
+		}
+	};
+
+	const onSubmit = async (data: { projectName: string }) => {
+		const { projectName } = data;
+
+		setIsCreating(true);
+		setIsCreating(false);
+		closeModal(ModalName.templateCreateProject);
+	};
+
+	return (
+		<Modal className="w-1/2 min-w-550 p-5" hideCloseButton name={ModalName.newProject}>
+			<form onSubmit={handleSubmit(onSubmit)}>
+				<div className="mb-3 flex items-center justify-end gap-5">
+					<h3 className="mb-5 mr-auto text-xl font-bold">{t("title")}</h3>
+				</div>
+				<Input
+					label={t("projectName")}
+					placeholder="Enter project name"
+					variant="light"
+					{...register("projectName", {
+						required: t("nameRequired"),
+						validate: validateProjectName,
+					})}
+					isError={!!errors.projectName}
+				/>
+				{errors.projectName ? (
+					<ErrorMessage className="relative mt-0.5">{errors.projectName.message}</ErrorMessage>
+				) : null}
+
+				<div className="mt-8 flex w-full justify-end gap-2">
+					<Button
+						ariaLabel={t("cancelButton")}
+						className="px-4 py-3 font-semibold hover:bg-gray-1100 hover:text-white"
+						onClick={() => closeModal(ModalName.templateCreateProject)}
+						variant="outline"
+					>
+						{t("cancelButton")}
+					</Button>
+					<Button
+						ariaLabel={t("createButton")}
+						className="bg-gray-1100 px-4 py-3 font-semibold"
+						disabled={isCreating || !!errors.projectName}
+						type="submit"
+						variant="filled"
+					>
+						{isCreating ? <Loader className="mr-2" size="sm" /> : null}
+						{t("createButton")}
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+};

--- a/src/components/organisms/newProjectModal.tsx
+++ b/src/components/organisms/newProjectModal.tsx
@@ -92,7 +92,7 @@ export const NewProjectModal = () => {
 					<Button
 						ariaLabel={t("cancelButton")}
 						className="px-4 py-3 font-semibold hover:bg-gray-1100 hover:text-white"
-						onClick={() => closeModal(ModalName.templateCreateProject)}
+						onClick={() => closeModal(ModalName.newProject)}
 						variant="outline"
 					>
 						{t("cancelButton")}

--- a/src/components/organisms/sidebar/sidebar.tsx
+++ b/src/components/organisms/sidebar/sidebar.tsx
@@ -8,7 +8,7 @@ import { NewProjectModal } from "../newProjectModal";
 import { isAuthEnabled } from "@constants";
 import { SubmenuInfo } from "@interfaces/components";
 
-import { useLoggerStore, useModalStore, useUserStore } from "@store";
+import { useLoggerStore, useUserStore } from "@store";
 
 import { Badge, Button, IconSvg, Loader } from "@components/atoms";
 import { MenuToggle } from "@components/atoms/menuToggle";

--- a/src/components/organisms/sidebar/sidebar.tsx
+++ b/src/components/organisms/sidebar/sidebar.tsx
@@ -4,10 +4,11 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
 
+import { NewProjectModal } from "../newProjectModal";
 import { isAuthEnabled } from "@constants";
 import { SubmenuInfo } from "@interfaces/components";
 
-import { useLoggerStore, useUserStore } from "@store";
+import { useLoggerStore, useModalStore, useUserStore } from "@store";
 
 import { Badge, Button, IconSvg, Loader } from "@components/atoms";
 import { MenuToggle } from "@components/atoms/menuToggle";
@@ -225,6 +226,7 @@ export const Sidebar = () => {
 					) : null}
 				</AnimatePresence>
 			</div>
+			<NewProjectModal />
 		</Suspense>
 	);
 };

--- a/src/components/organisms/topbar/dashboard.tsx
+++ b/src/components/organisms/topbar/dashboard.tsx
@@ -1,43 +1,18 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
 
-import { SidebarHrefMenu } from "@enums/components";
-import { defaultProjectFile } from "@src/constants";
+import { ModalName } from "@src/enums/components";
 
-import { useProjectStore, useToastStore } from "@store";
+import { useModalStore } from "@store";
 
-import { Button, IconSvg, Spinner, Typography } from "@components/atoms";
+import { Button, IconSvg, Typography } from "@components/atoms";
 
 import { PlusAccordionIcon } from "@assets/image/icons";
 
 export const DashboardTopbar = () => {
 	const { t } = useTranslation("dashboard", { keyPrefix: "topbar" });
-	const { createProject } = useProjectStore();
-	const [loadingNewProject, setLoadingNewProject] = useState(false);
-	const navigate = useNavigate();
-	const addToast = useToastStore((state) => state.addToast);
-
-	const handleCreateProject = async () => {
-		setLoadingNewProject(true);
-		const { data, error } = await createProject(true);
-		setLoadingNewProject(false);
-		if (error) {
-			addToast({
-				message: (error as Error).message,
-				type: "error",
-			});
-
-			return;
-		}
-
-		const projectId = data?.projectId;
-
-		navigate(`/${SidebarHrefMenu.projects}/${projectId}`, {
-			state: { fileToOpen: defaultProjectFile },
-		});
-	};
+	const { openModal } = useModalStore();
 
 	return (
 		<div className="z-10 flex flex-wrap">
@@ -48,11 +23,10 @@ export const DashboardTopbar = () => {
 
 				<Button
 					className="gap-2.5 whitespace-nowrap rounded-full border border-gray-750 py-2.5 pl-3 pr-4 font-averta text-base font-semibold"
-					disabled={loadingNewProject}
-					onClick={handleCreateProject}
+					onClick={() => openModal(ModalName.newProject)}
 					variant="filled"
 				>
-					<IconSvg className="fill-white" size="lg" src={!loadingNewProject ? PlusAccordionIcon : Spinner} />
+					<IconSvg className="fill-white" size="lg" src={PlusAccordionIcon} />
 
 					{t("buttons.newProject")}
 				</Button>

--- a/src/enums/components/modal.enum.ts
+++ b/src/enums/components/modal.enum.ts
@@ -11,5 +11,6 @@ export enum ModalName {
 	deleteProject = "deleteProject",
 	welcomePage = "welcomePage",
 	templateCreateProject = "templateCreateProject",
+	newProject = "newProject",
 	warningDeploymentActive = "warningDeploymentActive",
 }

--- a/src/interfaces/store/projectStore.interface.ts
+++ b/src/interfaces/store/projectStore.interface.ts
@@ -2,7 +2,7 @@ import { Project } from "@type/models";
 import { ServiceResponse } from "@type/services.types";
 
 export interface ProjectStore {
-	createProject: (isDefault?: boolean) => ServiceResponse<{ name: string; projectId: string }>;
+	createProject: (name: string, isDefault?: boolean) => ServiceResponse<{ name: string; projectId: string }>;
 	deleteProject: (projectId: string) => ServiceResponse<undefined>;
 	getProject: (projectId: string) => ServiceResponse<Project>;
 	getProjectsList: () => ServiceResponse<Project[]>;

--- a/src/locales/en/modals/translation.json
+++ b/src/locales/en/modals/translation.json
@@ -86,6 +86,7 @@
 		"cancelButton": "Cancel",
 		"createButton": "Create",
 		"projectName": "Project Name",
+		"inputPlaceholder": "Enter project name",
 		"description": "Description: {{description}}",
 		"moreInformaton": "About This Template",
 		"readme": "README",

--- a/src/locales/en/modals/translation.json
+++ b/src/locales/en/modals/translation.json
@@ -82,7 +82,7 @@
 		"agreeButton": "Ok"
 	},
 	"newProject": {
-		"title": "Create new projecct",
+		"title": "Create new project",
 		"cancelButton": "Cancel",
 		"createButton": "Create",
 		"projectName": "Project Name",

--- a/src/locales/en/modals/translation.json
+++ b/src/locales/en/modals/translation.json
@@ -79,5 +79,17 @@
 		"content": "Changes might affect the currently running deployments",
 		"cancelButton": "Cancel",
 		"agreeButton": "Ok"
+	},
+	"newProject": {
+		"title": "Create new projecct",
+		"cancelButton": "Cancel",
+		"createButton": "Create",
+		"projectName": "Project Name",
+		"description": "Description: {{description}}",
+		"moreInformaton": "About This Template",
+		"readme": "README",
+		"nameRequired": "Name is required",
+		"nameTaken": "Name is already taken",
+		"invalidName": "Project name can only use letters, numbers, and underscores, and must start with a letter or underscore"
 	}
 }

--- a/src/locales/en/modals/translation.json
+++ b/src/locales/en/modals/translation.json
@@ -70,6 +70,7 @@
 		"description": "Description: {{description}}",
 		"moreInformaton": "About This Template",
 		"readme": "README",
+		"errorCreatingProject": "Failed to create project",
 		"nameRequired": "Name is required",
 		"nameTaken": "Name is already taken",
 		"invalidName": "Project name can only use letters, numbers, and underscores, and must start with a letter or underscore"
@@ -90,6 +91,7 @@
 		"readme": "README",
 		"nameRequired": "Name is required",
 		"nameTaken": "Name is already taken",
+		"errorCreatingProject": "Failed to create project",
 		"invalidName": "Project name can only use letters, numbers, and underscores, and must start with a letter or underscore"
 	}
 }

--- a/src/services/projects.service.ts
+++ b/src/services/projects.service.ts
@@ -36,9 +36,9 @@ export class ProjectsService {
 		}
 	}
 
-	static async create(): Promise<ServiceResponse<string>> {
+	static async create(name?: string): Promise<ServiceResponse<string>> {
 		try {
-			const { projectId } = await projectsClient.create({ project: {} });
+			const { projectId } = await projectsClient.create({ project: { name } });
 			if (!projectId) {
 				LoggerService.error(namespaces.projectService, i18n.t("projectNotCreated", { ns: "services" }));
 

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -37,8 +37,8 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 		});
 	},
 
-	createProject: async (isDefault?: boolean) => {
-		const { data: projectId, error } = await ProjectsService.create();
+	createProject: async (name: string, isDefault?: boolean) => {
+		const { data: projectId, error } = await ProjectsService.create(name);
 
 		if (error) {
 			return { data: undefined, error };


### PR DESCRIPTION
## Description
When we click on Plus (new project), instead of creating a project with a random name - display a modal like we have with the templates - to get the new project name.

If a project with that name exist - display an error.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-949/create-new-project-open-creation-modal-like-in-templates

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
