### PR TITLE
fix(UI-1039): display trigger info popover on hover instead of on click

### DIFF
--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -169,7 +169,7 @@ export const TriggersTable = () => {
 									</div>
 								</Td>
 								<Td className="-ml-2 w-2/12 capitalize">
-									<Popover animation="slideFromBottom" interactionType="click">
+									<Popover animation="slideFromBottom" interactionType="hover">
 										<PopoverTrigger>
 											<IconButton>
 												<IconSvg className="size-4" src={InfoIcon} />


### PR DESCRIPTION
## Description
Display trigger info popover on hover instead of on click

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1039/display-trigger-info-popover-on-hover-instead-of-on-click

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
