### PR TITLE
fix(UI-1029): display an error message when copy button fails

### DIFF
--- a/src/utilities/copyToClipboard.utils.ts
+++ b/src/utilities/copyToClipboard.utils.ts
@@ -7,6 +7,6 @@ export const copyToClipboard = async (text: string): Promise<{ isError: boolean;
 		return { isError: false, message: i18n.t("copySuccess", { ns: "global" }) };
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	} catch (error) {
-		return { isError: false, message: i18n.t("copyFailure", { ns: "global" }) };
+		return { isError: true, message: i18n.t("copyFailure", { ns: "global" }) };
 	}
 };


### PR DESCRIPTION
## Description
Currently, we display a success message with an error text:

![image](https://github.com/user-attachments/assets/d634e599-21ca-4efe-8e2d-980918eb02d3)

We should display an error toast with the same message.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1029/display-an-error-message-on-copy-fail

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
