### PR TITLE
fix(UI-971): improve code editor tabs redesign

### DIFF
--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -175,8 +175,8 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 	const activeCloseIcon = (fileName: string) => {
 		const isActiveFile = openFiles[projectId!].find(({ isActive, name }) => name === fileName && isActive);
 
-		return cn("h-4 w-4 p-0.5 opacity-0 hover:bg-gray-1100 group-hover:opacity-100", {
-			"opacity-100": isActiveFile,
+		return cn("h-4 w-4 p-0.5 hover:bg-gray-1100 hidden", {
+			flex: isActiveFile,
 		});
 	};
 
@@ -192,27 +192,28 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 	};
 
 	return (
-		<div className="relative flex h-full flex-col pt-11">
+		<div className="relative flex h-full flex-col">
 			{projectId ? (
 				<>
-					<div className="absolute left-0 top-0 flex w-full justify-between">
+					<div className="relative flex w-full justify-between pb-3">
+						<div className="absolute -left-1/4 bottom-0 h-px w-[150%] bg-gray-1050" />
 						<div
 							className={
-								`flex h-8 select-none items-center gap-1 uppercase xl:gap-2 2xl:gap-4 3xl:gap-5 ` +
-								`scrollbar overflow-x-auto overflow-y-hidden whitespace-nowrap`
+								`flex select-none items-center gap-1 uppercase xl:gap-2 2xl:gap-4 3xl:gap-5 ` +
+								`scrollbar overflow-x-auto overflow-y-hidden whitespace-nowrap w-full`
 							}
 						>
 							{projectId
 								? openFiles[projectId]?.map(({ name }) => (
 										<Tab
 											activeTab={activeEditorFileName}
-											className="group flex items-center gap-1 normal-case"
+											className="group relative flex items-center gap-1 normal-case"
 											key={name}
 											onClick={() => openFileAsActive(name)}
 											value={name}
 										>
 											{name}
-
+											<div className="absolute -right-0.5 top-0 h-3/4 w-px bg-gray-950 xl:-right-1 2xl:-right-2 3xl:-right-2.5" />
 											<IconButton
 												ariaLabel={t("buttons.ariaCloseFile")}
 												className={activeCloseIcon(name)}
@@ -227,7 +228,7 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 
 						{openFiles[projectId]?.length ? (
 							<div
-								className="relative -right-4 -top-2 z-10 flex items-center gap-1 whitespace-nowrap"
+								className="relative -top-1 z-10 flex items-center gap-1 whitespace-nowrap"
 								title={lastSaved ? `${t("lastSaved")}:${lastSaved}` : ""}
 							>
 								<div className="inline-flex items-center gap-2 rounded-3xl border border-gray-1000 p-1">
@@ -250,7 +251,7 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 										onChange={() => setAutosaveMode((prevAutosave) => !prevAutosave)}
 									/>
 								</div>
-								<IconButton className="hover:bg-gray-1100" onClick={onExpand}>
+								<IconButton className="bg-gray-1100" onClick={onExpand}>
 									{isExpanded ? (
 										<CompressIcon className="size-4 fill-white" />
 									) : (

--- a/src/components/organisms/splitFrame.tsx
+++ b/src/components/organisms/splitFrame.tsx
@@ -21,7 +21,7 @@ export const SplitFrame = ({ children }: SplitFrameProps) => {
 	});
 	const [isExpanded, setIsExpanded] = useState(false);
 
-	const rightFrameClass = cn(`h-full overflow-hidden rounded-l-none pb-0`, {
+	const rightFrameClass = cn(`h-full overflow-hidden rounded-l-none pb-0 md:pt-5`, {
 		"rounded-2xl": !children || isExpanded,
 	});
 


### PR DESCRIPTION
## Description
Display X only on hover but keep the space of the X even when we are not hover

Horizontal scrolling

The active tab name should always be inside the view. If we scroll to the right it will stick to the right in the end. If to the left, then to the left. If we scroll to the right, it will stick to the right and tabs coming from the left, will come behind the active tab: https://www.figma.com/design/klCZL68fUd6pw0DEu0Sj7f/Autokitteh%3A-Look-%26-Feel-design-versions?node-id=3728-112639&t=uRi2LIHPfwLokW91-4
## Linear Ticket
https://linear.app/autokitteh/issue/UI-971/code-editor-tabs-redesign
## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
