### PR TITLE
fix(UI-1014): fix trigger table alignment

### DIFF
--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -181,7 +181,7 @@ export const TriggersTable = () => {
 									</Popover>
 									{trigger?.sourceType}
 								</Td>
-								<Td className="w-4/12">{trigger.entrypoint}</Td>
+								<Td className="w-4/12 pl-2">{trigger.entrypoint}</Td>
 								<Td className="w-2/12 pr-0">
 									<div className="flex">
 										<IconButton

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -164,8 +164,10 @@ export const TriggersTable = () => {
 						{sortedTriggers.map((trigger) => (
 							<Tr className="group" key={trigger.triggerId}>
 								<Td className="w-4/12 pl-4 font-semibold">
-									<div className="flex gap-3">
-										<div>{trigger.name}</div>
+									<div className="w-full overflow-hidden pr-2">
+										<div className="truncate" title={trigger.name}>
+											{trigger.name}
+										</div>
 									</div>
 								</Td>
 								<Td className="-ml-2 w-2/12 capitalize">


### PR DESCRIPTION
## Description
Fix Misalignment of “Call” Column in Triggers Table

Before:
![image](https://github.com/user-attachments/assets/b0c1f409-447c-41b3-af14-c127a751bf8e)

After:
![image](https://github.com/user-attachments/assets/648059cf-e175-4585-9fb5-b82a2e3044e9)

After name column fix:
![image](https://github.com/user-attachments/assets/29708abf-e35e-4586-a627-54a15c0f8c2f)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1014/fix-misalignment-of-type-and-call-columns-in-triggers-table

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
