### PR TITLE
fix(UI-1015): display error when projects cant load in menu

### DIFF
--- a/src/components/molecules/menu/menu.tsx
+++ b/src/components/molecules/menu/menu.tsx
@@ -6,10 +6,12 @@ import { useLocation } from "react-router-dom";
 
 import { ModalName } from "@enums/components";
 import { MenuProps, SubmenuInfo } from "@interfaces/components";
+import { LoggerService } from "@services/logger.service";
+import { namespaces } from "@src/constants";
 import { Project } from "@type/models";
 import { cn } from "@utilities";
 
-import { useModalStore, useProjectStore } from "@store";
+import { useModalStore, useProjectStore, useToastStore } from "@store";
 
 import { Button, IconSvg } from "@components/atoms";
 
@@ -21,6 +23,7 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 	const { getProjectsList, projectsList } = useProjectStore();
 	const [sortedProjectsList, setSortedProjectsList] = useState<Project[]>([]);
 	const { openModal } = useModalStore();
+	const addToast = useToastStore((state) => state.addToast);
 
 	useEffect(() => {
 		const sortedProjects = projectsList.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -32,8 +35,25 @@ export const Menu = ({ className, isOpen = false, onMouseLeave, onSubmenu }: Men
 		visible: { opacity: 1, transition: { duration: 0.35, ease: "easeOut" }, width: "auto" },
 	};
 
+	const fetchProjects = async () => {
+		const { error } = await getProjectsList();
+		if (error) {
+			addToast({
+				message: t("projectsListFetchFailed"),
+				type: "error",
+			});
+
+			LoggerService.error(
+				namespaces.ui.menu,
+				t("projectsListFetchFailedExtended", {
+					error,
+				})
+			);
+		}
+	};
+
 	useEffect(() => {
-		getProjectsList();
+		fetchProjects();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/src/components/pages/dashboard.tsx
+++ b/src/components/pages/dashboard.tsx
@@ -14,7 +14,7 @@ export const Dashboard = () => {
 	const { isLoadingProjectsList, projectsList } = useProjectStore();
 	const [leftSideWidth] = useResize({ direction: "horizontal", initial: 70, max: 78, min: 30, id: resizeId });
 
-	const hasProjects = !!projectsList.length;
+	const hasProjects = projectsList.length;
 
 	const dashboardContent = useMemo(() => {
 		if (isLoadingProjectsList) {

--- a/src/constants/namespaces.logger.constants.ts
+++ b/src/constants/namespaces.logger.constants.ts
@@ -33,6 +33,7 @@ export const namespaces = {
 		variables: "Variables UI",
 		sessions: "Sessions UI",
 		manualRun: "Manual Run UI",
+		menu: "Menu UI",
 	},
 	hooks: {
 		connectionForm: "Connection Form",

--- a/src/locales/en/menu/translation.json
+++ b/src/locales/en/menu/translation.json
@@ -4,5 +4,7 @@
     "myProjects": "My Projects",
     "newProject": "New Project",
     "settings": "Settings",
-    "stats": "Stats"
+    "stats": "Stats",
+    "projectsListFetchFailed": "Couldn't fetch projects list",
+    "projectsListFetchFailedExtended": "Couldn't fetch projects list, error: {{error}}"
 }

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -153,7 +153,7 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 		const { data: projects, error } = await ProjectsService.list();
 
 		if (error) {
-			set((state) => ({ ...state, isLoadingProjectsList: false }));
+			set((state) => ({ ...state, isLoadingProjectsList: false, projectsList: [] }));
 
 			return { data: undefined, error };
 		}


### PR DESCRIPTION
## Description
Avoid situation where everything looks okay, but actually we can't fetch projects from the backend.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1015/display-an-error-in-case-the-app-cant-fetch-projects

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
