### PR TITLE
fix(UI-1001): fix convert runtimes to files and function when the object is invalid

### DIFF
--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -57,8 +57,6 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 		const buildInfo = JSON.parse(buildDescription!);
 		const files = convertBuildRuntimesToViewTriggers(buildInfo.runtimes);
 
-		if (!Object.keys(files).length) return;
-
 		get().updateManualRunConfiguration(projectId!, { files, lastDeployment, isManualRunEnabled: true });
 	},
 

--- a/src/utilities/convertBuildRuntimesToViewTriggers.utils.ts
+++ b/src/utilities/convertBuildRuntimesToViewTriggers.utils.ts
@@ -12,7 +12,7 @@ const processRuntime = (runtime: BuildInfoRuntimes): Record<string, string[]> =>
 		if (fileName.startsWith("_") || fileName === "code.tar") {
 			return;
 		}
-		const entrypointsForFile = runtime.artifact.exports
+		const entrypointsForFile = (runtime?.artifact?.exports || [])
 			.filter(({ location: { path } }) => path === fileName)
 			.map(({ symbol: name }) => name);
 


### PR DESCRIPTION
## Description
When we try to run `convertBuildRuntimesToViewTriggers` function and the deployed version has broken files, we shouldn't write to system log, and need simply to display an empty list of functions.

https://github.com/user-attachments/assets/6092b4bb-f641-4fb1-96f2-7fa90df344e0


## Linear Ticket

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
