### PR TITLE
fix(UI-975): bring back missing icon of a connection in the trigger popover

### DIFF
--- a/src/components/organisms/triggers/table/popoverContent.tsx
+++ b/src/components/organisms/triggers/table/popoverContent.tsx
@@ -69,7 +69,7 @@ export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => 
 		<div className="text-white">
 			<div className="mb-2 flex w-full">
 				<div className="flex w-64 font-semibold">
-					<IconSvg className="mr-2" src={icon} />
+					<IconSvg className="mr-2 fill-white" src={icon} />
 					{t("info")}
 				</div>
 				<div className="w-full" />
@@ -91,7 +91,7 @@ export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => 
 	const webhookContent = trigger.sourceType === TriggerTypes.webhook && (
 		<div className="text-white">
 			<div className="mb-2 flex w-64 font-semibold">
-				<IconSvg className="mr-2" src={WebhookIcon} />
+				<IconSvg className="mr-2 fill-white" src={WebhookIcon} />
 				{t("info")}
 			</div>
 			<div className="flex items-center gap-x-1">

--- a/src/components/organisms/triggers/table/popoverContent.tsx
+++ b/src/components/organisms/triggers/table/popoverContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { ComponentType, useEffect, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 
@@ -61,7 +61,34 @@ export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [trigger]);
 
-	return trigger.sourceType === TriggerTypes.webhook ? (
+	const renderTriggerContent = (
+		icon: ComponentType<React.SVGProps<SVGSVGElement>>,
+		details: TriggerPopoverInformation[],
+		showIcon = false
+	) => (
+		<div className="text-white">
+			<div className="mb-2 flex w-full">
+				<div className="flex w-64 font-semibold">
+					<IconSvg className="mr-2" src={icon} />
+					{t("info")}
+				</div>
+				<div className="w-full" />
+			</div>
+			{details.map(({ icon: Icon, label, value }) =>
+				value ? (
+					<div className="flex items-center gap-x-1" key={label}>
+						<div className="font-semibold">{label}:</div>
+						{showIcon && Icon ? (
+							<Icon className="mx-1 size-4 shrink-0 rounded-full bg-white p-0.5" />
+						) : null}
+						{value}
+					</div>
+				) : null
+			)}
+		</div>
+	);
+
+	const webhookContent = trigger.sourceType === TriggerTypes.webhook && (
 		<div className="text-white">
 			<div className="mb-2 flex w-64 font-semibold">
 				<IconSvg className="mr-2" src={WebhookIcon} />
@@ -78,48 +105,18 @@ export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => 
 				value ? (
 					<div className="flex items-center gap-x-1" key={label}>
 						<div className="font-semibold">{label}:</div>
-						<div>{value}</div>
-					</div>
-				) : null
-			)}
-		</div>
-	) : trigger.sourceType === TriggerTypes.schedule ? (
-		<div className="text-white">
-			<div className="mb-2 flex w-full">
-				<div className="flex w-64 font-semibold">
-					<IconSvg className="mr-2" src={ClockIcon} />
-					{t("info")}
-				</div>
-				<div className="w-full" />
-			</div>
-
-			{scheduleDetails.map(({ label, value }) =>
-				value ? (
-					<div className="flex items-center gap-x-1" key={label}>
-						<div className="font-semibold">{label}:</div>
-						<div>{value}</div>
-					</div>
-				) : null
-			)}
-		</div>
-	) : trigger.sourceType === TriggerTypes.connection ? (
-		<div className="text-white">
-			<div className="mb-2 flex w-full">
-				<div className="flex w-64 font-semibold">
-					<IconSvg className="mr-2 fill-white" src={LinkIcon} />
-					{t("info")}
-				</div>
-				<div className="w-full" />
-			</div>
-			{connectionDetails?.map(({ icon: Icon, label, value }) =>
-				value ? (
-					<div className="flex items-center gap-x-1" key={label}>
-						<div className="font-semibold">{label}:</div>
-						{Icon ? <Icon className="mx-1 size-4 shrink-0 rounded-full bg-white p-0.5" /> : null}
 						{value}
 					</div>
 				) : null
 			)}
 		</div>
-	) : null;
+	);
+
+	return trigger.sourceType === TriggerTypes.webhook
+		? webhookContent
+		: trigger.sourceType === TriggerTypes.schedule
+			? renderTriggerContent(ClockIcon, scheduleDetails)
+			: trigger.sourceType === TriggerTypes.connection
+				? renderTriggerContent(LinkIcon, connectionDetails || [], true)
+				: null;
 };

