### PR TITLE
fix(UI-1072): fix loader display on connection edit

### DIFF
--- a/src/components/organisms/connections/edit.tsx
+++ b/src/components/organisms/connections/edit.tsx
@@ -54,8 +54,8 @@ export const EditConnection = () => {
 		? integrationToEditComponent[integrationType as keyof typeof Integrations]
 		: null;
 
-	const connectionInfoClass = cn("invisible", { visible: connectionInfoLoaded });
-	const loaderClass = cn("visible", { invisible: connectionInfoLoaded });
+	const connectionInfoClass = cn(connectionInfoLoaded ? "visible" : "invisible");
+	const loaderClass = cn(connectionInfoLoaded ? "invisible" : "visible");
 
 	return (
 		<div className="min-w-80">

--- a/src/components/organisms/connections/edit.tsx
+++ b/src/components/organisms/connections/edit.tsx
@@ -54,8 +54,8 @@ export const EditConnection = () => {
 		? integrationToEditComponent[integrationType as keyof typeof Integrations]
 		: null;
 
-	const connectionInfoClass = cn(connectionInfoLoaded ? "visible" : "invisible");
-	const loaderClass = cn(connectionInfoLoaded ? "invisible" : "visible");
+	const connectionInfoClass = cn("invisible", { visible: connectionInfoLoaded });
+	const loaderClass = cn("visible", { invisible: connectionInfoLoaded });
 
 	return (
 		<div className="min-w-80">

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -79,9 +79,8 @@ export const IntegrationEditForm = ({
 		formsPerIntegrationsMapping[integrationType]?.[connectionType as ConnectionAuthType];
 
 	useEffect(() => {
-		if (ConnectionTypeComponent) {
-			dispacthConnectionInfoLoaded(true);
-		}
+		dispacthConnectionInfoLoaded(true);
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ConnectionTypeComponent]);
 


### PR DESCRIPTION
## Description
When we edit the connection, the loader won't switch to the connection details while it should:

![image](https://github.com/user-attachments/assets/04ec40e5-f3ba-4937-a7c0-d85dd176b971)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1072/loader-on-connection-edit-displayed-constantly

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
