### PR TITLE
fix(UI-1035): popover bugs on sidebar

### DIFF
--- a/src/components/molecules/menu/menu.tsx
+++ b/src/components/molecules/menu/menu.tsx
@@ -119,15 +119,12 @@ export const Menu = ({ className, isOpen = false }: MenuProps) => {
 					</PopoverListTrigger>
 					<PopoverListContent
 						activeId={projectId}
-						className={cn(
-							"scrollbar z-30 flex h-screen flex-col overflow-scroll rounded-lg pb-16 pt-[212px] text-black",
-							"mr-2.5 w-auto border-x border-gray-500 bg-gray-250 px-2"
-						)}
+						className="scrollbar z-30 flex h-screen flex-col overflow-scroll rounded-lg bg-white px-4 pb-16 pt-[212px] text-black"
 						emptyListMessage={t("noProjectsFound")}
 						itemClassName={cn(
-							"flex cursor-pointer items-center gap-2.5 rounded-3xl p-2 transition hover:text-current",
-							"text-center duration-300 whitespace-nowrap px-4 text-gray-1100 hover:bg-green-200",
-							"max-w-245 overflow-hidden"
+							"flex cursor-pointer items-center gap-2.5 rounded-3xl p-2 transition",
+							"hover:text-current text-center text-gray-1100 duration-300 hover:bg-gray-1250",
+							"text-fira-code whitespace-nowrap text-gray-1100 hover:bg-green-200 max-w-245 overflow-hidden p-4"
 						)}
 						items={sortedProjectsList.map(({ id, name }) => ({ id, label: name, value: id }))}
 						onItemSelect={({ id: projectId }: { id: string }) =>

--- a/src/components/molecules/menu/menu.tsx
+++ b/src/components/molecules/menu/menu.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { AnimatePresence, motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { ModalName, SidebarHrefMenu } from "@enums/components";
 import { MenuProps } from "@interfaces/components";
@@ -25,6 +25,7 @@ export const Menu = ({ className, isOpen = false }: MenuProps) => {
 	const [sortedProjectsList, setSortedProjectsList] = useState<Project[]>([]);
 	const { openModal } = useModalStore();
 	const addToast = useToastStore((state) => state.addToast);
+	const { projectId } = useParams();
 
 	useEffect(() => {
 		const sortedProjects = projectsList.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -117,12 +118,16 @@ export const Menu = ({ className, isOpen = false }: MenuProps) => {
 						</li>
 					</PopoverListTrigger>
 					<PopoverListContent
-						className="scrollbar z-30 flex h-screen flex-col overflow-scroll rounded-lg bg-white px-4 pb-16 pt-[212px] text-black"
+						activeId={projectId}
+						className={cn(
+							"scrollbar z-30 flex h-screen flex-col overflow-scroll rounded-lg pb-16 pt-[212px] text-black",
+							"mr-2.5 w-auto border-x border-gray-500 bg-gray-250 px-2"
+						)}
 						emptyListMessage={t("noProjectsFound")}
 						itemClassName={cn(
-							"flex cursor-pointer items-center gap-2.5 rounded-3xl p-2 transition",
-							"hover:text-current text-center text-gray-1100 duration-300 hover:bg-gray-1250",
-							"text-fira-code whitespace-nowrap text-gray-1100 hover:bg-green-200 max-w-245 overflow-hidden p-4"
+							"flex cursor-pointer items-center gap-2.5 rounded-3xl p-2 transition hover:text-current",
+							"text-center duration-300 whitespace-nowrap px-4 text-gray-1100 hover:bg-green-200",
+							"max-w-245 overflow-hidden"
 						)}
 						items={sortedProjectsList.map(({ id, name }) => ({ id, label: name, value: id }))}
 						onItemSelect={({ id: projectId }: { id: string }) =>

--- a/src/components/molecules/menu/menu.tsx
+++ b/src/components/molecules/menu/menu.tsx
@@ -119,12 +119,15 @@ export const Menu = ({ className, isOpen = false }: MenuProps) => {
 					</PopoverListTrigger>
 					<PopoverListContent
 						activeId={projectId}
-						className="scrollbar z-30 flex h-screen flex-col overflow-scroll rounded-lg bg-white px-4 pb-16 pt-[212px] text-black"
+						className={cn(
+							"scrollbar z-30 flex h-screen flex-col overflow-scroll rounded-lg pb-16 pt-[212px] text-black",
+							"mr-2.5 w-auto border-x border-gray-500 bg-gray-250 px-2"
+						)}
 						emptyListMessage={t("noProjectsFound")}
 						itemClassName={cn(
-							"flex cursor-pointer items-center gap-2.5 rounded-3xl p-2 transition",
-							"hover:text-current text-center text-gray-1100 duration-300 hover:bg-gray-1250",
-							"text-fira-code whitespace-nowrap text-gray-1100 hover:bg-green-200 max-w-245 overflow-hidden p-4"
+							"flex cursor-pointer items-center gap-2.5 rounded-3xl p-2 transition hover:text-current",
+							"text-center duration-300 whitespace-nowrap px-4 text-gray-1100 hover:bg-green-200",
+							"max-w-245 overflow-hidden"
 						)}
 						items={sortedProjectsList.map(({ id, name }) => ({ id, label: name, value: id }))}
 						onItemSelect={({ id: projectId }: { id: string }) =>

--- a/src/components/molecules/popover/popoverListContent.tsx
+++ b/src/components/molecules/popover/popoverListContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 
 import { PopoverCloseButton } from "./popoverCloseButton";
 import { PopoverContentBase } from "./popoverContentBase";
@@ -11,17 +11,20 @@ import { useMergeRefsCustom } from "@components/molecules/popover/utilities";
 export const PopoverListContent = React.forwardRef<
 	HTMLDivElement,
 	React.HTMLProps<HTMLDivElement> & {
+		activeId?: string;
 		className?: string;
 		emptyListMessage?: string;
 		itemClassName?: string;
 		items: PopoverListItem[];
 		onItemSelect?: (item: PopoverListItem) => void;
 	}
->(function PopoverListContent({ emptyListMessage, itemClassName, items, onItemSelect, style, ...props }, propRef) {
+>(function PopoverListContent(
+	{ activeId, emptyListMessage, itemClassName, items, onItemSelect, style, ...props },
+	propRef
+) {
 	const { context: floatingContext, ...context } = usePopoverListContext();
 	const listRef = useRef<(HTMLElement | null)[]>([]);
 	const ref = useMergeRefsCustom(context.refs.setFloating, propRef);
-	const [activeId, setActiveId] = useState("");
 
 	useEffect(() => {
 		if (listRef.current) {
@@ -29,16 +32,15 @@ export const PopoverListContent = React.forwardRef<
 		}
 	}, [context.listRef]);
 
-	const handleItemClick = (item: PopoverListItem, index: number, id: string) => {
+	const handleItemClick = (item: PopoverListItem, index: number) => {
 		onItemSelect?.(item);
-		setActiveId(id);
 		context.setActiveIndex(index);
 		context.setOpen(false);
 	};
 
 	const onKeyDown = (event: React.KeyboardEvent, item: PopoverListItem, index: number) => {
 		if (event.key === "Enter" || event.key === " ") {
-			handleItemClick(item, index, item.id);
+			handleItemClick(item, index);
 		}
 		if (event.key === "ArrowDown" || event.key === "Tab") {
 			context.setActiveIndex(Math.min(index + 1, items.length - 1));
@@ -58,7 +60,7 @@ export const PopoverListContent = React.forwardRef<
 							"bg-gray-1100 text-white hover:bg-gray-1100 cursor-pointer": item.id === activeId,
 						})}
 						key={item.id}
-						onClick={() => handleItemClick(item, index, item.id)}
+						onClick={() => handleItemClick(item, index)}
 						onKeyDown={(event) => onKeyDown(event, item, index)}
 						ref={(node) => {
 							if (node) listRef.current[index] = node;

--- a/src/components/organisms/sidebar/sidebar.tsx
+++ b/src/components/organisms/sidebar/sidebar.tsx
@@ -162,7 +162,7 @@ export const Sidebar = () => {
 						</Button>
 
 						{isAuthEnabled ? (
-							<Popover animation="slideFromBottom" interactionType="click">
+							<Popover interactionType="click" placement="right-start">
 								<PopoverTrigger className="ml-1 flex items-center">
 									<Avatar color="black" name={user?.name} round={true} size="36" />
 									<AnimatePresence>

--- a/src/hooks/usePopover.ts
+++ b/src/hooks/usePopover.ts
@@ -20,7 +20,6 @@ import { PopoverOptions } from "@src/interfaces/components";
 
 const useBasePopover = (
 	{ animation, initialOpen = false, placement = "bottom" }: PopoverOptions = {
-		animation: "slideFromBottom",
 		interactionType: "hover",
 	}
 ) => {

--- a/src/hooks/usePopover.ts
+++ b/src/hooks/usePopover.ts
@@ -55,7 +55,7 @@ const useBasePopover = (
 			close: { opacity: 0, top: "50px" },
 		},
 	};
-	const transitionConfiguration = animationConfigurations[animation] || {};
+	const transitionConfiguration = animation ? animationConfigurations[animation] : {};
 
 	const { isMounted, styles } = useTransitionStyles(context, transitionConfiguration);
 
@@ -71,17 +71,21 @@ const useBasePopover = (
 
 export const usePopover = (options: PopoverOptions = { interactionType: "hover", animation: "slideFromBottom" }) => {
 	const { context, data, isMounted, open, setOpen, styles } = useBasePopover(options);
+	const { interactionType } = options;
 
 	const dismiss = useDismiss(context);
-	const role = useRole(context);
-	const hover = useHover(context, {
-		handleClose: safePolygon({
-			buffer: 100,
-		}),
-	});
-	const click = useClick(context);
 
-	const interactions = useInteractions([dismiss, role, hover, click]);
+	const interactionHooks = {
+		click: useClick(context, {
+			enabled: interactionType === "click",
+		}),
+		hover: useHover(context, {
+			enabled: interactionType === "hover",
+			handleClose: safePolygon({ buffer: 100 }),
+		}),
+	};
+
+	const interactions = useInteractions([interactionHooks[interactionType], dismiss]);
 
 	return useMemo(
 		() => ({

--- a/src/interfaces/components/popover.interface.ts
+++ b/src/interfaces/components/popover.interface.ts
@@ -7,7 +7,7 @@ export interface PopoverOptions {
 	open?: boolean;
 	interactionType: "click" | "hover";
 	onOpenChange?: (open: boolean) => void;
-	animation: "slideFromLeft" | "slideFromBottom";
+	animation?: "slideFromLeft" | "slideFromBottom";
 }
 
 export interface PopoverTriggerProps {


### PR DESCRIPTION
## Description
**Projects sub-menu in the sidebar - Buttons design got wrong**

![Screenshot 2024-12-04 at 17 13 31](https://github.com/user-attachments/assets/5555f9d5-04fd-4963-9fcf-15e9c6b3cc44)


**Profile button in the sidebar**

1. The animation is wrong - it shouldn't come from the left
2. Should open on the right, not on top
3. Should open on click, not on hover

https://github.com/user-attachments/assets/a7a5e92c-9e99-47e5-a85c-64a3f6fc8b7e


## Linear Ticket

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
