### PR TITLE
fix(UI-1037): events table - make the columns equal width

### DIFF
--- a/src/components/organisms/events/table/header.tsx
+++ b/src/components/organisms/events/table/header.tsx
@@ -32,7 +32,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 	return (
 		<THead className="pl-3">
 			<Th>
-				<Td>
+				<Td className="w-1/4">
 					<SortableHeader
 						columnKey="createdAt"
 						columnLabel={t("createdAt")}
@@ -40,7 +40,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 						sortConfig={sortConfig}
 					/>
 				</Td>
-				<Td className="-ml-2">
+				<Td className="-ml-2 w-1/4">
 					<SortableHeader
 						columnKey="eventId"
 						columnLabel={t("eventId")}
@@ -48,7 +48,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 						sortConfig={sortConfig}
 					/>
 				</Td>
-				<Td className="-ml-2">
+				<Td className="-ml-2 w-1/4">
 					<SortableHeader
 						columnKey="destinationId"
 						columnLabel={t("destinationId")}
@@ -56,7 +56,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 						sortConfig={sortConfig}
 					/>
 				</Td>
-				<Td className="-ml-2 mr-2 w-56">
+				<Td className="-ml-2 mr-2 w-1/4">
 					<SortableHeader
 						columnKey="eventType"
 						columnLabel={t("type")}

--- a/src/components/organisms/events/table/row.tsx
+++ b/src/components/organisms/events/table/row.tsx
@@ -19,14 +19,14 @@ export const EventRow = memo(
 		style: CSSProperties;
 	}) => (
 		<Tr className="cursor-pointer pl-3 hover:bg-gray-750" onClick={onClick} style={style}>
-			<Td>{moment(createdAt).local().format(dateTimeFormat)}</Td>
-			<Td>
+			<Td className="w-1/4">{moment(createdAt).local().format(dateTimeFormat)}</Td>
+			<Td className="w-1/4">
 				<IdCopyButton id={eventId} />
 			</Td>
-			<Td>
+			<Td className="w-1/4">
 				<IdCopyButton id={destinationId || ""} />
 			</Td>
-			<Td className="w-56">{eventType}</Td>
+			<Td className="w-1/4">{eventType}</Td>
 		</Tr>
 	)
 );


### PR DESCRIPTION
## Description
Events - make type column wider and IDs shorter

Before (type column had a little space):
![image](https://github.com/user-attachments/assets/248c9b9b-b640-4102-8641-999b2ca037fe)

After (more space for the type column):
![image](https://github.com/user-attachments/assets/0774653e-48ac-4705-9cda-07025cca1b43)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1037/events-make-type-column-wider-and-ids-shorter

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
