### PR TITLE
feat(UI-1067): add full text tooltip in events table cells on hover

### DIFF
--- a/src/components/organisms/events/table/row.tsx
+++ b/src/components/organisms/events/table/row.tsx
@@ -19,14 +19,18 @@ export const EventRow = memo(
 		style: CSSProperties;
 	}) => (
 		<Tr className="cursor-pointer pl-3 hover:bg-gray-750" onClick={onClick} style={style}>
-			<Td className="w-1/4">{moment(createdAt).local().format(dateTimeFormat)}</Td>
-			<Td className="w-1/4">
+			<Td className="w-1/4" title={moment(createdAt).local().format(dateTimeFormat)}>
+				{moment(createdAt).local().format(dateTimeFormat)}
+			</Td>
+			<Td className="w-1/4" title={eventId}>
 				<IdCopyButton id={eventId} />
 			</Td>
-			<Td className="w-1/4">
+			<Td className="w-1/4" title={destinationId || ""}>
 				<IdCopyButton id={destinationId || ""} />
 			</Td>
-			<Td className="w-1/4">{eventType}</Td>
+			<Td className="w-1/4" title={eventType}>
+				{eventType}
+			</Td>
 		</Tr>
 	)
 );


### PR DESCRIPTION
## Description
Events table - add ID tooltip on hover, since the full ID isn't displayed:
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/a47ef5af-b6e9-4835-a7a8-12217fda5c64" />


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1067/events-table-add-id-tooltip-on-hover

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
