### PR TITLE
fix(UI-1099): events table - change column width back relative to resolution

### DIFF
--- a/src/components/molecules/idCopyButton.tsx
+++ b/src/components/molecules/idCopyButton.tsx
@@ -8,10 +8,12 @@ import { Button } from "@components/atoms/buttons/button";
 import { CopyButton } from "@components/molecules/copyButton";
 
 export const IdCopyButton = ({
+	buttonClassName,
 	id,
 	onIdClick,
 	variant,
 }: {
+	buttonClassName?: string;
 	id: string;
 	onIdClick?: (id?: string) => void;
 	variant?: ButtonType;
@@ -22,7 +24,7 @@ export const IdCopyButton = ({
 
 	return (
 		<div className="flex flex-row items-center">
-			<Button onClick={() => onIdClick?.(id)} variant={variant}>
+			<Button className={buttonClassName} onClick={() => onIdClick?.(id)} variant={variant}>
 				{" "}
 				{id.substring(0, 8)}...
 			</Button>

--- a/src/components/organisms/events/table/header.tsx
+++ b/src/components/organisms/events/table/header.tsx
@@ -32,7 +32,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 	return (
 		<THead>
 			<Tr>
-				<Th className="mr-2 w-36 pl-4">
+				<Th className="mr-2 w-1/5 min-w-36 pl-4">
 					<SortableHeader
 						columnKey="createdAt"
 						columnLabel={t("createdAt")}
@@ -40,7 +40,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 						sortConfig={sortConfig}
 					/>
 				</Th>
-				<Th className="mr-2 w-24">
+				<Th className="mr-2 w-1/5 min-w-32">
 					<SortableHeader
 						columnKey="eventId"
 						columnLabel={t("eventId")}
@@ -48,7 +48,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 						sortConfig={sortConfig}
 					/>
 				</Th>
-				<Th className="mr-2 w-24">
+				<Th className="mr-2 w-1/5 min-w-32">
 					<SortableHeader
 						columnKey="destinationId"
 						columnLabel={t("sourceId")}
@@ -56,7 +56,7 @@ export const TableHeader = memo(({ onSort, sortConfig }: TableHeaderProps) => {
 						sortConfig={sortConfig}
 					/>
 				</Th>
-				<Th className="mr-2 w-1/4">
+				<Th className="mr-2 w-2/5 min-w-40">
 					<SortableHeader
 						columnKey="eventType"
 						columnLabel={t("type")}

--- a/src/components/organisms/events/table/row.tsx
+++ b/src/components/organisms/events/table/row.tsx
@@ -29,19 +29,29 @@ export const EventRow = memo(
 		return (
 			<Tr className={rowClass} style={style}>
 				<Td
-					className="mr-2 w-36 pl-4"
+					className="mr-2 w-1/5 min-w-36 pl-4"
 					onClick={onClick}
 					title={moment(createdAt).local().format(dateTimeFormat)}
 				>
 					{moment(createdAt).local().format(dateTimeFormat)}
 				</Td>
-				<Td className="mr-2 w-24" title={eventId}>
-					<IdCopyButton id={eventId} onIdClick={onClick} variant={ButtonVariant.flatText} />
+				<Td className="mr-2 w-1/5 min-w-32" title={eventId}>
+					<IdCopyButton
+						buttonClassName="pl-0"
+						id={eventId}
+						onIdClick={onClick}
+						variant={ButtonVariant.flatText}
+					/>
 				</Td>
-				<Td className="mr-2 w-24" title={destinationId || ""}>
-					<IdCopyButton id={destinationId || ""} onIdClick={onClick} variant={ButtonVariant.flatText} />
+				<Td className="mr-2 w-1/5 min-w-32" title={destinationId || ""}>
+					<IdCopyButton
+						buttonClassName="pl-0"
+						id={destinationId || ""}
+						onIdClick={onClick}
+						variant={ButtonVariant.flatText}
+					/>
 				</Td>
-				<Td className="w-1/4" onClick={onClick} title={eventType}>
+				<Td className="mr-2 w-2/5 min-w-40" onClick={onClick} title={eventType}>
 					<div className="truncate">{eventType}</div>
 				</Td>
 			</Tr>


### PR DESCRIPTION
## Description
Events table - change column width back to percent - In order to avoid states like this:

![image](https://github.com/user-attachments/assets/d0904e83-6342-4ef5-b996-fa5cc07cfe8b)

After:

2K:
![Screenshot 2024-12-19 at 11 52 08](https://github.com/user-attachments/assets/8da3f850-3cac-4f72-b5c2-03de3c9048f0)

1920px:
![Screenshot 2024-12-19 at 11 52 11](https://github.com/user-attachments/assets/a2352f4d-8dc8-4540-88c4-c3a32abedf78)

1440px:
![Screenshot 2024-12-19 at 11 52 18](https://github.com/user-attachments/assets/1fbaad15-501f-4246-9bab-851509af9951)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1099/events-table-change-column-width-back-to-percents

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
