### PR TITLE
feat(UI-1069): add support of a proxy configuration for the API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,30 @@ Ensure you have the following installed on your system:
 
     `npm install`
 
+### API Proxy Configuration 🔄
+
+The application includes a proxy configuration for API requests. When running in development mode, all requests to `/api` are automatically proxied to the backend server.
+
+#### Configuration Options:
+
+`VITE_HOST_URL`
+
+-   Default: http://localhost:9980
+-   Description: Specifies the target URL where API requests should be proxied to. This is particularly useful when running the frontend and backend on different ports or hosts during development.
+-   Example: VITE_HOST_URL=http://localhost:3000
+
+The proxy configuration:
+
+-   Forwards all `/api/*` requests to the backend server
+-   Handles CORS issues automatically
+-   Removes the `/api` prefix before forwarding requests
+-   Supports both HTTP and HTTPS backends
+
 ### Environment Setup 🌐
 
 Create a `.env` file in the root of the project directory and add the necessary environment variables. Refer to the `validateEnv` script for required variables:
 
 `sh cp .env.example .env # Edit .env with your environment-specific settings`
-
-`VITE_HOST_URL`
-
-- Default: A predefined default host URL mentioned in [getApiBaseUrlFile](https://github.com/autokitteh/web-platform/blob/main/src/utilities/getApiBaseUrl.utils.ts)
-- Description: Defines the backend URL that the application will use as its host. If not set, the application will use a default host URL.
-- Example: VITE_HOST_URL=http://localhost:1234
 
 `VITE_AUTH_ENABLED`
 

--- a/src/utilities/getApiBaseUrl.utils.ts
+++ b/src/utilities/getApiBaseUrl.utils.ts
@@ -9,5 +9,5 @@ export const getApiBaseUrl = (): string => {
 		return `https://${env}-api.${rest.join(".")}`;
 	}
 
-	return import.meta.env.VITE_HOST_URL || "http://localhost:9980";
+	return "/api";
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,5 +141,13 @@ export default defineConfig({
 		origin: process.env.VITE_DOMAIN_URL,
 		port: 8000,
 		strictPort: true,
+		proxy: {
+			"/api": {
+				target: process.env.VITE_HOST_URL || "http://localhost:9980",
+				changeOrigin: true,
+				secure: false,
+				rewrite: (path) => path.replace(/^\/api/, ""),
+			},
+		},
 	},
 });


### PR DESCRIPTION
## Description
Enable the UI to start with a webserver and proxy the requests to AK backend using the webserver instead of the UI talking directly to a different domain.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1069/add-support-of-the-backend-requests-proxy

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