--- a/src/components/organisms/triggers/table/popoverContent.tsx
+++ b/src/components/organisms/triggers/table/popoverContent.tsx
@@ -6,6 +6,7 @@ import { IntegrationsService } from "@services/integrations.service";
 import { TriggerTypes } from "@src/enums";
 import { IntegrationsMap } from "@src/enums/components/connection.enum";
 import { useCacheStore } from "@src/store";
+import { TriggerPopoverInformation } from "@src/types/components/tables";
 import { Trigger } from "@src/types/models";
 import { getApiBaseUrl } from "@src/utilities";
 
@@ -14,19 +15,13 @@ import { CopyButton } from "@components/molecules";
 
 import { ClockIcon, LinkIcon, WebhookIcon } from "@assets/image/icons";
 
-type TriggerInformation = {
-	icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-	label: string;
-	value?: string;
-};
-
 export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => {
 	const apiBaseUrl = getApiBaseUrl();
 	const webhookUrl = trigger?.webhookSlug ? `${apiBaseUrl}/webhooks/${trigger.webhookSlug}` : "";
 	const { t } = useTranslation("tabs", { keyPrefix: "triggers.infoPopover" });
 	const { connections } = useCacheStore();
-	const [connectionDetails, setConnectionDetails] = useState<TriggerInformation[]>();
-	const [scheduleDetails, setScheduleDetails] = useState<TriggerInformation[]>([]);
+	const [connectionDetails, setConnectionDetails] = useState<TriggerPopoverInformation[]>();
+	const [scheduleDetails, setScheduleDetails] = useState<TriggerPopoverInformation[]>([]);
 
 	const baseDetails = [
 		{ label: t("file"), value: trigger.path },

--- a/src/components/organisms/triggers/table/popoverContent.tsx
+++ b/src/components/organisms/triggers/table/popoverContent.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 
+import { IntegrationsService } from "@services/integrations.service";
 import { TriggerTypes } from "@src/enums";
 import { IntegrationsMap } from "@src/enums/components/connection.enum";
 import { useCacheStore } from "@src/store";
@@ -13,109 +14,117 @@ import { CopyButton } from "@components/molecules";
 
 import { ClockIcon, LinkIcon, WebhookIcon } from "@assets/image/icons";
 
+type TriggerInformation = {
+	icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+	label: string;
+	value?: string;
+};
+
 export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => {
 	const apiBaseUrl = getApiBaseUrl();
 	const webhookUrl = trigger?.webhookSlug ? `${apiBaseUrl}/webhooks/${trigger.webhookSlug}` : "";
 	const { t } = useTranslation("tabs", { keyPrefix: "triggers.infoPopover" });
 	const { connections } = useCacheStore();
-	const triggerConnection = connections?.find((connection) => connection.connectionId === trigger.connectionId);
-	const TriggerConnectionIntegrationKey = Object.keys(IntegrationsMap).find(
-		(integration) => integration === (triggerConnection?.integrationName?.toLowerCase() || "")
-	);
-
-	const TriggerConnectionItegrationIcon =
-		IntegrationsMap[(TriggerConnectionIntegrationKey || "") as keyof typeof IntegrationsMap]?.icon;
+	const [connectionDetails, setConnectionDetails] = useState<TriggerInformation[]>();
+	const [scheduleDetails, setScheduleDetails] = useState<TriggerInformation[]>([]);
 
 	const baseDetails = [
 		{ label: t("file"), value: trigger.path },
 		{ label: t("entrypoint"), value: trigger.entryFunction },
 	];
 
-	const connectionDetails = [
-		{
-			label: t("connection"),
-			value: triggerConnection?.name,
-			icon: TriggerConnectionItegrationIcon,
-		},
-		{
-			label: t("connectionId"),
-			value: triggerConnection?.connectionId,
-		},
-		...baseDetails,
-		{ label: t("eventType"), value: trigger.eventType },
-		{ label: t("filter"), value: trigger.filter },
-	];
+	const configureTriggerDisplay = async (trigger: Trigger) => {
+		const triggerConnection = connections?.find((connection) => connection.connectionId === trigger.connectionId);
+		const { data: integrations } = await IntegrationsService.list();
+		const TriggerConnectionIntegrationKey = integrations?.find(
+			(integration) => integration.integrationId === triggerConnection?.integrationId
+		)?.uniqueName;
 
-	const scheduleDetails = [{ label: t("cron"), value: trigger.schedule }, ...baseDetails];
+		const TriggerConnectionItegrationIcon =
+			IntegrationsMap[(TriggerConnectionIntegrationKey || "") as keyof typeof IntegrationsMap]?.icon;
 
-	switch (trigger.sourceType) {
-		case TriggerTypes.webhook:
-			return (
-				<div className="text-white">
-					<div className="mb-2 flex w-64 font-semibold">
-						<IconSvg className="mr-2" src={WebhookIcon} />
-						{t("info")}
-					</div>
-					<div className="flex items-center gap-x-1">
-						<div className="font-semibold">{t("webhookUrl")}:</div>
-						{webhookUrl}
-						<div className="w-8">
-							<CopyButton size="sm" text={webhookUrl} />
-						</div>
-					</div>
-					{baseDetails.map(({ label, value }) =>
-						value ? (
-							<div className="flex items-center gap-x-1" key={label}>
-								<div className="font-semibold">{label}:</div>
-								<div>{value}</div>
-							</div>
-						) : null
-					)}
-				</div>
-			);
-		case TriggerTypes.schedule:
-			return (
-				<div className="text-white">
-					<div className="mb-2 flex w-full">
-						<div className="flex w-64 font-semibold">
-							<IconSvg className="mr-2" src={ClockIcon} />
-							{t("info")}
-						</div>
-						<div className="w-full" />
-					</div>
+		setConnectionDetails([
+			{
+				label: t("connection"),
+				value: triggerConnection?.name,
+				icon: TriggerConnectionItegrationIcon,
+			},
+			{
+				label: t("connectionId"),
+				value: triggerConnection?.connectionId,
+			},
+			...baseDetails,
+			{ label: t("eventType"), value: trigger.eventType },
+			{ label: t("filter"), value: trigger.filter },
+		]);
 
-					{scheduleDetails.map(({ label, value }) =>
-						value ? (
-							<div className="flex items-center gap-x-1" key={label}>
-								<div className="font-semibold">{label}:</div>
-								<div>{value}</div>
-							</div>
-						) : null
-					)}
+		setScheduleDetails([{ label: t("cron"), value: trigger.schedule }, ...baseDetails]);
+	};
+
+	useEffect(() => {
+		configureTriggerDisplay(trigger);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [trigger]);
+
+	return trigger.sourceType === TriggerTypes.webhook ? (
+		<div className="text-white">
+			<div className="mb-2 flex w-64 font-semibold">
+				<IconSvg className="mr-2" src={WebhookIcon} />
+				{t("info")}
+			</div>
+			<div className="flex items-center gap-x-1">
+				<div className="font-semibold">{t("webhookUrl")}:</div>
+				{webhookUrl}
+				<div className="w-8">
+					<CopyButton size="sm" text={webhookUrl} />
 				</div>
-			);
-		case TriggerTypes.connection:
-			return (
-				<div className="text-white">
-					<div className="mb-2 flex w-full">
-						<div className="flex w-64 font-semibold">
-							<IconSvg className="mr-2 fill-white" src={LinkIcon} />
-							{t("info")}
-						</div>
-						<div className="w-full" />
+			</div>
+			{baseDetails.map(({ label, value }) =>
+				value ? (
+					<div className="flex items-center gap-x-1" key={label}>
+						<div className="font-semibold">{label}:</div>
+						<div>{value}</div>
 					</div>
-					{connectionDetails.map(({ icon: Icon, label, value }) =>
-						value ? (
-							<div className="flex items-center gap-x-1" key={label}>
-								<div className="font-semibold">{label}:</div>
-								{Icon ? <Icon className="size-4" /> : null}
-								{value}
-							</div>
-						) : null
-					)}
+				) : null
+			)}
+		</div>
+	) : trigger.sourceType === TriggerTypes.schedule ? (
+		<div className="text-white">
+			<div className="mb-2 flex w-full">
+				<div className="flex w-64 font-semibold">
+					<IconSvg className="mr-2" src={ClockIcon} />
+					{t("info")}
 				</div>
-			);
-		default:
-			return null;
-	}
+				<div className="w-full" />
+			</div>
+
+			{scheduleDetails.map(({ label, value }) =>
+				value ? (
+					<div className="flex items-center gap-x-1" key={label}>
+						<div className="font-semibold">{label}:</div>
+						<div>{value}</div>
+					</div>
+				) : null
+			)}
+		</div>
+	) : trigger.sourceType === TriggerTypes.connection ? (
+		<div className="text-white">
+			<div className="mb-2 flex w-full">
+				<div className="flex w-64 font-semibold">
+					<IconSvg className="mr-2 fill-white" src={LinkIcon} />
+					{t("info")}
+				</div>
+				<div className="w-full" />
+			</div>
+			{connectionDetails?.map(({ icon: Icon, label, value }) =>
+				value ? (
+					<div className="flex items-center gap-x-1" key={label}>
+						<div className="font-semibold">{label}:</div>
+						{Icon ? <Icon className="mx-1 size-4 shrink-0 rounded-full bg-white p-0.5" /> : null}
+						{value}
+					</div>
+				) : null
+			)}
+		</div>
+	) : null;
 };

--- a/src/interfaces/store/cacheStore.interface.ts
+++ b/src/interfaces/store/cacheStore.interface.ts
@@ -1,4 +1,4 @@
-import { BaseEvent, Connection, Deployment, Trigger, Variable } from "@src/types/models";
+import { BaseEvent, Connection, Deployment, Integration, Trigger, Variable } from "@src/types/models";
 
 export type ProjectValidationLevel = "error" | "warning";
 
@@ -16,6 +16,7 @@ export interface CacheStore {
 	hasActiveDeployments?: boolean;
 	triggers: Trigger[];
 	events?: BaseEvent[];
+	integrations?: Integration[];
 	variables: Variable[];
 	connections?: Connection[];
 	resourses?: Record<string, Uint8Array>;

--- a/src/services/integrations.service.ts
+++ b/src/services/integrations.service.ts
@@ -7,11 +7,17 @@ import { convertIntegrationProtoToModel } from "@src/models";
 import { Integration } from "@src/types/models";
 import { ServiceResponse } from "@type";
 
+import { useCacheStore } from "@store";
+
 export class IntegrationsService {
 	static async list(): Promise<ServiceResponse<Integration[]>> {
 		try {
-			const { integrations } = await integrationsClient.list({});
+			const cachedIntegrations = useCacheStore.getState().integrations;
+			if (cachedIntegrations) {
+				return { data: cachedIntegrations, error: undefined };
+			}
 
+			const { integrations } = await integrationsClient.list({});
 			const integrationsConverted = integrations.map(convertIntegrationProtoToModel);
 
 			return { data: integrationsConverted, error: undefined };

--- a/src/store/cache/useCacheStore.ts
+++ b/src/store/cache/useCacheStore.ts
@@ -6,6 +6,7 @@ import {
 	DeploymentsService,
 	EventsService,
 	IndexedDBService,
+	IntegrationsService,
 	LoggerService,
 	ProjectsService,
 	TriggersService,
@@ -59,6 +60,7 @@ const initialState: Omit<
 	hasActiveDeployments: false,
 	variables: [],
 	triggers: [],
+	integrations: undefined,
 	connections: undefined,
 	resourses: undefined,
 	events: undefined,
@@ -77,6 +79,41 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 			get().fetchVariables(projectId, force),
 			get().fetchConnections(projectId, force),
 		]);
+	},
+
+	fetchIntegrations: async (force?: boolean) => {
+		const { integrations } = get();
+		if (integrations && !force) {
+			return integrations;
+		}
+
+		try {
+			const { data, error } = await IntegrationsService.list();
+
+			if (error) {
+				useToastStore.getState().addToast({
+					message: i18n.t("errorFetchingIntegrations", { ns: "errors" }),
+					type: "error",
+				});
+
+				return;
+			}
+
+			set((state) => ({
+				...state,
+				integrations: data,
+			}));
+
+			return data;
+		} catch (error) {
+			LoggerService.error(
+				namespaces.stores.cache,
+				i18n.t("errorFetchingIntegrationsExtended", {
+					ns: "errors",
+					error: (error as Error).message,
+				})
+			);
+		}
 	},
 
 	fetchResources: async (projectId, force) => {

--- a/src/types/components/tables/index.ts
+++ b/src/types/components/tables/index.ts
@@ -1,1 +1,1 @@
-export type { SortableColumns } from "@type/components/tables/triggersTable.type";
+export type { SortableColumns, TriggerPopoverInformation } from "@type/components/tables/triggersTable.type";

--- a/src/types/components/tables/triggersTable.type.ts
+++ b/src/types/components/tables/triggersTable.type.ts
@@ -1,3 +1,9 @@
 import { Trigger } from "@src/types/models";
 
 export type SortableColumns = keyof Pick<Trigger, "name" | "sourceType" | "entrypoint">;
+
+export type TriggerPopoverInformation = {
+	icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+	label: string;
+	value?: string;
+};


### PR DESCRIPTION
## Description
In some of the connections we are missing an icon here:

![image](https://github.com/user-attachments/assets/310b3b5b-0472-479e-90ab-52b010bf5106)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-975/fix-missing-connection-icon-in-trigger-popover

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
