### PR TITLE
fix(UI-1016): remember last visited deployment and session

### DIFF
--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -46,10 +46,10 @@ export const SessionViewer = () => {
 
 	const { loading: loadingOutputs, reload: reloadOutputs } = useOutputsCacheStore();
 	const { loading: loadingActivities, reload: reloadActivities } = useActivitiesCacheStore();
-	const { setLatestOpenedSessionId } = useProjectStore();
+	const { setLatestOpened } = useProjectStore();
 
 	const closeEditor = useCallback(() => {
-		setLatestOpenedSessionId("", projectId!);
+		setLatestOpened("sessionId", "", projectId!);
 
 		navigate(`/projects/${projectId}/deployments/${deploymentId}/sessions`);
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -19,7 +19,7 @@ import { LoggerService } from "@services/index";
 import { SessionsService } from "@services/sessions.service";
 import { SessionState } from "@src/enums";
 import { ViewerSession } from "@src/interfaces/models/session.interface";
-import { useActivitiesCacheStore, useOutputsCacheStore, useToastStore } from "@src/store";
+import { useActivitiesCacheStore, useOutputsCacheStore, useProjectStore, useToastStore } from "@src/store";
 
 import { Frame, IconButton, IconSvg, Loader, LogoCatLarge, Tab } from "@components/atoms";
 import { Accordion, CopyButton, RefreshButton } from "@components/molecules";
@@ -46,11 +46,14 @@ export const SessionViewer = () => {
 
 	const { loading: loadingOutputs, reload: reloadOutputs } = useOutputsCacheStore();
 	const { loading: loadingActivities, reload: reloadActivities } = useActivitiesCacheStore();
+	const { setLatestOpenedSessionId } = useProjectStore();
 
-	const closeEditor = useCallback(
-		() => navigate(`/projects/${projectId}/deployments/${deploymentId}/sessions`),
-		[navigate, projectId, deploymentId]
-	);
+	const closeEditor = useCallback(() => {
+		setLatestOpenedSessionId("", projectId!);
+
+		navigate(`/projects/${projectId}/deployments/${deploymentId}/sessions`);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [navigate, projectId, deploymentId]);
 
 	const fetchSessionInfo = useCallback(async () => {
 		if (!sessionId) return;

--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 
 import moment from "moment";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { DeploymentStateVariant } from "@enums";
 import { ModalName } from "@enums/components";
@@ -11,7 +11,7 @@ import { dateTimeFormat, namespaces } from "@src/constants";
 import { Deployment } from "@type/models";
 
 import { useSort } from "@hooks";
-import { useModalStore, useToastStore } from "@store";
+import { useModalStore, useProjectStore, useToastStore } from "@store";
 
 import { IconButton, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import { IdCopyButton, SortButton } from "@components/molecules";
@@ -28,12 +28,14 @@ export const DeploymentsTableContent = ({
 }) => {
 	const { t } = useTranslation("deployments", { keyPrefix: "history" });
 	const navigate = useNavigate();
+	const { projectId } = useParams();
 	const { items: sortedDeployments, requestSort, sortConfig } = useSort<Deployment>(deployments);
 	const addToast = useToastStore((state) => state.addToast);
 	const { closeModal, openModal } = useModalStore();
 	const [deploymentId, setDeploymentId] = useState<string>();
 	const [isDeleting, setIsDeleting] = useState(false);
 	const { t: tSessionsStats } = useTranslation("deployments", { keyPrefix: "sessionStats" });
+	const { setLatestOpened } = useProjectStore();
 
 	const showDeleteModal = (event: React.MouseEvent, id: string) => {
 		event.stopPropagation();
@@ -105,6 +107,11 @@ export const DeploymentsTableContent = ({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[]
 	);
+
+	const goToDeploymentSessions = (id: string) => {
+		setLatestOpened("sessionId", "", projectId);
+		navigate(`${id}/sessions`);
+	};
 
 	return (
 		<>
@@ -194,13 +201,13 @@ export const DeploymentsTableContent = ({
 						<Tr className="hover:bg-gray-1300" key={deploymentId}>
 							<Td
 								className="w-1/8 cursor-pointer pl-4"
-								onClick={() => navigate(`${deploymentId}/sessions`)}
+								onClick={() => goToDeploymentSessions(deploymentId)}
 							>
 								{moment(createdAt).local().format(dateTimeFormat)}
 							</Td>
 							<Td className="w-1/12" />
 
-							<Td className="w-1/3 cursor-pointer" onClick={() => navigate(`${deploymentId}/sessions`)}>
+							<Td className="w-1/3 cursor-pointer" onClick={() => goToDeploymentSessions(deploymentId)}>
 								<DeploymentSessionStats sessionStats={sessionStats} />
 							</Td>
 							<Td className="w-1/12" />
@@ -211,7 +218,7 @@ export const DeploymentsTableContent = ({
 
 							<Td
 								className="w-1/8 cursor-pointer border-r-0"
-								onClick={() => navigate(`${deploymentId}/sessions`)}
+								onClick={() => goToDeploymentSessions(deploymentId)}
 							>
 								<DeploymentState deploymentState={state} />
 							</Td>

--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -12,17 +12,23 @@ import { Button, IconSvg } from "@components/atoms";
 export const ProjectTopbarNavigation = () => {
 	const { deploymentId: paramDeploymentId, projectId } = useParams();
 	const { pathname } = useLocation();
-	const { latestOpenedTab } = useProjectStore();
+	const { currentProjectId, latestOpenedDeploymentId, latestOpenedTab } = useProjectStore();
 	const { deployments } = useCacheStore();
 	const navigate = useNavigate();
+	const { setLatestOpenedDeploymentId } = useProjectStore();
 
-	const deploymentId = paramDeploymentId || deployments?.[0]?.deploymentId;
+	const deploymentId =
+		latestOpenedDeploymentId && currentProjectId === projectId
+			? latestOpenedDeploymentId
+			: paramDeploymentId || deployments?.[0]?.deploymentId;
 
 	const selectedSection = useMemo(() => {
 		if (paramDeploymentId) return "sessions";
+
 		if (pathname.includes("deployments")) return "deployments";
 
 		return "assets";
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [paramDeploymentId, pathname]);
 
 	const navigationItems = useMemo(

--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -12,22 +12,27 @@ import { Button, IconSvg } from "@components/atoms";
 export const ProjectTopbarNavigation = () => {
 	const { deploymentId: paramDeploymentId, projectId, sessionId } = useParams();
 	const { pathname } = useLocation();
-	const { currentProjectId, latestOpened, setLatestOpened } = useProjectStore();
+	const { latestOpened, setLatestOpened } = useProjectStore();
 	const { deployments } = useCacheStore();
 	const navigate = useNavigate();
+
+	if (!paramDeploymentId && !sessionId && projectId !== latestOpened.projectId) {
+		setLatestOpened("deploymentId", "", projectId!);
+		setLatestOpened("sessionId", "", projectId!);
+	}
 
 	if (paramDeploymentId) {
 		setLatestOpened("deploymentId", paramDeploymentId, projectId!);
 	}
 
+	const deploymentId =
+		latestOpened.deploymentId && latestOpened.projectId === projectId
+			? latestOpened.deploymentId
+			: paramDeploymentId || deployments?.[0]?.deploymentId;
+
 	if (sessionId) {
 		setLatestOpened("sessionId", sessionId, projectId!);
 	}
-
-	const deploymentId =
-		latestOpened.deploymentId && currentProjectId === projectId
-			? latestOpened.deploymentId
-			: paramDeploymentId || deployments?.[0]?.deploymentId;
 
 	const selectedSection = useMemo(() => {
 		if (paramDeploymentId) return "sessions";

--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -18,7 +18,7 @@ export const ProjectTopbarNavigation = () => {
 	const navigate = useNavigate();
 
 	if (paramDeploymentId) {
-		setLatestOpenedDeploymentId(paramDeploymentId);
+		setLatestOpenedDeploymentId(paramDeploymentId, projectId!);
 	}
 
 	const deploymentId =

--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -12,10 +12,14 @@ import { Button, IconSvg } from "@components/atoms";
 export const ProjectTopbarNavigation = () => {
 	const { deploymentId: paramDeploymentId, projectId } = useParams();
 	const { pathname } = useLocation();
-	const { currentProjectId, latestOpenedDeploymentId, latestOpenedTab } = useProjectStore();
+	const { currentProjectId, latestOpenedDeploymentId, latestOpenedTab, setLatestOpenedDeploymentId } =
+		useProjectStore();
 	const { deployments } = useCacheStore();
 	const navigate = useNavigate();
-	const { setLatestOpenedDeploymentId } = useProjectStore();
+
+	if (paramDeploymentId) {
+		setLatestOpenedDeploymentId(paramDeploymentId);
+	}
 
 	const deploymentId =
 		latestOpenedDeploymentId && currentProjectId === projectId
@@ -28,7 +32,6 @@ export const ProjectTopbarNavigation = () => {
 		if (pathname.includes("deployments")) return "deployments";
 
 		return "assets";
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [paramDeploymentId, pathname]);
 
 	const navigationItems = useMemo(

--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -4,35 +4,20 @@ import { motion } from "motion/react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { mainNavigationItems } from "@src/constants";
-import { useCacheStore, useProjectStore } from "@src/store";
+import { useProjectStore } from "@src/store";
 import { cn } from "@src/utilities";
+
+import { useLastVisitedEntity } from "@hooks";
 
 import { Button, IconSvg } from "@components/atoms";
 
 export const ProjectTopbarNavigation = () => {
 	const { deploymentId: paramDeploymentId, projectId, sessionId } = useParams();
 	const { pathname } = useLocation();
-	const { latestOpened, setLatestOpened } = useProjectStore();
-	const { deployments } = useCacheStore();
+	const { latestOpened } = useProjectStore();
 	const navigate = useNavigate();
 
-	if (!paramDeploymentId && !sessionId && projectId !== latestOpened.projectId) {
-		setLatestOpened("deploymentId", "", projectId!);
-		setLatestOpened("sessionId", "", projectId!);
-	}
-
-	if (paramDeploymentId) {
-		setLatestOpened("deploymentId", paramDeploymentId, projectId!);
-	}
-
-	const deploymentId =
-		latestOpened.deploymentId && latestOpened.projectId === projectId
-			? latestOpened.deploymentId
-			: paramDeploymentId || deployments?.[0]?.deploymentId;
-
-	if (sessionId) {
-		setLatestOpened("sessionId", sessionId, projectId!);
-	}
+	const { deploymentId, deployments } = useLastVisitedEntity(projectId, paramDeploymentId, sessionId);
 
 	const selectedSection = useMemo(() => {
 		if (paramDeploymentId) return "sessions";

--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -10,15 +10,25 @@ import { cn } from "@src/utilities";
 import { Button, IconSvg } from "@components/atoms";
 
 export const ProjectTopbarNavigation = () => {
-	const { deploymentId: paramDeploymentId, projectId } = useParams();
+	const { deploymentId: paramDeploymentId, projectId, sessionId } = useParams();
 	const { pathname } = useLocation();
-	const { currentProjectId, latestOpenedDeploymentId, latestOpenedTab, setLatestOpenedDeploymentId } =
-		useProjectStore();
+	const {
+		currentProjectId,
+		latestOpenedDeploymentId,
+		latestOpenedSessionId,
+		latestOpenedTab,
+		setLatestOpenedDeploymentId,
+		setLatestOpenedSessionId,
+	} = useProjectStore();
 	const { deployments } = useCacheStore();
 	const navigate = useNavigate();
 
 	if (paramDeploymentId) {
 		setLatestOpenedDeploymentId(paramDeploymentId, projectId!);
+	}
+
+	if (sessionId) {
+		setLatestOpenedSessionId(sessionId, projectId!);
 	}
 
 	const deploymentId =
@@ -56,7 +66,12 @@ export const ProjectTopbarNavigation = () => {
 						case "assets":
 							return latestOpenedTab ? `/${latestOpenedTab}` : "/code";
 						case "sessions":
-							return deploymentId ? `/deployments/${deploymentId}/sessions` : "";
+							return latestOpenedSessionId
+								? deploymentId
+									? `/deployments/${deploymentId}/sessions/${latestOpenedSessionId}`
+									: ""
+								: `/deployments/${deploymentId}/sessions/`;
+
 						case "deployments":
 							return "/deployments";
 						default:

--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -12,28 +12,21 @@ import { Button, IconSvg } from "@components/atoms";
 export const ProjectTopbarNavigation = () => {
 	const { deploymentId: paramDeploymentId, projectId, sessionId } = useParams();
 	const { pathname } = useLocation();
-	const {
-		currentProjectId,
-		latestOpenedDeploymentId,
-		latestOpenedSessionId,
-		latestOpenedTab,
-		setLatestOpenedDeploymentId,
-		setLatestOpenedSessionId,
-	} = useProjectStore();
+	const { currentProjectId, latestOpened, setLatestOpened } = useProjectStore();
 	const { deployments } = useCacheStore();
 	const navigate = useNavigate();
 
 	if (paramDeploymentId) {
-		setLatestOpenedDeploymentId(paramDeploymentId, projectId!);
+		setLatestOpened("deploymentId", paramDeploymentId, projectId!);
 	}
 
 	if (sessionId) {
-		setLatestOpenedSessionId(sessionId, projectId!);
+		setLatestOpened("sessionId", sessionId, projectId!);
 	}
 
 	const deploymentId =
-		latestOpenedDeploymentId && currentProjectId === projectId
-			? latestOpenedDeploymentId
+		latestOpened.deploymentId && currentProjectId === projectId
+			? latestOpened.deploymentId
 			: paramDeploymentId || deployments?.[0]?.deploymentId;
 
 	const selectedSection = useMemo(() => {
@@ -64,11 +57,11 @@ export const ProjectTopbarNavigation = () => {
 				const getPath = () => {
 					switch (item.key) {
 						case "assets":
-							return latestOpenedTab ? `/${latestOpenedTab}` : "/code";
+							return latestOpened.tab ? `/${latestOpened.tab}` : "/code";
 						case "sessions":
-							return latestOpenedSessionId
+							return latestOpened.sessionId
 								? deploymentId
-									? `/deployments/${deploymentId}/sessions/${latestOpenedSessionId}`
+									? `/deployments/${deploymentId}/sessions/${latestOpened.sessionId}`
 									: ""
 								: `/deployments/${deploymentId}/sessions/`;
 

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -20,7 +20,7 @@ export const Project = () => {
 	const { t } = useTranslation("global", { keyPrefix: "pageTitles" });
 	const [pageTitle, setPageTitle] = useState<string>(t("base"));
 	const { projectId } = useParams();
-	const { getProject, setLatestOpenedTab } = useProjectStore();
+	const { getProject, setLatestOpened } = useProjectStore();
 
 	const loadProject = async (projectId: string) => {
 		if (currentProjectId === projectId) return;
@@ -54,7 +54,7 @@ export const Project = () => {
 	const displayTabs = useMemo(() => calculatePathDepth(location.pathname) < 4, [location.pathname]);
 
 	const goTo = (path: string) => {
-		setLatestOpenedTab(path);
+		setLatestOpened("tab", path, projectId!);
 		navigate(path.toLowerCase());
 	};
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,6 +3,8 @@ export { useConnectionForm } from "@hooks/useConnectionForm";
 export { useCreateProjectFromTemplate } from "@hooks/useCreateProjectFromTemplate";
 export { useFileOperations } from "@hooks/useFileOperations";
 export { useInterval } from "@hooks/useInterval";
+export { useLastVisitedEntity } from "@hooks/useLastVisitedEntity";
+export { useProjectCreation } from "@hooks/useProjectCreation";
 export { useResize } from "@hooks/useResize";
 export { useSort } from "@hooks/useSort";
 export { useToastAndLog } from "@hooks/useToastAndLog";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,7 +4,6 @@ export { useCreateProjectFromTemplate } from "@hooks/useCreateProjectFromTemplat
 export { useFileOperations } from "@hooks/useFileOperations";
 export { useInterval } from "@hooks/useInterval";
 export { useLastVisitedEntity } from "@hooks/useLastVisitedEntity";
-export { useProjectCreation } from "@hooks/useProjectCreation";
 export { useResize } from "@hooks/useResize";
 export { useSort } from "@hooks/useSort";
 export { useToastAndLog } from "@hooks/useToastAndLog";

--- a/src/hooks/useLastVisitedEntity.ts
+++ b/src/hooks/useLastVisitedEntity.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { useCacheStore, useProjectStore } from "@src/store";
 
-export const useLastVisitedEntity = (projectId: string | undefined, paramDeploymentId?: string, sessionId?: string) => {
+export const useLastVisitedEntity = (projectId?: string, paramDeploymentId?: string, sessionId?: string) => {
 	const { latestOpened, setLatestOpened } = useProjectStore();
 	const { deployments } = useCacheStore();
 

--- a/src/hooks/useLastVisitedEntity.ts
+++ b/src/hooks/useLastVisitedEntity.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+import { useCacheStore, useProjectStore } from "@src/store";
+
+export const useLastVisitedEntity = (projectId: string | undefined, paramDeploymentId?: string, sessionId?: string) => {
+	const { latestOpened, setLatestOpened } = useProjectStore();
+	const { deployments } = useCacheStore();
+
+	useEffect(() => {
+		if (!paramDeploymentId && !sessionId && projectId !== latestOpened.projectId) {
+			setLatestOpened("deploymentId", "", projectId!);
+			setLatestOpened("sessionId", "", projectId!);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [paramDeploymentId, sessionId, projectId, latestOpened.projectId]);
+
+	useEffect(() => {
+		if (paramDeploymentId) {
+			setLatestOpened("deploymentId", paramDeploymentId, projectId!);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [paramDeploymentId, projectId]);
+
+	useEffect(() => {
+		if (sessionId) {
+			setLatestOpened("sessionId", sessionId, projectId!);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [sessionId, projectId]);
+
+	return {
+		deploymentId:
+			latestOpened.deploymentId && latestOpened.projectId === projectId
+				? latestOpened.deploymentId
+				: paramDeploymentId || deployments?.[0]?.deploymentId,
+		deployments,
+	};
+};

--- a/src/hooks/useLastVisitedEntity.ts
+++ b/src/hooks/useLastVisitedEntity.ts
@@ -17,6 +17,7 @@ export const useLastVisitedEntity = (projectId: string | undefined, paramDeploym
 	useEffect(() => {
 		if (paramDeploymentId) {
 			setLatestOpened("deploymentId", paramDeploymentId, projectId!);
+			setLatestOpened("sessionId", "", projectId!);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [paramDeploymentId, projectId]);

--- a/src/interfaces/store/projectStore.interface.ts
+++ b/src/interfaces/store/projectStore.interface.ts
@@ -14,7 +14,7 @@ export interface ProjectStore {
 	latestOpenedDeploymentId?: string;
 	renameProject: (projectId: string, projectName: string) => void;
 	setLatestOpenedTab: (tab: string) => void;
-	setLatestOpenedDeploymentId: (deploymentId: string, projectId: string) => void;
+	setLatestOpenedDeploymentId: (deploymentId: string) => void;
 	isLoadingProjectsList: boolean;
 	initialEditorWidth: number;
 	pendingFile?: File;

--- a/src/interfaces/store/projectStore.interface.ts
+++ b/src/interfaces/store/projectStore.interface.ts
@@ -14,7 +14,7 @@ export interface ProjectStore {
 	latestOpenedDeploymentId?: string;
 	renameProject: (projectId: string, projectName: string) => void;
 	setLatestOpenedTab: (tab: string) => void;
-	setLatestOpenedDeploymentId: (deploymentId: string) => void;
+	setLatestOpenedDeploymentId: (deploymentId: string, projectId: string) => void;
 	isLoadingProjectsList: boolean;
 	initialEditorWidth: number;
 	pendingFile?: File;

--- a/src/interfaces/store/projectStore.interface.ts
+++ b/src/interfaces/store/projectStore.interface.ts
@@ -1,6 +1,13 @@
 import { Project } from "@type/models";
 import { ServiceResponse } from "@type/services.types";
 
+type LatestOpened = {
+	deploymentId: string;
+	projectId?: string;
+	sessionId: string;
+	tab: string;
+};
+
 export interface ProjectStore {
 	createProject: (name: string, isDefault?: boolean) => ServiceResponse<{ name: string; projectId: string }>;
 	deleteProject: (projectId: string) => ServiceResponse<undefined>;
@@ -10,17 +17,13 @@ export interface ProjectStore {
 	createProjectFromManifest: (manifest: string) => ServiceResponse<string>;
 	projectsList: Project[];
 	currentProjectId?: string;
-	latestOpenedTab: string;
-	latestOpenedDeploymentId?: string;
-	latestOpenedSessionId?: string;
+	latestOpened: LatestOpened;
 	renameProject: (projectId: string, projectName: string) => void;
-	setLatestOpenedTab: (tab: string) => void;
-	setLatestOpenedDeploymentId: (deploymentId: string, projectId: string) => void;
-	setLatestOpenedSessionId: (session: string, projectId: string) => void;
 	isLoadingProjectsList: boolean;
 	initialEditorWidth: number;
 	pendingFile?: File;
 	setPendingFile: (file?: File) => void;
 	setEditorWidth: (width: number) => void;
 	isExporting: boolean;
+	setLatestOpened: (type: keyof Omit<LatestOpened, "projectId">, value: string, projectId?: string) => void;
 }

--- a/src/interfaces/store/projectStore.interface.ts
+++ b/src/interfaces/store/projectStore.interface.ts
@@ -9,9 +9,12 @@ export interface ProjectStore {
 	getProjectsList: () => ServiceResponse<Project[]>;
 	createProjectFromManifest: (manifest: string) => ServiceResponse<string>;
 	projectsList: Project[];
+	currentProjectId?: string;
 	latestOpenedTab: string;
+	latestOpenedDeploymentId?: string;
 	renameProject: (projectId: string, projectName: string) => void;
 	setLatestOpenedTab: (tab: string) => void;
+	setLatestOpenedDeploymentId: (deploymentId: string, projectId: string) => void;
 	isLoadingProjectsList: boolean;
 	initialEditorWidth: number;
 	pendingFile?: File;

--- a/src/interfaces/store/projectStore.interface.ts
+++ b/src/interfaces/store/projectStore.interface.ts
@@ -12,9 +12,11 @@ export interface ProjectStore {
 	currentProjectId?: string;
 	latestOpenedTab: string;
 	latestOpenedDeploymentId?: string;
+	latestOpenedSessionId?: string;
 	renameProject: (projectId: string, projectName: string) => void;
 	setLatestOpenedTab: (tab: string) => void;
 	setLatestOpenedDeploymentId: (deploymentId: string, projectId: string) => void;
+	setLatestOpenedSessionId: (session: string, projectId: string) => void;
 	isLoadingProjectsList: boolean;
 	initialEditorWidth: number;
 	pendingFile?: File;

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -57,10 +57,6 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 					projectId,
 				};
 
-				if (type === "deploymentId") {
-					state.latestOpened.sessionId = "";
-				}
-
 				return state;
 			}
 

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -54,15 +54,12 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 		});
 	},
 
-	setLatestOpenedDeploymentId: (deploymentId, projectId) => {
+	setLatestOpenedDeploymentId: (deploymentId) => {
 		set((state) => {
 			if (state.latestOpenedDeploymentId === deploymentId) {
 				return state;
 			}
-			if (projectId !== state.currentProjectId && state.latestOpenedDeploymentId !== deploymentId) {
-				state.latestOpenedDeploymentId = deploymentId;
-				state.currentProjectId = projectId;
-			}
+			state.latestOpenedDeploymentId = deploymentId;
 
 			return state;
 		});

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -45,19 +45,27 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 		set((state) => {
 			if (projectId && projectId !== state.latestOpened.projectId) {
 				state.latestOpened = {
+					tab: "",
+					deploymentId: "",
+					sessionId: "",
+					projectId,
+				};
+				state.latestOpened = {
 					tab: type === "tab" ? value : "",
 					deploymentId: type === "deploymentId" ? value : "",
 					sessionId: type === "sessionId" ? value : "",
 					projectId,
 				};
 
+				if (type === "deploymentId") {
+					state.latestOpened.sessionId = "";
+				}
+
 				return state;
 			}
 
 			state.latestOpened[type] = value;
-			if (projectId) {
-				state.latestOpened.projectId = projectId;
-			}
+			state.latestOpened.projectId = projectId;
 
 			return state;
 		});

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -21,68 +21,51 @@ const defaultState: Omit<
 	| "exportProject"
 	| "createProjectFromManifest"
 	| "setEditorWidth"
-	| "setLatestOpenedTab"
-	| "setLatestOpenedDeploymentId"
-	| "setLatestOpenedSessionId"
 	| "setPendingFile"
+	| "setLatestOpened"
 > = {
 	projectsList: [],
-	latestOpenedTab: "",
-	latestOpenedDeploymentId: "",
-	latestOpenedSessionId: "",
 	isLoadingProjectsList: true,
 	initialEditorWidth: 50,
 	currentProjectId: undefined,
 	pendingFile: undefined,
 	isExporting: false,
+	latestOpened: {
+		tab: "",
+		deploymentId: "",
+		sessionId: "",
+		projectId: undefined,
+	},
 };
 
 const store: StateCreator<ProjectStore> = (set, get) => ({
 	...defaultState,
 
+	setLatestOpened: (type, value, projectId) => {
+		set((state) => {
+			if (projectId && projectId !== state.latestOpened.projectId) {
+				state.latestOpened = {
+					tab: type === "tab" ? value : "",
+					deploymentId: type === "deploymentId" ? value : "",
+					sessionId: type === "sessionId" ? value : "",
+					projectId,
+				};
+
+				return state;
+			}
+
+			state.latestOpened[type] = value;
+			if (projectId) {
+				state.latestOpened.projectId = projectId;
+			}
+
+			return state;
+		});
+	},
+
 	setEditorWidth: (width) => {
 		set((state) => {
 			state.initialEditorWidth = width;
-
-			return state;
-		});
-	},
-
-	setLatestOpenedTab: (tab) => {
-		set((state) => {
-			state.latestOpenedTab = tab;
-
-			return state;
-		});
-	},
-
-	setLatestOpenedDeploymentId: (deploymentId, projectId) => {
-		set((state) => {
-			if (state.latestOpenedDeploymentId === deploymentId) {
-				return state;
-			}
-			state.latestOpenedDeploymentId = deploymentId;
-
-			if (projectId !== state.currentProjectId) {
-				state.currentProjectId = projectId;
-				state.latestOpenedDeploymentId = "";
-			}
-
-			return state;
-		});
-	},
-
-	setLatestOpenedSessionId: (sessionId, projectId) => {
-		set((state) => {
-			if (state.latestOpenedSessionId === sessionId) {
-				return state;
-			}
-			state.latestOpenedSessionId = sessionId;
-
-			if (projectId !== state.currentProjectId) {
-				state.currentProjectId = projectId;
-				state.latestOpenedSessionId = "";
-			}
 
 			return state;
 		});

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -23,11 +23,13 @@ const defaultState: Omit<
 	| "setEditorWidth"
 	| "setLatestOpenedTab"
 	| "setLatestOpenedDeploymentId"
+	| "setLatestOpenedSessionId"
 	| "setPendingFile"
 > = {
 	projectsList: [],
 	latestOpenedTab: "",
 	latestOpenedDeploymentId: "",
+	latestOpenedSessionId: "",
 	isLoadingProjectsList: true,
 	initialEditorWidth: 50,
 	currentProjectId: undefined,
@@ -64,6 +66,22 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 			if (projectId !== state.currentProjectId) {
 				state.currentProjectId = projectId;
 				state.latestOpenedDeploymentId = "";
+			}
+
+			return state;
+		});
+	},
+
+	setLatestOpenedSessionId: (sessionId, projectId) => {
+		set((state) => {
+			if (state.latestOpenedSessionId === sessionId) {
+				return state;
+			}
+			state.latestOpenedSessionId = sessionId;
+
+			if (projectId !== state.currentProjectId) {
+				state.currentProjectId = projectId;
+				state.latestOpenedSessionId = "";
 			}
 
 			return state;

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -54,12 +54,17 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 		});
 	},
 
-	setLatestOpenedDeploymentId: (deploymentId) => {
+	setLatestOpenedDeploymentId: (deploymentId, projectId) => {
 		set((state) => {
 			if (state.latestOpenedDeploymentId === deploymentId) {
 				return state;
 			}
 			state.latestOpenedDeploymentId = deploymentId;
+
+			if (projectId !== state.currentProjectId) {
+				state.currentProjectId = projectId;
+				state.latestOpenedDeploymentId = "";
+			}
 
 			return state;
 		});

--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -22,12 +22,15 @@ const defaultState: Omit<
 	| "createProjectFromManifest"
 	| "setEditorWidth"
 	| "setLatestOpenedTab"
+	| "setLatestOpenedDeploymentId"
 	| "setPendingFile"
 > = {
 	projectsList: [],
 	latestOpenedTab: "",
+	latestOpenedDeploymentId: "",
 	isLoadingProjectsList: true,
 	initialEditorWidth: 50,
+	currentProjectId: undefined,
 	pendingFile: undefined,
 	isExporting: false,
 };
@@ -46,6 +49,20 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 	setLatestOpenedTab: (tab) => {
 		set((state) => {
 			state.latestOpenedTab = tab;
+
+			return state;
+		});
+	},
+
+	setLatestOpenedDeploymentId: (deploymentId, projectId) => {
+		set((state) => {
+			if (state.latestOpenedDeploymentId === deploymentId) {
+				return state;
+			}
+			if (projectId !== state.currentProjectId && state.latestOpenedDeploymentId !== deploymentId) {
+				state.latestOpenedDeploymentId = deploymentId;
+				state.currentProjectId = projectId;
+			}
 
 			return state;
 		});


### PR DESCRIPTION
## Description
When we move between project assets to deployments to sessions, when we visit sessions of a specific deployment, when we get to assets/deployments and then click back on sessions, we should get the same deployment we visited last time.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1016/remember-last-deployment-we-displayed

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
