### PR TITLE
feat(UI-914): remove 'warning active deployment' modal from edit forms

### DIFF
--- a/e2e/project/trigger.spec.ts
+++ b/e2e/project/trigger.spec.ts
@@ -32,7 +32,7 @@ async function createTriggerScheduler(
 	fileName: string,
 	functionName: string
 ) {
-	await page.getByRole("link", { name: "Add new" }).click();
+	await page.getByRole("button", { name: "Add new" }).click();
 
 	const nameInput = page.getByRole("textbox", { name: "Name", exact: true });
 	await nameInput.click();
@@ -65,13 +65,17 @@ async function modifyTrigger(
 	newFunctionName: string,
 	withActiveDeployment: boolean
 ) {
-	await page.getByRole("button", { name: `Modify ${name} trigger` }).click();
-
 	if (withActiveDeployment) {
 		const deployButton = page.getByRole("button", { name: "Deploy project" });
 		await deployButton.click();
 		const toast = await waitForToast(page, "Project deployment completed successfully");
 		await expect(toast).toBeVisible();
+	}
+
+	await page.getByRole("button", { name: `Modify ${name} trigger` }).click();
+
+	if (withActiveDeployment) {
+		await expect(page.getByText("Changes might affect the currently running deployments.")).toBeVisible();
 		await page.getByRole("button", { name: "Ok" }).click();
 	}
 
@@ -156,7 +160,7 @@ test.describe("Project Triggers Suite", () => {
 	});
 
 	test("Create trigger without a values", async ({ page }) => {
-		await page.getByRole("link", { name: "Add new" }).click();
+		await page.getByRole("button", { name: "Add new" }).click();
 		await page.getByTestId("select-trigger-type").click();
 		await page.getByRole("option", { name: "Scheduler" }).click();
 		await page.getByTestId("select-file").click();

--- a/e2e/project/trigger.spec.ts
+++ b/e2e/project/trigger.spec.ts
@@ -67,6 +67,14 @@ async function modifyTrigger(
 ) {
 	await page.getByRole("button", { name: `Modify ${name} trigger` }).click();
 
+	if (withActiveDeployment) {
+		const deployButton = page.getByRole("button", { name: "Deploy project" });
+		await deployButton.click();
+		const toast = await waitForToast(page, "Project deployment completed successfully");
+		await expect(toast).toBeVisible();
+		await page.getByRole("button", { name: "Ok" }).click();
+	}
+
 	const cronInput = page.getByRole("textbox", { name: "Cron expression" });
 	await cronInput.click();
 	await cronInput.fill(newCronExpression);
@@ -74,17 +82,6 @@ async function modifyTrigger(
 	const functionNameInput = page.getByRole("textbox", { name: "Function name" });
 	await functionNameInput.click();
 	await functionNameInput.fill(newFunctionName);
-
-	if (withActiveDeployment) {
-		const deployButton = page.getByRole("button", { name: "Deploy project" });
-		await deployButton.click();
-		const toast = await waitForToast(page, "Project deployment completed successfully");
-		await expect(toast).toBeVisible();
-		await page.getByRole("button", { name: "Save", exact: true }).click();
-		await page.getByRole("button", { name: "Ok" }).click();
-
-		return;
-	}
 
 	await page.getByRole("button", { name: "Save", exact: true }).click();
 }

--- a/e2e/project/variable.spec.ts
+++ b/e2e/project/variable.spec.ts
@@ -47,10 +47,10 @@ test.describe("Project Variables Suite", () => {
 		await expect(toast).toBeVisible();
 
 		await page.getByRole("button", { name: "Modify nameVariable variable" }).click();
+		await page.getByRole("button", { name: "Ok" }).click();
 		await page.getByLabel("Value").click();
 		await page.getByLabel("Value").fill("newValueVariable");
 		await page.getByRole("button", { name: "Save", exact: true }).click();
-		await page.getByRole("button", { name: "Ok" }).click();
 		const newVariableInTable = page.getByRole("cell", { exact: true, name: "newValueVariable" });
 		await expect(newVariableInTable).toBeVisible();
 	});

--- a/e2e/project/variable.spec.ts
+++ b/e2e/project/variable.spec.ts
@@ -5,7 +5,7 @@ test.beforeEach(async ({ dashboardPage, page }) => {
 	await dashboardPage.createProjectFromMenu();
 
 	await page.getByRole("tab", { name: "variables" }).click();
-	await page.getByRole("link", { name: "Add new" }).click();
+	await page.getByRole("button", { name: "Add new" }).click();
 
 	await page.getByLabel("Name").click();
 	await page.getByLabel("Name").fill("nameVariable");
@@ -21,7 +21,7 @@ test.beforeEach(async ({ dashboardPage, page }) => {
 
 test.describe("Project Variables Suite", () => {
 	test("Create variable with empty fields", async ({ page }) => {
-		await page.getByRole("link", { name: "Add new" }).click();
+		await page.getByRole("button", { name: "Add new" }).click();
 		await page.getByRole("button", { name: "Save", exact: true }).click();
 
 		const nameErrorMessage = page.getByRole("alert", { name: "Name is required" });

--- a/e2e/project/webhookSessionTriggered.spec.ts
+++ b/e2e/project/webhookSessionTriggered.spec.ts
@@ -68,6 +68,9 @@ async function setupProjectAndTriggerSession({ dashboardPage, page, request }: S
 	await page.getByRole("tab", { name: "Triggers" }).click();
 	await page.getByRole("button", { name: "Modify receive_http_get_or_head trigger" }).click();
 
+	await expect(page.getByText("Changes might affect the currently running deployments.")).toBeVisible();
+	await page.getByRole("button", { name: "Ok" }).click();
+
 	await page.waitForSelector('[data-testid="webhook-url"]');
 
 	const webhookUrl = await page.evaluate(() => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,9 +75,6 @@ export default defineConfig({
 		trace: "on",
 		video: "on",
 		screenshot: "on",
-		extraHTTPHeaders: {
-			Authorization: `Bearer ${process.env.TESTS_JWT_AUTH_TOKEN}`,
-		},
 	},
 
 	webServer: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,6 +75,9 @@ export default defineConfig({
 		trace: "on",
 		video: "on",
 		screenshot: "on",
+		extraHTTPHeaders: {
+			Authorization: `Bearer ${process.env.TESTS_JWT_AUTH_TOKEN}`,
+		},
 	},
 
 	webServer: {

--- a/src/components/molecules/activeDeploymentWarning.tsx
+++ b/src/components/molecules/activeDeploymentWarning.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import { useTranslation } from "react-i18next";
+
+import { IconSvg } from "@components/atoms";
+
+import { WarningTriangleIcon } from "@assets/image/icons";
+
+export const ActiveDeploymentWarning = () => {
+	const { t } = useTranslation("tabs", { keyPrefix: "shared" });
+
+	return (
+		<div className="mb-6 flex">
+			<IconSvg src={WarningTriangleIcon} />
+			<div className="ml-2">{t("warningActiveDeployment")}</div>
+		</div>
+	);
+};

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,4 +1,5 @@
 export { Accordion } from "@components/molecules/accordion";
+export { ActiveDeploymentWarning } from "@components/molecules/activeDeploymentWarning";
 export { ConnectionTableStatus } from "@components/molecules/connectionTableStatus";
 export { CopyButton } from "@components/molecules/copyButton";
 export { Drawer } from "@components/molecules/drawer";

--- a/src/components/organisms/activeDeploymentWarningModal.tsx
+++ b/src/components/organisms/activeDeploymentWarningModal.tsx
@@ -3,15 +3,22 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import { ModalName } from "@enums/components";
-import { WarningDeploymentActivetedModalProps } from "@interfaces/components";
+import { ActiveDeploymentWarningModalProps } from "@interfaces/components";
 import { useModalStore } from "@src/store";
 
 import { Button } from "@components/atoms";
 import { Modal } from "@components/molecules";
 
-export const WarningDeploymentActivetedModal = ({ onClick }: WarningDeploymentActivetedModalProps) => {
+export const ActiveDeploymentWarningModal = ({
+	action,
+	modifiedId,
+	onDelete,
+	onEdit,
+}: ActiveDeploymentWarningModalProps) => {
 	const { t } = useTranslation("modals", { keyPrefix: "warningActiveDeployment" });
 	const { closeModal } = useModalStore();
+
+	const onOkClick = () => (action === "edit" ? onEdit(modifiedId) : onDelete(modifiedId));
 
 	return (
 		<Modal hideCloseButton name={ModalName.warningDeploymentActive}>
@@ -34,7 +41,7 @@ export const WarningDeploymentActivetedModal = ({ onClick }: WarningDeploymentAc
 				<Button
 					ariaLabel={t("agreeButton")}
 					className="bg-gray-1100 px-4 py-3 font-semibold"
-					onClick={onClick}
+					onClick={onOkClick}
 					variant="filled"
 				>
 					{t("agreeButton")}

--- a/src/components/organisms/activeDeploymentWarningModal.tsx
+++ b/src/components/organisms/activeDeploymentWarningModal.tsx
@@ -9,16 +9,11 @@ import { useModalStore } from "@src/store";
 import { Button } from "@components/atoms";
 import { Modal } from "@components/molecules";
 
-export const ActiveDeploymentWarningModal = ({
-	action,
-	modifiedId,
-	onDelete,
-	onEdit,
-}: ActiveDeploymentWarningModalProps) => {
+export const ActiveDeploymentWarningModal = ({ modifiedId, onOk }: ActiveDeploymentWarningModalProps) => {
 	const { t } = useTranslation("modals", { keyPrefix: "warningActiveDeployment" });
 	const { closeModal } = useModalStore();
 
-	const onOkClick = () => (action === "edit" ? onEdit(modifiedId) : onDelete(modifiedId));
+	const onOkClick = () => onOk(modifiedId);
 
 	return (
 		<Modal hideCloseButton name={ModalName.warningDeploymentActive}>

--- a/src/components/organisms/activeDeploymentWarningModal.tsx
+++ b/src/components/organisms/activeDeploymentWarningModal.tsx
@@ -9,11 +9,18 @@ import { useModalStore } from "@src/store";
 import { Button } from "@components/atoms";
 import { Modal } from "@components/molecules";
 
-export const ActiveDeploymentWarningModal = ({ modifiedId, onOk }: ActiveDeploymentWarningModalProps) => {
+export const ActiveDeploymentWarningModal = ({
+	action,
+	goToAdd,
+	goToEdit,
+	modifiedId,
+}: ActiveDeploymentWarningModalProps) => {
 	const { t } = useTranslation("modals", { keyPrefix: "warningActiveDeployment" });
 	const { closeModal } = useModalStore();
 
-	const onOkClick = () => onOk(modifiedId);
+	if (!action) return null;
+
+	const onOkClick = () => (action === "edit" ? goToEdit(modifiedId) : goToAdd());
 
 	return (
 		<Modal hideCloseButton name={ModalName.warningDeploymentActive}>

--- a/src/components/organisms/connections/add.tsx
+++ b/src/components/organisms/connections/add.tsx
@@ -6,13 +6,14 @@ import { integrationTypes } from "@constants/lists";
 import { SelectOption } from "@interfaces/components";
 import { integrationAddFormComponents } from "@src/constants/connections";
 import { Integrations } from "@src/enums/components";
+import { useHasActiveDeployments } from "@src/store";
 import { stripGoogleConnectionName } from "@src/utilities";
 import { connectionSchema } from "@validations";
 
 import { useConnectionForm } from "@hooks";
 
 import { ErrorMessage, Input } from "@components/atoms";
-import { Select, TabFormHeader } from "@components/molecules";
+import { ActiveDeploymentWarning, Select, TabFormHeader } from "@components/molecules";
 
 export const AddConnection = () => {
 	const { t } = useTranslation("integrations");
@@ -20,6 +21,7 @@ export const AddConnection = () => {
 		connectionSchema,
 		"create"
 	);
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	const selectedIntegration: SelectOption = watch("integration");
 
@@ -35,6 +37,7 @@ export const AddConnection = () => {
 	return (
 		<div className="min-w-80">
 			<TabFormHeader className="mb-11" isHiddenButtons title={t("addNewConnection")} />
+			{hasActiveDeployments ? <ActiveDeploymentWarning /> : null}
 
 			<form className="mb-6 flex w-5/6 flex-col" onSubmit={handleSubmit(onSubmit)}>
 				<div className="relative mb-6">

--- a/src/components/organisms/connections/deleteModal.tsx
+++ b/src/components/organisms/connections/deleteModal.tsx
@@ -7,7 +7,7 @@ import { DeleteModalProps } from "@interfaces/components";
 import { ConnectionService } from "@services";
 import { Connection } from "@type/models";
 
-import { useCacheStore, useModalStore, useToastStore } from "@store";
+import { useHasActiveDeployments, useModalStore, useToastStore } from "@store";
 
 import { Button, Loader } from "@components/atoms";
 import { Modal } from "@components/molecules";
@@ -18,7 +18,7 @@ export const DeleteConnectionModal = ({ id, isDeleting, onDelete }: DeleteModalP
 	const [connection, setConnection] = useState<Connection>();
 	const addToast = useToastStore((state) => state.addToast);
 	const { closeModal } = useModalStore();
-	const { hasActiveDeployments } = useCacheStore();
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	const fetchConnection = async () => {
 		if (!id) {

--- a/src/components/organisms/connections/edit.tsx
+++ b/src/components/organisms/connections/edit.tsx
@@ -7,11 +7,12 @@ import { integrationTypes } from "@constants/lists";
 import { useConnectionForm } from "@hooks/useConnectionForm";
 import { integrationToEditComponent } from "@src/constants";
 import { Integrations } from "@src/enums/components";
+import { useHasActiveDeployments } from "@src/store";
 import { stripGoogleConnectionName } from "@src/utilities";
 import { connectionSchema } from "@validations";
 
 import { Input } from "@components/atoms";
-import { Select, TabFormHeader } from "@components/molecules";
+import { ActiveDeploymentWarning, Select, TabFormHeader } from "@components/molecules";
 
 export const EditConnection = () => {
 	const { t } = useTranslation("integrations");
@@ -23,6 +24,8 @@ export const EditConnection = () => {
 		integration: selectedIntegration,
 		register,
 	} = useConnectionForm(connectionSchema, "edit");
+
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	useEffect(() => {
 		if (connectionId) {
@@ -50,7 +53,7 @@ export const EditConnection = () => {
 	return (
 		<div className="min-w-80">
 			<TabFormHeader className="mb-11" isHiddenButtons={true} title={t("editConnection")} />
-
+			{hasActiveDeployments ? <ActiveDeploymentWarning /> : null}
 			<div className="mb-6 flex w-5/6 flex-col">
 				<div className="relative mb-6">
 					<Input

--- a/src/components/organisms/connections/integrations/asana/edit.tsx
+++ b/src/components/organisms/connections/integrations/asana/edit.tsx
@@ -5,23 +5,18 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { integrationVariablesMapping } from "@src/constants";
-import { ModalName } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
-import { useCacheStore, useModalStore } from "@src/store";
 import { setFormValues } from "@src/utilities";
 import { asanaIntegrationSchema } from "@validations";
 
 import { Button, ErrorMessage, SecretInput, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 
 import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 
 export const AsanaIntegrationEditForm = () => {
 	const { t } = useTranslation("integrations");
 	const [lockState, setLockState] = useState(true);
-	const { hasActiveDeployments } = useCacheStore();
-	const { openModal } = useModalStore();
 	const { connectionVariables, control, errors, handleSubmit, isLoading, onSubmitEdit, register, setValue } =
 		useConnectionForm(asanaIntegrationSchema, "edit");
 
@@ -32,17 +27,8 @@ export const AsanaIntegrationEditForm = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 
-	const handleFormSubmit = () => {
-		if (hasActiveDeployments) {
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmitEdit();
-	};
-
 	return (
-		<form className="flex flex-col gap-6" onSubmit={handleSubmit(handleFormSubmit)}>
+		<form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmitEdit)}>
 			<div className="relative">
 				<SecretInput
 					type="password"
@@ -83,8 +69,6 @@ export const AsanaIntegrationEditForm = () => {
 
 				{t("buttons.saveConnection")}
 			</Button>
-
-			<WarningDeploymentActivetedModal onClick={onSubmitEdit} />
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/aws/edit.tsx
+++ b/src/components/organisms/connections/integrations/aws/edit.tsx
@@ -5,15 +5,12 @@ import { useTranslation } from "react-i18next";
 
 import { selectIntegrationAws } from "@constants/lists/connections";
 import { integrationVariablesMapping } from "@src/constants";
-import { ModalName } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
-import { useCacheStore, useModalStore } from "@src/store";
 import { setFormValues } from "@src/utilities";
 import { awsIntegrationSchema } from "@validations";
 
 import { Button, ErrorMessage, SecretInput, Spinner } from "@components/atoms";
 import { Select } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 
 import { FloppyDiskIcon } from "@assets/image/icons";
 
@@ -27,9 +24,6 @@ export const AwsIntegrationEditForm = () => {
 	const { connectionVariables, control, errors, handleSubmit, isLoading, onSubmitEdit, register, setValue } =
 		useConnectionForm(awsIntegrationSchema, "edit");
 
-	const { hasActiveDeployments } = useCacheStore();
-	const { openModal } = useModalStore();
-
 	const accessKey = useWatch({ control, name: "access_key" });
 	const secretKey = useWatch({ control, name: "secret_key" });
 	const token = useWatch({ control, name: "token" });
@@ -39,17 +33,8 @@ export const AwsIntegrationEditForm = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 
-	const handleFormSubmit = () => {
-		if (hasActiveDeployments) {
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmitEdit();
-	};
-
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit(handleFormSubmit)}>
+		<form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmitEdit)}>
 			<div className="relative">
 				<Controller
 					control={control}
@@ -134,8 +119,6 @@ export const AwsIntegrationEditForm = () => {
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 				{t("buttons.saveConnection")}
 			</Button>
-
-			<WarningDeploymentActivetedModal onClick={onSubmitEdit} />
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/discord/edit.tsx
+++ b/src/components/organisms/connections/integrations/discord/edit.tsx
@@ -5,24 +5,18 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { integrationVariablesMapping } from "@src/constants";
-import { ModalName } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
-import { useCacheStore, useModalStore } from "@src/store";
 import { setFormValues } from "@src/utilities";
 import { discordIntegrationSchema } from "@validations";
 
 import { Button, ErrorMessage, SecretInput, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 
 import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 
 export const DiscordIntegrationEditForm = () => {
 	const { t } = useTranslation("integrations");
 	const [lockState, setLockState] = useState(true);
-
-	const { hasActiveDeployments } = useCacheStore();
-	const { openModal } = useModalStore();
 
 	const { connectionVariables, control, errors, handleSubmit, isLoading, onSubmitEdit, register, setValue } =
 		useConnectionForm(discordIntegrationSchema, "edit");
@@ -34,17 +28,8 @@ export const DiscordIntegrationEditForm = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 
-	const handleFormSubmit = () => {
-		if (hasActiveDeployments) {
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmitEdit();
-	};
-
 	return (
-		<form className="flex flex-col gap-6" onSubmit={handleSubmit(handleFormSubmit)}>
+		<form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmitEdit)}>
 			<div className="relative">
 				<SecretInput
 					type="password"
@@ -82,8 +67,6 @@ export const DiscordIntegrationEditForm = () => {
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 				{t("buttons.saveConnection")}
 			</Button>
-
-			<WarningDeploymentActivetedModal onClick={onSubmitEdit} />
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/googleGemini/edit.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/edit.tsx
@@ -5,25 +5,18 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 import { integrationVariablesMapping } from "@src/constants";
-import { ModalName } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
-import { useCacheStore, useModalStore } from "@src/store";
 import { setFormValues } from "@src/utilities";
 import { googleGeminiIntegrationSchema } from "@validations";
 
 import { Button, ErrorMessage, SecretInput, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 
 import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 
 export const GoogleGeminiIntegrationEditForm = () => {
 	const { t } = useTranslation("integrations");
 	const [lockState, setLockState] = useState(true);
-
-	const { hasActiveDeployments } = useCacheStore();
-	const { openModal } = useModalStore();
-
 	const { connectionVariables, control, errors, handleSubmit, isLoading, onSubmitEdit, register, setValue } =
 		useConnectionForm(googleGeminiIntegrationSchema, "edit");
 
@@ -34,17 +27,8 @@ export const GoogleGeminiIntegrationEditForm = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 
-	const handleFormSubmit = () => {
-		if (hasActiveDeployments) {
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmitEdit();
-	};
-
 	return (
-		<form className="flex flex-col gap-6" onSubmit={handleSubmit(handleFormSubmit)}>
+		<form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmitEdit)}>
 			<div className="relative">
 				<SecretInput
 					type="password"
@@ -93,8 +77,6 @@ export const GoogleGeminiIntegrationEditForm = () => {
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 				{t("buttons.saveConnection")}
 			</Button>
-
-			<WarningDeploymentActivetedModal onClick={onSubmitEdit} />
 		</form>
 	);
 };

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -6,14 +6,12 @@ import { SingleValue } from "react-select";
 import { integrationVariablesMapping } from "../../../../constants/connections/integrationVariablesMapping.constants";
 import { formsPerIntegrationsMapping } from "@constants";
 import { ConnectionAuthType } from "@enums";
-import { Integrations, ModalName, isGoogleIntegration } from "@src/enums/components";
+import { Integrations, isGoogleIntegration } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { SelectOption } from "@src/interfaces/components";
-import { useCacheStore, useModalStore } from "@src/store";
 import { setFormValues } from "@src/utilities";
 
 import { Select } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 
 export const IntegrationEditForm = ({
 	integrationType,
@@ -46,9 +44,6 @@ export const IntegrationEditForm = ({
 
 	const [initialConnectionType, setInitialConnectionType] = useState<boolean>();
 	const [isFirstConnectionType, setIsFirstConnectionType] = useState(true);
-
-	const { hasActiveDeployments } = useCacheStore();
-	const { closeModal, openModal } = useModalStore();
 
 	useEffect(() => {
 		if (!isGoogleIntegration(integrationType)) {
@@ -90,7 +85,6 @@ export const IntegrationEditForm = ({
 
 	const onSubmit = () => {
 		if (connectionId && connectionType === ConnectionAuthType.Oauth) {
-			closeModal(ModalName.warningDeploymentActive);
 			if (isGoogleIntegration(integrationType)) {
 				handleGoogleOauth(connectionId);
 
@@ -101,15 +95,6 @@ export const IntegrationEditForm = ({
 			return;
 		}
 		onSubmitEdit();
-	};
-
-	const handleFormSubmit = () => {
-		if (hasActiveDeployments) {
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmit();
 	};
 
 	useEffect(() => {
@@ -133,7 +118,7 @@ export const IntegrationEditForm = ({
 				placeholder={t("placeholders.selectConnectionType")}
 				value={selectConnectionTypeValue}
 			/>
-			<form className="mt-6 flex flex-col items-stretch gap-6" onSubmit={handleSubmit(handleFormSubmit)}>
+			<form className="mt-6 flex flex-col items-stretch gap-6" onSubmit={handleSubmit(onSubmit)}>
 				{ConnectionTypeComponent ? (
 					<ConnectionTypeComponent
 						control={control}
@@ -146,8 +131,6 @@ export const IntegrationEditForm = ({
 					/>
 				) : null}
 			</form>
-
-			<WarningDeploymentActivetedModal onClick={onSubmit} />
 		</>
 	);
 };

--- a/src/components/organisms/connections/integrations/openAI/edit.tsx
+++ b/src/components/organisms/connections/integrations/openAI/edit.tsx
@@ -5,23 +5,18 @@ import { useTranslation } from "react-i18next";
 
 import { infoOpenAiLinks } from "@constants/lists/connections";
 import { integrationVariablesMapping } from "@src/constants";
-import { ModalName } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
-import { useCacheStore, useModalStore } from "@src/store";
 import { setFormValues } from "@src/utilities";
 import { openAiIntegrationSchema } from "@validations";
 
 import { Button, ErrorMessage, Link, SecretInput, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 
 import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 
 export const OpenAiIntegrationEditForm = () => {
 	const { t } = useTranslation("integrations");
 	const [lockState, setLockState] = useState(true);
-	const { hasActiveDeployments } = useCacheStore();
-	const { openModal } = useModalStore();
 
 	const { connectionVariables, control, errors, handleSubmit, isLoading, onSubmitEdit, register, setValue } =
 		useConnectionForm(openAiIntegrationSchema, "edit");
@@ -33,17 +28,8 @@ export const OpenAiIntegrationEditForm = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 
-	const handleFormSubmit = () => {
-		if (hasActiveDeployments) {
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmitEdit();
-	};
-
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit(handleFormSubmit)}>
+		<form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmitEdit)}>
 			<div className="relative">
 				<SecretInput
 					type="password"
@@ -86,8 +72,6 @@ export const OpenAiIntegrationEditForm = () => {
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 				{t("buttons.saveConnection")}
 			</Button>
-
-			<WarningDeploymentActivetedModal onClick={onSubmitEdit} />
 		</form>
 	);
 };

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -36,7 +36,6 @@ export const ConnectionsTable = () => {
 	} = useCacheStore();
 	const { items: sortedConnections, requestSort, sortConfig } = useSort<Connection>(connections || [], "name");
 	const { resetChecker, setFetchConnectionsCallback } = useConnectionCheckerStore();
-	const [warningModalAction, setWarningModalAction] = useState<"edit" | "delete">("edit");
 
 	useEffect(() => {
 		setFetchConnectionsCallback(() => fetchConnections(projectId!, true));
@@ -97,7 +96,6 @@ export const ConnectionsTable = () => {
 
 	const handleAction = (action: "edit" | "delete", connectionId: string) => {
 		setConnectionId(connectionId);
-		setWarningModalAction(action);
 		if (hasActiveDeployments) {
 			openModal(ModalName.warningDeploymentActive);
 
@@ -235,12 +233,7 @@ export const ConnectionsTable = () => {
 			{connectionId ? (
 				<DeleteConnectionModal id={connectionId} isDeleting={isDeleting} onDelete={handleDeleteConnection} />
 			) : null}
-			<ActiveDeploymentWarningModal
-				action={warningModalAction}
-				modifiedId={connectionId || ""}
-				onDelete={handleOpenModalDeleteConnection}
-				onEdit={navigateToEditForm}
-			/>
+			<ActiveDeploymentWarningModal modifiedId={connectionId || ""} onOk={navigateToEditForm} />
 		</>
 	);
 };

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -9,7 +9,13 @@ import { namespaces } from "@src/constants";
 import { Connection } from "@type/models";
 
 import { useSort } from "@hooks";
-import { useCacheStore, useConnectionCheckerStore, useModalStore, useToastStore } from "@store";
+import {
+	useCacheStore,
+	useConnectionCheckerStore,
+	useHasActiveDeployments,
+	useModalStore,
+	useToastStore,
+} from "@store";
 
 import { Button, IconButton, IconSvg, Loader, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import { ConnectionTableStatus, EmptyTableAddButton, SortButton } from "@components/molecules";
@@ -31,9 +37,11 @@ export const ConnectionsTable = () => {
 	const {
 		connections,
 		fetchConnections,
-		hasActiveDeployments,
 		loading: { connections: isLoading },
 	} = useCacheStore();
+
+	const hasActiveDeployments = useHasActiveDeployments();
+
 	const { items: sortedConnections, requestSort, sortConfig } = useSort<Connection>(connections || [], "name");
 	const { resetChecker, setFetchConnectionsCallback } = useConnectionCheckerStore();
 

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -26,7 +26,6 @@ export const ConnectionsTable = () => {
 	const navigate = useNavigate();
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [connectionId, setConnectionId] = useState<string>();
-
 	const addToast = useToastStore((state) => state.addToast);
 	const {
 		connections,

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -53,8 +53,9 @@ export const ConnectionsTable = () => {
 		(connectionId: string) => {
 			setConnectionId(connectionId);
 			openModal(ModalName.deleteConnection);
+			closeModal(ModalName.warningDeploymentActive);
 		},
-		[openModal]
+		[openModal, closeModal]
 	);
 
 	const handleDeleteConnection = async () => {
@@ -92,15 +93,26 @@ export const ConnectionsTable = () => {
 		fetchConnections(projectId!, true);
 	};
 
-	const navigateToEditForm = (connectionId: string) =>
+	const navigateToEditForm = (connectionId: string) => {
+		closeModal(ModalName.warningDeploymentActive);
+
 		navigate(`/projects/${projectId}/connections/${connectionId}/edit`);
+	};
 
 	const handleAction = (action: "edit" | "delete", connectionId: string) => {
 		setConnectionId(connectionId);
 		setWarningModalAction(action);
 		if (hasActiveDeployments) {
 			openModal(ModalName.warningDeploymentActive);
+
+			return;
 		}
+		if (action === "edit") {
+			navigateToEditForm(connectionId);
+
+			return;
+		}
+		handleOpenModalDeleteConnection(connectionId);
 	};
 
 	return isLoading ? (

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -37,16 +37,13 @@ export const ConnectionsTable = () => {
 	const { items: sortedConnections, requestSort, sortConfig } = useSort<Connection>(connections || [], "name");
 	const { resetChecker, setFetchConnectionsCallback } = useConnectionCheckerStore();
 
-	// Add state for warning modal action
 	const [warningModalAction, setWarningModalAction] = useState<"edit" | "add">();
 
-	// Modify the navigateToEditForm function
 	const navigateToEditForm = (connectionId: string) => {
 		closeModal(ModalName.warningDeploymentActive);
 		navigate(`/projects/${projectId}/connections/${connectionId}/edit`);
 	};
 
-	// Replace handleAction with this version
 	const handleAction = (action: "edit" | "add", connectionId: string) => {
 		if (hasActiveDeployments) {
 			setConnectionId(connectionId);

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -53,9 +53,8 @@ export const ConnectionsTable = () => {
 		(connectionId: string) => {
 			setConnectionId(connectionId);
 			openModal(ModalName.deleteConnection);
-			closeModal(ModalName.warningDeploymentActive);
 		},
-		[openModal, closeModal]
+		[openModal]
 	);
 
 	const handleDeleteConnection = async () => {
@@ -93,11 +92,8 @@ export const ConnectionsTable = () => {
 		fetchConnections(projectId!, true);
 	};
 
-	const navigateToEditForm = (connectionId: string) => {
-		closeModal(ModalName.warningDeploymentActive);
-
+	const navigateToEditForm = (connectionId: string) =>
 		navigate(`/projects/${projectId}/connections/${connectionId}/edit`);
-	};
 
 	const handleAction = (action: "edit" | "delete", connectionId: string) => {
 		setConnectionId(connectionId);
@@ -107,11 +103,14 @@ export const ConnectionsTable = () => {
 
 			return;
 		}
+		closeModal(ModalName.warningDeploymentActive);
+
 		if (action === "edit") {
 			navigateToEditForm(connectionId);
 
 			return;
 		}
+
 		handleOpenModalDeleteConnection(connectionId);
 	};
 

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,3 +1,4 @@
+export { ActiveDeploymentWarningModal } from "@components/organisms/activeDeploymentWarningModal";
 export { DashboardProjectsTable } from "@components/organisms/dashboard";
 export { SessionsTable } from "@components/organisms/deployments";
 export { DeploymentsTable } from "@components/organisms/deployments/table";
@@ -10,4 +11,3 @@ export { SplitFrame } from "@components/organisms/splitFrame";
 export { SystemLog } from "@components/organisms/systemLog";
 export { ProjectConfigTopbar, DashboardTopbar, DeleteProjectModal } from "@components/organisms/topbar";
 export { TitleTopbar } from "@components/organisms/topbar";
-export { WarningDeploymentActivetedModal } from "@components/organisms/warningDeploymentActivetedModal";

--- a/src/components/organisms/triggers/add.tsx
+++ b/src/components/organisms/triggers/add.tsx
@@ -12,10 +12,10 @@ import { TriggerTypes } from "@src/enums";
 import { TriggerFormIds } from "@src/enums/components";
 import { TriggerFormData, triggerResolver } from "@validations";
 
-import { useCacheStore, useToastStore } from "@store";
+import { useCacheStore, useHasActiveDeployments, useToastStore } from "@store";
 
 import { Loader } from "@components/atoms";
-import { TabFormHeader } from "@components/molecules";
+import { ActiveDeploymentWarning, TabFormHeader } from "@components/molecules";
 import {
 	NameAndConnectionFields,
 	SchedulerFields,
@@ -35,6 +35,8 @@ export const AddTrigger = () => {
 		fetchTriggers,
 		loading: { connections: isLoadingConnections },
 	} = useCacheStore();
+
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	const [filesNameList, setFilesNameList] = useState<SelectOption[]>([]);
 	const [isLoadingFiles, setIsLoadingFiles] = useState(false);
@@ -142,6 +144,7 @@ export const AddTrigger = () => {
 					isLoading={isSaving}
 					title={t("addNewTrigger")}
 				/>
+				{hasActiveDeployments ? <ActiveDeploymentWarning /> : null}
 
 				<form
 					className="flex flex-col gap-6"

--- a/src/components/organisms/triggers/deleteModal.tsx
+++ b/src/components/organisms/triggers/deleteModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ModalName } from "@enums/components";
 import { DeleteModalProps } from "@interfaces/components";
 import { TriggersService } from "@services";
-import { useCacheStore, useModalStore } from "@src/store";
+import { useHasActiveDeployments, useModalStore } from "@src/store";
 import { Trigger } from "@type/models";
 
 import { Button, Loader } from "@components/atoms";
@@ -16,7 +16,7 @@ export const DeleteTriggerModal = ({ id, isDeleting, onDelete }: DeleteModalProp
 	const { t: tWarning } = useTranslation("modals", { keyPrefix: "warningActiveDeployment" });
 	const [trigger, setTrigger] = useState<Trigger>();
 	const { closeModal } = useModalStore();
-	const { hasActiveDeployments } = useCacheStore();
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	const fetchTrigger = async () => {
 		if (!id) {

--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -10,16 +10,15 @@ import { TriggerSpecificFields } from "./formParts/fileAndFunction";
 import { TriggersService } from "@services";
 import { extraTriggerTypes } from "@src/constants";
 import { TriggerTypes } from "@src/enums";
-import { ModalName, TriggerFormIds } from "@src/enums/components";
+import { TriggerFormIds } from "@src/enums/components";
 import { SelectOption } from "@src/interfaces/components";
 import { triggerSchema } from "@validations";
 
 import { useFetchTrigger } from "@hooks";
-import { useCacheStore, useModalStore, useToastStore } from "@store";
+import { useCacheStore, useToastStore } from "@store";
 
 import { Loader } from "@components/atoms";
 import { TabFormHeader } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 import {
 	NameAndConnectionFields,
 	SchedulerFields,
@@ -42,14 +41,11 @@ export const EditTrigger = () => {
 		connections,
 		fetchResources,
 		fetchTriggers,
-		hasActiveDeployments,
 		loading: { connections: isLoadingConnections },
 	} = useCacheStore();
-	const { closeModal, openModal } = useModalStore();
 
 	const [filesNameList, setFilesNameList] = useState<SelectOption[]>([]);
 	const [isSaving, setIsSaving] = useState(false);
-	const [formData, setFormData] = useState<TriggerFormData>();
 
 	useEffect(() => {
 		setWebhookUrlHighlight(navigationData?.highlightWebhookUrl || false);
@@ -124,7 +120,6 @@ export const EditTrigger = () => {
 	}, [trigger, connections]);
 
 	const onSubmit = async (data: TriggerFormData) => {
-		closeModal(ModalName.warningDeploymentActive);
 		setIsSaving(true);
 		const { connection, cron, entryFunction, eventTypeSelect, filePath, filter, name } = data;
 		try {
@@ -166,16 +161,6 @@ export const EditTrigger = () => {
 		}
 	};
 
-	const handleFormSubmit = (data: TriggerFormData) => {
-		if (hasActiveDeployments) {
-			setFormData(data);
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmit(data);
-	};
-
 	const watchedEventTypeSelect = useWatch({ control, name: "eventTypeSelect" });
 
 	if (isLoadingConnections || isLoadingTrigger) {
@@ -196,7 +181,7 @@ export const EditTrigger = () => {
 				<form
 					className="flex flex-col gap-6"
 					id={TriggerFormIds.modifyTriggerForm}
-					onSubmit={handleSubmit(handleFormSubmit)}
+					onSubmit={handleSubmit(onSubmit)}
 				>
 					<NameAndConnectionFields isEdit />
 
@@ -214,8 +199,6 @@ export const EditTrigger = () => {
 				</form>
 
 				{trigger?.sourceType === TriggerTypes.schedule ? <SchedulerInfo /> : null}
-
-				{formData ? <WarningDeploymentActivetedModal onClick={() => onSubmit(formData)} /> : null}
 			</div>
 		</FormProvider>
 	);

--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -15,10 +15,10 @@ import { SelectOption } from "@src/interfaces/components";
 import { triggerSchema } from "@validations";
 
 import { useFetchTrigger } from "@hooks";
-import { useCacheStore, useToastStore } from "@store";
+import { useCacheStore, useHasActiveDeployments, useToastStore } from "@store";
 
 import { Loader } from "@components/atoms";
-import { TabFormHeader } from "@components/molecules";
+import { ActiveDeploymentWarning, TabFormHeader } from "@components/molecules";
 import {
 	NameAndConnectionFields,
 	SchedulerFields,
@@ -43,6 +43,7 @@ export const EditTrigger = () => {
 		fetchTriggers,
 		loading: { connections: isLoadingConnections },
 	} = useCacheStore();
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	const [filesNameList, setFilesNameList] = useState<SelectOption[]>([]);
 	const [isSaving, setIsSaving] = useState(false);
@@ -177,6 +178,7 @@ export const EditTrigger = () => {
 					isLoading={isSaving}
 					title={t("modifyTrigger")}
 				/>
+				{hasActiveDeployments ? <ActiveDeploymentWarning /> : null}
 
 				<form
 					className="flex flex-col gap-6"

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -114,11 +114,9 @@ export const TriggersTable = () => {
 	const handleOpenModalDeleteTrigger = useCallback(
 		(id: string) => {
 			setTriggerId(id);
-			closeModal(ModalName.warningDeploymentActive);
-
 			openModal(ModalName.deleteTrigger);
 		},
-		[openModal, closeModal]
+		[openModal]
 	);
 
 	const tableHeaderClass = (sortable: boolean, className: string) =>
@@ -128,10 +126,7 @@ export const TriggersTable = () => {
 		return <Loader isCenter size="xl" />;
 	}
 
-	const navigateToEditForm = (triggerId: string) => {
-		closeModal(ModalName.warningDeploymentActive);
-		navigate(`/projects/${projectId}/triggers/${triggerId}/edit`);
-	};
+	const navigateToEditForm = (triggerId: string) => navigate(`/projects/${projectId}/triggers/${triggerId}/edit`);
 
 	const handleAction = (action: "edit" | "delete", triggerId: string) => {
 		setTriggerId(triggerId);
@@ -141,6 +136,8 @@ export const TriggersTable = () => {
 
 			return;
 		}
+		closeModal(ModalName.warningDeploymentActive);
+
 		if (action === "edit") {
 			navigateToEditForm(triggerId);
 

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -72,6 +72,7 @@ export const TriggersTable = () => {
 	const [triggerId, setTriggerId] = useState<string>();
 	const addToast = useToastStore((state) => state.addToast);
 	const { items: sortedTriggers, requestSort, sortConfig } = useSort<Trigger>(triggers, "name");
+	const [warningModalAction, setWarningModalAction] = useState<"edit" | "add">();
 
 	const tableHeaders = useTableHeaders(t);
 
@@ -130,14 +131,21 @@ export const TriggersTable = () => {
 		navigate(`/projects/${projectId}/triggers/${triggerId}/edit`);
 	};
 
-	const handleEditAction = (triggerId: string) => {
-		setTriggerId(triggerId);
+	const handleAction = (action: "add" | "edit", triggerId: string) => {
 		if (hasActiveDeployments) {
+			setTriggerId(triggerId);
+			setWarningModalAction(action);
 			openModal(ModalName.warningDeploymentActive);
 
 			return;
 		}
-		navigateToEditForm(triggerId);
+
+		if (action === "edit") {
+			navigateToEditForm(triggerId);
+
+			return;
+		}
+		navigate("add");
 	};
 
 	return (
@@ -147,7 +155,7 @@ export const TriggersTable = () => {
 				<Button
 					ariaLabel={t("buttons.addNew")}
 					className="group w-auto gap-1 p-0 font-semibold capitalize text-gray-500 hover:text-white"
-					href="add"
+					onClick={() => handleAction("add", "")}
 				>
 					<PlusCircle className="size-5 stroke-gray-500 duration-300 group-hover:stroke-white" />
 					{t("buttons.addNew")}
@@ -208,7 +216,7 @@ export const TriggersTable = () => {
 												name: trigger.name,
 											})}
 											className="size-8"
-											onClick={() => handleEditAction(trigger.triggerId!)}
+											onClick={() => handleAction("edit", trigger.triggerId!)}
 										>
 											<EditIcon className="size-3 fill-white" />
 										</IconButton>
@@ -232,7 +240,12 @@ export const TriggersTable = () => {
 
 			<DeleteTriggerModal id={triggerId} isDeleting={isDeleting} onDelete={handleDeleteTrigger} />
 
-			<ActiveDeploymentWarningModal modifiedId={triggerId || ""} onOk={navigateToEditForm} />
+			<ActiveDeploymentWarningModal
+				action={warningModalAction}
+				goToAdd={() => navigate("add")}
+				goToEdit={navigateToEditForm}
+				modifiedId={triggerId || ""}
+			/>
 		</>
 	);
 };

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -72,7 +72,6 @@ export const TriggersTable = () => {
 	const [triggerId, setTriggerId] = useState<string>();
 	const addToast = useToastStore((state) => state.addToast);
 	const { items: sortedTriggers, requestSort, sortConfig } = useSort<Trigger>(triggers, "name");
-	const [warningModalAction, setWarningModalAction] = useState<"edit" | "delete">("edit");
 
 	const tableHeaders = useTableHeaders(t);
 
@@ -126,24 +125,19 @@ export const TriggersTable = () => {
 		return <Loader isCenter size="xl" />;
 	}
 
-	const navigateToEditForm = (triggerId: string) => navigate(`/projects/${projectId}/triggers/${triggerId}/edit`);
+	const navigateToEditForm = (triggerId: string) => {
+		closeModal(ModalName.warningDeploymentActive);
+		navigate(`/projects/${projectId}/triggers/${triggerId}/edit`);
+	};
 
-	const handleAction = (action: "edit" | "delete", triggerId: string) => {
+	const handleEditAction = (triggerId: string) => {
 		setTriggerId(triggerId);
-		setWarningModalAction(action);
 		if (hasActiveDeployments) {
 			openModal(ModalName.warningDeploymentActive);
 
 			return;
 		}
-		closeModal(ModalName.warningDeploymentActive);
-
-		if (action === "edit") {
-			navigateToEditForm(triggerId);
-
-			return;
-		}
-		handleOpenModalDeleteTrigger(triggerId);
+		navigateToEditForm(triggerId);
 	};
 
 	return (
@@ -214,7 +208,7 @@ export const TriggersTable = () => {
 												name: trigger.name,
 											})}
 											className="size-8"
-											onClick={() => handleAction("edit", trigger.triggerId!)}
+											onClick={() => handleEditAction(trigger.triggerId!)}
 										>
 											<EditIcon className="size-3 fill-white" />
 										</IconButton>
@@ -222,7 +216,7 @@ export const TriggersTable = () => {
 											ariaLabel={t("table.buttons.ariaDeleteTrigger", {
 												name: trigger.name,
 											})}
-											onClick={() => handleAction("delete", trigger.triggerId!)}
+											onClick={() => handleOpenModalDeleteTrigger(trigger.triggerId!)}
 										>
 											<TrashIcon className="size-4 stroke-white" />
 										</IconButton>
@@ -238,12 +232,7 @@ export const TriggersTable = () => {
 
 			<DeleteTriggerModal id={triggerId} isDeleting={isDeleting} onDelete={handleDeleteTrigger} />
 
-			<ActiveDeploymentWarningModal
-				action={warningModalAction}
-				modifiedId={triggerId || ""}
-				onDelete={handleOpenModalDeleteTrigger}
-				onEdit={navigateToEditForm}
-			/>
+			<ActiveDeploymentWarningModal modifiedId={triggerId || ""} onOk={navigateToEditForm} />
 		</>
 	);
 };

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -12,7 +12,7 @@ import { cn } from "@src/utilities";
 import { Trigger } from "@type/models";
 
 import { useSort } from "@hooks";
-import { useCacheStore, useModalStore, useToastStore } from "@store";
+import { useCacheStore, useHasActiveDeployments, useModalStore, useToastStore } from "@store";
 
 import { Button, IconButton, IconSvg, Loader, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import { EmptyTableAddButton, PopoverTrigger, SortButton } from "@components/molecules";
@@ -64,10 +64,10 @@ export const TriggersTable = () => {
 	const { closeModal, openModal } = useModalStore();
 	const {
 		fetchTriggers,
-		hasActiveDeployments,
 		loading: { triggers: loadingTriggers },
 		triggers,
 	} = useCacheStore();
+	const hasActiveDeployments = useHasActiveDeployments();
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [triggerId, setTriggerId] = useState<string>();
 	const addToast = useToastStore((state) => state.addToast);

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { ActiveDeploymentWarningModal } from "../activeDeploymentWarningModal";
 import { ModalName } from "@enums/components";
 import { LoggerService, TriggersService } from "@services";
 import { namespaces } from "@src/constants";
@@ -19,6 +18,7 @@ import { Button, IconButton, IconSvg, Loader, TBody, THead, Table, Td, Th, Tr } 
 import { EmptyTableAddButton, PopoverTrigger, SortButton } from "@components/molecules";
 import { Popover } from "@components/molecules/popover/index";
 import { PopoverContent } from "@components/molecules/popover/popoverContent";
+import { ActiveDeploymentWarningModal } from "@components/organisms";
 import { DeleteTriggerModal } from "@components/organisms/triggers";
 import { InformationPopoverContent } from "@components/organisms/triggers/table/popoverContent";
 

--- a/src/components/organisms/variables/add.tsx
+++ b/src/components/organisms/variables/add.tsx
@@ -6,12 +6,12 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { VariablesService } from "@services";
-import { useCacheStore } from "@src/store";
+import { useCacheStore, useHasActiveDeployments } from "@src/store";
 import { useToastStore } from "@store/useToastStore";
 import { newVariableShema } from "@validations";
 
 import { ErrorMessage, Input, SecretInput } from "@components/atoms";
-import { TabFormHeader } from "@components/molecules";
+import { ActiveDeploymentWarning, TabFormHeader } from "@components/molecules";
 
 export const AddVariable = () => {
 	const { t } = useTranslation("errors");
@@ -21,6 +21,7 @@ export const AddVariable = () => {
 	const [isLoading, setIsLoading] = useState(false);
 	const addToast = useToastStore((state) => state.addToast);
 	const { fetchVariables } = useCacheStore();
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	const {
 		control,
@@ -70,8 +71,8 @@ export const AddVariable = () => {
 				form="createNewVariableForm"
 				isLoading={isLoading}
 				title={tForm("addNewVariable")}
-			/>
-
+			/>{" "}
+			{hasActiveDeployments ? <ActiveDeploymentWarning /> : null}
 			<form className="flex flex-col gap-6" id="createNewVariableForm" onSubmit={handleSubmit(onSubmit)}>
 				<div className="relative">
 					<Input

--- a/src/components/organisms/variables/deleteModal.tsx
+++ b/src/components/organisms/variables/deleteModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { ModalName } from "@enums/components";
 import { DeleteModalProps } from "@interfaces/components";
-import { useCacheStore, useModalStore } from "@src/store";
+import { useHasActiveDeployments, useModalStore } from "@src/store";
 
 import { Button, Loader } from "@components/atoms";
 import { Modal } from "@components/molecules";
@@ -13,7 +13,7 @@ export const DeleteVariableModal = ({ id, isDeleting, onDelete }: DeleteModalPro
 	const { t } = useTranslation("modals", { keyPrefix: "deleteVariable" });
 	const { t: tWarning } = useTranslation("modals", { keyPrefix: "warningActiveDeployment" });
 	const { closeModal } = useModalStore();
-	const { hasActiveDeployments } = useCacheStore();
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	return (
 		<Modal hideCloseButton name={ModalName.deleteVariable}>

--- a/src/components/organisms/variables/edit.tsx
+++ b/src/components/organisms/variables/edit.tsx
@@ -6,12 +6,12 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { VariablesService } from "@services";
-import { useCacheStore } from "@src/store";
+import { useCacheStore, useHasActiveDeployments } from "@src/store";
 import { useToastStore } from "@store/useToastStore";
 import { newVariableShema } from "@validations";
 
 import { ErrorMessage, Input, Loader, SecretInput } from "@components/atoms";
-import { TabFormHeader } from "@components/molecules";
+import { ActiveDeploymentWarning, TabFormHeader } from "@components/molecules";
 
 export const EditVariable = () => {
 	const { t: tForm } = useTranslation("tabs", {
@@ -26,6 +26,7 @@ export const EditVariable = () => {
 	const navigate = useNavigate();
 	const [isLoading, setIsLoading] = useState(false);
 	const [isLoadingData, setIsLoadingData] = useState(true);
+	const hasActiveDeployments = useHasActiveDeployments();
 
 	const {
 		control,
@@ -106,6 +107,7 @@ export const EditVariable = () => {
 				isLoading={isLoading}
 				title={tForm("modifyVariable")}
 			/>
+			{hasActiveDeployments ? <ActiveDeploymentWarning /> : null}
 
 			<form className="flex flex-col gap-6" id="modifyVariableForm" onSubmit={handleSubmit(onSubmit)}>
 				<div className="relative">

--- a/src/components/organisms/variables/edit.tsx
+++ b/src/components/organisms/variables/edit.tsx
@@ -6,14 +6,12 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { VariablesService } from "@services";
-import { ModalName } from "@src/enums/components";
-import { useCacheStore, useModalStore } from "@src/store";
+import { useCacheStore } from "@src/store";
 import { useToastStore } from "@store/useToastStore";
 import { newVariableShema } from "@validations";
 
 import { ErrorMessage, Input, Loader, SecretInput } from "@components/atoms";
 import { TabFormHeader } from "@components/molecules";
-import { WarningDeploymentActivetedModal } from "@components/organisms";
 
 export const EditVariable = () => {
 	const { t: tForm } = useTranslation("tabs", {
@@ -21,9 +19,8 @@ export const EditVariable = () => {
 	});
 	const { t } = useTranslation("errors");
 
-	const { closeModal, openModal } = useModalStore();
 	const addToast = useToastStore((state) => state.addToast);
-	const { fetchVariables, hasActiveDeployments } = useCacheStore();
+	const { fetchVariables } = useCacheStore();
 
 	const { projectId, variableName } = useParams();
 	const navigate = useNavigate();
@@ -78,7 +75,6 @@ export const EditVariable = () => {
 	}, []);
 
 	const onSubmit = async () => {
-		closeModal(ModalName.warningDeploymentActive);
 		const { isSecret, name, value } = getValues();
 		setIsLoading(true);
 		const { error } = await VariablesService.setByProjectId(projectId!, {
@@ -100,15 +96,6 @@ export const EditVariable = () => {
 		navigate(-1);
 	};
 
-	const handleFormSubmit = () => {
-		if (hasActiveDeployments) {
-			openModal(ModalName.warningDeploymentActive);
-
-			return;
-		}
-		onSubmit();
-	};
-
 	return isLoadingData ? (
 		<Loader isCenter size="xl" />
 	) : (
@@ -120,7 +107,7 @@ export const EditVariable = () => {
 				title={tForm("modifyVariable")}
 			/>
 
-			<form className="flex flex-col gap-6" id="modifyVariableForm" onSubmit={handleSubmit(handleFormSubmit)}>
+			<form className="flex flex-col gap-6" id="modifyVariableForm" onSubmit={handleSubmit(onSubmit)}>
 				<div className="relative">
 					<Input
 						value={name}
@@ -150,8 +137,6 @@ export const EditVariable = () => {
 					<ErrorMessage ariaLabel={tForm("ariaValueRequired")}>{errors.value?.message}</ErrorMessage>
 				</div>
 			</form>
-
-			<WarningDeploymentActivetedModal onClick={onSubmit} />
 		</div>
 	);
 };

--- a/src/components/organisms/variables/table.tsx
+++ b/src/components/organisms/variables/table.tsx
@@ -9,7 +9,7 @@ import { namespaces } from "@src/constants";
 import { Variable } from "@type/models";
 
 import { useSort } from "@hooks";
-import { useCacheStore, useModalStore, useToastStore } from "@store";
+import { useCacheStore, useHasActiveDeployments, useModalStore, useToastStore } from "@store";
 
 import { Button, IconButton, Loader, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import { EmptyTableAddButton, SortButton } from "@components/molecules";
@@ -30,10 +30,10 @@ export const VariablesTable = () => {
 
 	const {
 		fetchVariables,
-		hasActiveDeployments,
 		loading: { variables: loadingVariables },
 		variables,
 	} = useCacheStore();
+	const hasActiveDeployments = useHasActiveDeployments();
 	const addToast = useToastStore((state) => state.addToast);
 	const { items: sortedVariables, requestSort, sortConfig } = useSort<Variable>(variables, "name");
 

--- a/src/components/organisms/variables/table.tsx
+++ b/src/components/organisms/variables/table.tsx
@@ -26,6 +26,8 @@ export const VariablesTable = () => {
 	const navigate = useNavigate();
 	const { projectId } = useParams();
 	const { closeModal, openModal } = useModalStore();
+	const [warningModalAction, setWarningModalAction] = useState<"edit" | "add">();
+
 	const {
 		fetchVariables,
 		hasActiveDeployments,
@@ -77,13 +79,21 @@ export const VariablesTable = () => {
 		navigate(`edit/${variableName}`);
 	};
 
-	const handleEditAction = (variableName: string) => {
+	const handleAction = (action: "add" | "edit", variableName: string) => {
 		if (hasActiveDeployments) {
+			setDeleteVariable({ name: variableName } as Variable);
+			setWarningModalAction(action);
 			openModal(ModalName.warningDeploymentActive);
 
 			return;
 		}
-		navigateToEditForm(variableName);
+
+		if (action === "edit") {
+			navigateToEditForm(variableName);
+
+			return;
+		}
+		navigate("add");
 	};
 
 	return loadingVariables ? (
@@ -92,14 +102,12 @@ export const VariablesTable = () => {
 		<>
 			<div className="flex items-center justify-between">
 				<div className="text-base text-gray-500">{t("titleAvailable")}</div>
-
 				<Button
 					ariaLabel={t("buttons.addNew")}
 					className="group w-auto gap-1 p-0 font-semibold capitalize text-gray-500 hover:text-white"
-					href="add"
+					onClick={() => handleAction("add", "")}
 				>
 					<PlusCircle className="size-5 stroke-gray-500 duration-300 group-hover:stroke-white" />
-
 					{t("buttons.addNew")}
 				</Button>
 			</div>
@@ -157,7 +165,7 @@ export const VariablesTable = () => {
 									<div className="flex size-8 space-x-1">
 										<IconButton
 											ariaLabel={t("table.buttons.ariaModifyVariable", { name })}
-											onClick={() => handleEditAction(name)}
+											onClick={() => handleAction("edit", name)}
 										>
 											<EditIcon className="size-3 fill-white" />
 										</IconButton>
@@ -177,10 +185,13 @@ export const VariablesTable = () => {
 			) : (
 				<EmptyTableAddButton buttonText={t("titleEmptyVariablesButton")} onClick={() => navigate("add")} />
 			)}
-
 			<DeleteVariableModal id={deleteVariable?.name} isDeleting={isDeleting} onDelete={handleDeleteVariable} />
-
-			<ActiveDeploymentWarningModal modifiedId={deleteVariable?.name || ""} onOk={navigateToEditForm} />
+			<ActiveDeploymentWarningModal
+				action={warningModalAction}
+				goToAdd={() => navigate("add")}
+				goToEdit={navigateToEditForm}
+				modifiedId={deleteVariable?.name || ""}
+			/>
 		</>
 	);
 };

--- a/src/interfaces/components/index.ts
+++ b/src/interfaces/components/index.ts
@@ -29,7 +29,7 @@ export type {
 	ModalDeleteVariableProps,
 	ModalModifyVariableProps,
 	ModalProps,
-	WarningDeploymentActivetedModalProps,
+	ActiveDeploymentWarningModalProps,
 } from "@interfaces/components/modal.interface";
 export type { NotificationProps } from "@interfaces/components/notification.interface";
 export type { PopoverOptions, PopoverTriggerProps } from "@interfaces/components/popover.interface";

--- a/src/interfaces/components/modal.interface.ts
+++ b/src/interfaces/components/modal.interface.ts
@@ -33,6 +33,8 @@ export interface CreateProjectModalProps {
 }
 
 export interface ActiveDeploymentWarningModalProps {
-	onOk: (modifiedId: string) => void;
+	goToEdit: (modifiedId: string) => void;
+	goToAdd: () => void;
 	modifiedId: string;
+	action?: "add" | "edit";
 }

--- a/src/interfaces/components/modal.interface.ts
+++ b/src/interfaces/components/modal.interface.ts
@@ -33,8 +33,6 @@ export interface CreateProjectModalProps {
 }
 
 export interface ActiveDeploymentWarningModalProps {
-	onEdit: (modifiedId: string) => void;
-	onDelete: (modifiedId: string) => void;
+	onOk: (modifiedId: string) => void;
 	modifiedId: string;
-	action: "delete" | "edit";
 }

--- a/src/interfaces/components/modal.interface.ts
+++ b/src/interfaces/components/modal.interface.ts
@@ -32,6 +32,9 @@ export interface CreateProjectModalProps {
 	cardTemplate: TemplateMetadata;
 }
 
-export interface WarningDeploymentActivetedModalProps {
-	onClick?: () => void;
+export interface ActiveDeploymentWarningModalProps {
+	onEdit: (modifiedId: string) => void;
+	onDelete: (modifiedId: string) => void;
+	modifiedId: string;
+	action: "delete" | "edit";
 }

--- a/src/interfaces/store/cacheStore.interface.ts
+++ b/src/interfaces/store/cacheStore.interface.ts
@@ -13,7 +13,6 @@ interface LoadingState {
 
 export interface CacheStore {
 	deployments?: Deployment[];
-	hasActiveDeployments?: boolean;
 	triggers: Trigger[];
 	events?: BaseEvent[];
 	integrations?: Integration[];

--- a/src/locales/en/modals/translation.json
+++ b/src/locales/en/modals/translation.json
@@ -77,7 +77,7 @@
 	},
 	"warningActiveDeployment": {
 		"title": "Warning",
-		"content": "Changes might affect the currently running deployments",
+		"content": "Changes might affect the currently running deployments.",
 		"cancelButton": "Cancel",
 		"agreeButton": "Ok"
 	},

--- a/src/locales/en/tabs/translation.json
+++ b/src/locales/en/tabs/translation.json
@@ -5,6 +5,9 @@
 		"noTriggers": "No triggers available",
 		"emptyVariable": "Variable name and value cannot be empty"
 	},
+	"shared": {
+		"warningActiveDeployment": "Changes might affect the currently running deployments."
+	},
 	"code&assets": {
 		"successRemoveFile": "{{fileName}} succesfully removed",
 		"buttons": {

--- a/src/store/cache/useCacheStore.ts
+++ b/src/store/cache/useCacheStore.ts
@@ -466,7 +466,7 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 
 const selectHasActiveDeployments = createSelector(
 	(state: CacheStore) => state.deployments,
-	(deployments) => deployments?.some((dep) => dep.state === DeploymentStateVariant.active) ?? false
+	(deployments) => deployments?.some(({ state }) => state === DeploymentStateVariant.active) || false
 );
 
 export const useCacheStore = create<CacheStore>(store);

--- a/src/store/cache/useCacheStore.ts
+++ b/src/store/cache/useCacheStore.ts
@@ -1,4 +1,5 @@
 import i18n from "i18next";
+import { createSelector } from "reselect";
 import { StateCreator, create } from "zustand";
 
 import { maxResultsLimitToDisplay, namespaces } from "@constants";
@@ -57,7 +58,6 @@ const initialState: Omit<
 		resourses: false,
 	},
 	deployments: undefined,
-	hasActiveDeployments: false,
 	variables: [],
 	triggers: [],
 	integrations: undefined,
@@ -199,7 +199,6 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 			set((state) => ({
 				...state,
 				deployments: incomingDeployments,
-				hasActiveDeployments: incomingDeployments?.some((dep) => dep.state === DeploymentStateVariant.active),
 				loading: { ...state.loading, deployments: false },
 			}));
 
@@ -465,4 +464,10 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 	},
 });
 
+const selectHasActiveDeployments = createSelector(
+	(state: CacheStore) => state.deployments,
+	(deployments) => deployments?.some((dep) => dep.state === DeploymentStateVariant.active) ?? false
+);
+
 export const useCacheStore = create<CacheStore>(store);
+export const useHasActiveDeployments = () => useCacheStore(selectHasActiveDeployments);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 export { useActivitiesCacheStore } from "@src/store/cache/useActivitiesCacheStore";
-export { useCacheStore } from "@src/store/cache/useCacheStore";
+export { useCacheStore, useHasActiveDeployments } from "@src/store/cache/useCacheStore";
 export { useOutputsCacheStore } from "@src/store/cache/useOutputsCacheStore";
 export { useTemplatesStore } from "@src/store/useTemplatesStore";
 export { useConnectionCheckerStore } from "@store/useConnectionCheckerStore";


### PR DESCRIPTION
## Description
When we have active deployment, and we are adding/editing connection/trigger/variable we have a warning dialog.
Display the dialog before we click add/edit on the table page.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-914/this-might-affect-active-deployment-before-save-on-editadd-click

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
