### PR TITLE
fix(1008): improve error handling in connection editing and remove redundant toast notification

### DIFF
--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -145,7 +145,6 @@ export const EditTrigger = () => {
 				filter,
 				triggerId: triggerId!,
 			});
-
 			if (error) {
 				addToast({
 					message: tErrors("triggerNotEdited"),

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -210,6 +210,11 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 			);
 			navigate(`/projects/${projectId}/connections`);
 		} catch (error) {
+			addToast({
+				message: tErrors("errorEditingConnection"),
+				type: "error",
+			});
+
 			if (axios.isAxiosError(error)) {
 				LoggerService.error(
 					namespaces.hooks.connectionForm,
@@ -219,10 +224,6 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 
 				return;
 			}
-			addToast({
-				message: tErrors("errorEditingConnection"),
-				type: "error",
-			});
 			LoggerService.error(namespaces.hooks.connectionForm, tErrors("errorEditingConnectionExtended", { error }));
 		} finally {
 			setIsLoading(false);


### PR DESCRIPTION
## Description
When there is an issue saving connection - we should display a toast with an error:


https://github.com/user-attachments/assets/81c2f4c4-2a80-4209-b680-a686e6dc1e58


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1008/when-there-is-an-error-in-save-connection-no-toast-displayed
## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
