### PR TITLE
feat(UI-960): extra hard code to copy to clipboard

### DIFF
--- a/src/utilities/copyToClipboard.utils.ts
+++ b/src/utilities/copyToClipboard.utils.ts
@@ -4,6 +4,14 @@ export const copyToClipboard = async (text: string): Promise<{ isError: boolean;
 	try {
 		await navigator.clipboard.writeText(text);
 
+		const tempInput = document.createElement("input");
+		tempInput.style.cssText = "position: absolute; left: -1000px; top: -1000px";
+		tempInput.value = text;
+		document.body.appendChild(tempInput);
+		tempInput.select();
+		document.execCommand("copy");
+		document.body.removeChild(tempInput);
+
 		return { isError: false, message: i18n.t("copySuccess", { ns: "global" }) };
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	} catch (error) {


### PR DESCRIPTION
## Description
The bug is when we click on the copy button, it doesn't do anything to the clipboard, and we can paste the value we copied.
This script should give an extra backup for this functionality.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-960/the-copy-url-in-webhook-open-source-does-not-work

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
