### PR TITLE
fix(UI-1000): fix nested json converter when string

### DIFF
--- a/src/utilities/convertWrappedJson.utils.ts
+++ b/src/utilities/convertWrappedJson.utils.ts
@@ -19,11 +19,11 @@ export const parseNestedJson = (object: Value): Record<string, any> => {
 
 		if (isWrappedJsonValueWithString(value)) {
 			try {
-				result[key] = JSON.parse(value.string);
+				result[key] = typeof value.string === "string" ? value.string : JSON.parse(value.string);
 			} catch (error) {
 				const errorMessage = i18n.t("convertWrappedJsonError", {
 					error: (error as Error).message,
-					ns: "errors",
+					ns: "services",
 					key,
 				});
 				LoggerService.error(namespaces.sessionsService, errorMessage, true);

--- a/src/utilities/convertWrappedJson.utils.ts
+++ b/src/utilities/convertWrappedJson.utils.ts
@@ -19,15 +19,19 @@ export const parseNestedJson = (object: Value): Record<string, any> => {
 
 		if (isWrappedJsonValueWithString(value)) {
 			try {
-				result[key] = typeof value.string === "string" ? value.string : JSON.parse(value.string);
+				result[key] = JSON.parse(value.string);
 			} catch (error) {
-				const errorMessage = i18n.t("convertWrappedJsonError", {
-					error: (error as Error).message,
-					ns: "services",
-					key,
-				});
-				LoggerService.error(namespaces.sessionsService, errorMessage, true);
-				result[key] = errorMessage;
+				if (typeof value.string === "string") {
+					result[key] = value.string;
+				} else {
+					const errorMessage = i18n.t("convertWrappedJsonError", {
+						error: (error as Error).message,
+						ns: "services",
+						key,
+					});
+					LoggerService.error(namespaces.sessionsService, errorMessage, true);
+					result[key] = errorMessage;
+				}
 			}
 		} else {
 			result[key] = value;

--- a/src/utilities/convertWrappedJson.utils.ts
+++ b/src/utilities/convertWrappedJson.utils.ts
@@ -23,15 +23,16 @@ export const parseNestedJson = (object: Value): Record<string, any> => {
 			} catch (error) {
 				if (typeof value.string === "string") {
 					result[key] = value.string;
-				} else {
-					const errorMessage = i18n.t("convertWrappedJsonError", {
-						error: (error as Error).message,
-						ns: "services",
-						key,
-					});
-					LoggerService.error(namespaces.sessionsService, errorMessage, true);
-					result[key] = errorMessage;
+
+					continue;
 				}
+				const errorMessage = i18n.t("convertWrappedJsonError", {
+					error: (error as Error).message,
+					ns: "services",
+					key,
+				});
+				LoggerService.error(namespaces.sessionsService, errorMessage, true);
+				result[key] = errorMessage;
 			}
 		} else {
 			result[key] = value;


### PR DESCRIPTION
## Description
When our converter tries to convert a string using `JSON.parse` obviously it will get an exception, added type check, in case we get a string - save the value as is, in case `JSON.parse` doesn't fail - meaning the value is a valid JSON, meaning this is the value we should keep in `result[key]`.

Example of the bug:

![image](https://github.com/user-attachments/assets/eb5bfebf-e769-4c30-8477-5ce469aba1eb)

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1000/event-issues

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
