### PR TITLE
feat(UI-1009): display loader while connection information loaded

### DIFF
--- a/src/components/organisms/connections/edit.tsx
+++ b/src/components/organisms/connections/edit.tsx
@@ -56,7 +56,7 @@ export const EditConnection = () => {
 		: null;
 
 	const connectionInfoClass = cn("invisible", { visible: connectionInfoLoaded });
-	const loaderClass = cn("visible", { invisible: connectionInfoLoaded });
+	const loaderClass = cn("visible", { invisible: !connectionInfoLoaded });
 
 	return (
 		<div className="min-w-80">

--- a/src/components/organisms/connections/edit.tsx
+++ b/src/components/organisms/connections/edit.tsx
@@ -39,7 +39,6 @@ export const EditConnection = () => {
 	let googleIntegrationApplication;
 
 	const [connectionInfoLoaded, setConnectionInfoLoaded] = useState(false);
-
 	useEvent("onConnectionLoaded", setConnectionInfoLoaded);
 
 	if (integrationType) {

--- a/src/components/organisms/connections/edit.tsx
+++ b/src/components/organisms/connections/edit.tsx
@@ -56,7 +56,7 @@ export const EditConnection = () => {
 		: null;
 
 	const connectionInfoClass = cn("invisible", { visible: connectionInfoLoaded });
-	const loaderClass = cn("visible", { invisible: !connectionInfoLoaded });
+	const loaderClass = cn("visible", { invisible: connectionInfoLoaded });
 
 	return (
 		<div className="min-w-80">

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -100,7 +100,7 @@ export const IntegrationEditForm = ({
 	useEffect(() => {
 		setTimeout(() => {
 			dispacthConnectionInfoLoaded(true);
-		}, 1500);
+		}, 500);
 		setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -98,10 +98,8 @@ export const IntegrationEditForm = ({
 	};
 
 	useEffect(() => {
-		setTimeout(() => {
-			dispacthConnectionInfoLoaded(true);
-		}, 500);
 		setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
+		dispacthConnectionInfoLoaded(true);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -78,6 +78,13 @@ export const IntegrationEditForm = ({
 	const ConnectionTypeComponent =
 		formsPerIntegrationsMapping[integrationType]?.[connectionType as ConnectionAuthType];
 
+	useEffect(() => {
+		if (ConnectionTypeComponent) {
+			dispacthConnectionInfoLoaded(true);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ConnectionTypeComponent]);
+
 	const selectConnectionTypeValue = useMemo(
 		() => selectOptions.find((method) => method.value === connectionType),
 		[connectionType, selectOptions]
@@ -98,8 +105,9 @@ export const IntegrationEditForm = ({
 	};
 
 	useEffect(() => {
-		setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
-		dispacthConnectionInfoLoaded(true);
+		if (connectionVariables) {
+			setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);
 

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -3,11 +3,10 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SingleValue } from "react-select";
 
-import { integrationVariablesMapping } from "../../../../constants/connections/integrationVariablesMapping.constants";
-import { formsPerIntegrationsMapping } from "@constants";
+import { formsPerIntegrationsMapping, integrationVariablesMapping } from "@constants";
 import { ConnectionAuthType } from "@enums";
-import { Integrations, isGoogleIntegration } from "@src/enums/components";
-import { useConnectionForm } from "@src/hooks";
+import { Integrations, ModalName, isGoogleIntegration } from "@src/enums/components";
+import { useConnectionForm, useEvent } from "@src/hooks";
 import { SelectOption } from "@src/interfaces/components";
 import { setFormValues } from "@src/utilities";
 
@@ -44,6 +43,7 @@ export const IntegrationEditForm = ({
 
 	const [initialConnectionType, setInitialConnectionType] = useState<boolean>();
 	const [isFirstConnectionType, setIsFirstConnectionType] = useState(true);
+	const { dispatch: dispacthConnectionInfoLoaded } = useEvent("onConnectionLoaded");
 
 	useEffect(() => {
 		if (!isGoogleIntegration(integrationType)) {
@@ -98,6 +98,7 @@ export const IntegrationEditForm = ({
 	};
 
 	useEffect(() => {
+		dispacthConnectionInfoLoaded(true);
 		setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -5,7 +5,7 @@ import { SingleValue } from "react-select";
 
 import { formsPerIntegrationsMapping, integrationVariablesMapping } from "@constants";
 import { ConnectionAuthType } from "@enums";
-import { Integrations, ModalName, isGoogleIntegration } from "@src/enums/components";
+import { Integrations, isGoogleIntegration } from "@src/enums/components";
 import { useConnectionForm, useEvent } from "@src/hooks";
 import { SelectOption } from "@src/interfaces/components";
 import { setFormValues } from "@src/utilities";
@@ -44,7 +44,6 @@ export const IntegrationEditForm = ({
 	const [initialConnectionType, setInitialConnectionType] = useState<boolean>();
 	const [isFirstConnectionType, setIsFirstConnectionType] = useState(true);
 	const { dispatch: dispacthConnectionInfoLoaded } = useEvent("onConnectionLoaded");
-	const [valuesLoaded, setValuesLoaded] = useState(false);
 
 	useEffect(() => {
 		if (!isGoogleIntegration(integrationType)) {
@@ -80,11 +79,11 @@ export const IntegrationEditForm = ({
 		formsPerIntegrationsMapping[integrationType]?.[connectionType as ConnectionAuthType];
 
 	useEffect(() => {
-		if (valuesLoaded && ConnectionTypeComponent) {
+		if (ConnectionTypeComponent) {
 			dispacthConnectionInfoLoaded(true);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ConnectionTypeComponent, valuesLoaded]);
+	}, [ConnectionTypeComponent]);
 
 	const selectConnectionTypeValue = useMemo(
 		() => selectOptions.find((method) => method.value === connectionType),
@@ -108,7 +107,6 @@ export const IntegrationEditForm = ({
 	useEffect(() => {
 		if (connectionVariables) {
 			setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
-			setValuesLoaded(true);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -44,6 +44,7 @@ export const IntegrationEditForm = ({
 	const [initialConnectionType, setInitialConnectionType] = useState<boolean>();
 	const [isFirstConnectionType, setIsFirstConnectionType] = useState(true);
 	const { dispatch: dispacthConnectionInfoLoaded } = useEvent("onConnectionLoaded");
+	const [valuesLoaded, setValuesLoaded] = useState(false);
 
 	useEffect(() => {
 		if (!isGoogleIntegration(integrationType)) {
@@ -79,11 +80,11 @@ export const IntegrationEditForm = ({
 		formsPerIntegrationsMapping[integrationType]?.[connectionType as ConnectionAuthType];
 
 	useEffect(() => {
-		if (ConnectionTypeComponent) {
+		if (valuesLoaded && ConnectionTypeComponent) {
 			dispacthConnectionInfoLoaded(true);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ConnectionTypeComponent]);
+	}, [ConnectionTypeComponent, valuesLoaded]);
 
 	const selectConnectionTypeValue = useMemo(
 		() => selectOptions.find((method) => method.value === connectionType),
@@ -107,6 +108,7 @@ export const IntegrationEditForm = ({
 	useEffect(() => {
 		if (connectionVariables) {
 			setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
+			setValuesLoaded(true);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -98,7 +98,9 @@ export const IntegrationEditForm = ({
 	};
 
 	useEffect(() => {
-		dispacthConnectionInfoLoaded(true);
+		setTimeout(() => {
+			dispacthConnectionInfoLoaded(true);
+		}, 1500);
 		setFormValues(connectionVariables, integrationVariablesMapping[integrationType], setValue);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [connectionVariables]);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,4 +9,5 @@ export { useSort } from "@hooks/useSort";
 export { useToastAndLog } from "@hooks/useToastAndLog";
 export { useVirtualizedList } from "@hooks/useVirtualizedList";
 export { useWindowDimensions } from "@hooks/useWindowDimensions";
+export { useEvent } from "@src/hooks/useEvent";
 export { usePopover, usePopoverList } from "@src/hooks/usePopover";

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -12,26 +12,27 @@ export const useEvent = <PayloadType = unknown>(
 	eventName: keyof CustomWindowEventMap,
 	callback?: Dispatch<PayloadType> | VoidFunction
 ) => {
+	const listener = useCallback(
+		((event: AppEvent<PayloadType>) => {
+			callback?.(event.detail);
+		}) as EventListener,
+		[callback]
+	);
+
 	useEffect(() => {
 		if (!callback) {
 			return;
 		}
 
-		const listener = ((event: AppEvent<PayloadType>) => {
-			callback(event.detail);
-		}) as EventListener;
-
 		window.addEventListener(eventName, listener);
 
-		return () => {
-			window.removeEventListener(eventName, listener);
-		};
-	}, [callback, eventName]);
+		return () => window.removeEventListener(eventName, listener);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [eventName, listener]);
 
 	const dispatch = useCallback(
 		(detail: PayloadType) => {
-			const event = new CustomEvent(eventName, { detail });
-			window.dispatchEvent(event);
+			window.dispatchEvent(new CustomEvent(eventName, { detail }));
 		},
 		[eventName]
 	);

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -5,7 +5,7 @@ interface AppEvent<PayloadType = unknown> extends Event {
 }
 
 export interface CustomWindowEventMap extends WindowEventMap {
-	onConnectionLoaded: AppEvent<boolean | string>;
+	onConnectionLoaded: AppEvent<boolean>;
 }
 
 export const useEvent = <PayloadType = unknown>(

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -1,0 +1,40 @@
+import { type Dispatch, useCallback, useEffect } from "react";
+
+interface AppEvent<PayloadType = unknown> extends Event {
+	detail: PayloadType;
+}
+
+export interface CustomWindowEventMap extends WindowEventMap {
+	onConnectionLoaded: AppEvent<boolean | string>;
+}
+
+export const useEvent = <PayloadType = unknown>(
+	eventName: keyof CustomWindowEventMap,
+	callback?: Dispatch<PayloadType> | VoidFunction
+) => {
+	useEffect(() => {
+		if (!callback) {
+			return;
+		}
+
+		const listener = ((event: AppEvent<PayloadType>) => {
+			callback(event.detail);
+		}) as EventListener;
+
+		window.addEventListener(eventName, listener);
+
+		return () => {
+			window.removeEventListener(eventName, listener);
+		};
+	}, [callback, eventName]);
+
+	const dispatch = useCallback(
+		(detail: PayloadType) => {
+			const event = new CustomEvent(eventName, { detail });
+			window.dispatchEvent(event);
+		},
+		[eventName]
+	);
+
+	return { dispatch };
+};


### PR DESCRIPTION
## Description
**Display loader while connection information is loaded**

When we enter the Edit Connection page, display a loader on the left side until the information is completely loaded - to avoid the user seeing the connection fields loading one by one, he should see a complete connection after all data is loaded:


https://github.com/user-attachments/assets/5eb27188-36e9-431a-ab43-b849125ede8f

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1009/while-connection-information-is-loaded-display-a-loader

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
