### PR TITLE
fix(UI-1114): align triggers and connections tables

### DIFF
--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -209,7 +209,7 @@ export const ConnectionsTable = () => {
 									</Td>
 
 									<Td className="w-4/12">
-										<div className="inline">
+										<div className="inline truncate">
 											<ConnectionTableStatus status={status} />: {statusInfoMessage}
 										</div>
 									</Td>

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -192,9 +192,9 @@ export const ConnectionsTable = () => {
 						{sortedConnections.map(
 							({ connectionId, integrationName, logo, name, status, statusInfoMessage }) => (
 								<Tr className="group" key={connectionId}>
-									<Td className="w-1/4 pl-4 font-semibold">{name}</Td>
+									<Td className="w-1/4 pl-4 pr-2 font-semibold">{name}</Td>
 
-									<Td className="w-1/4">
+									<Td className="w-1/4 pr-2">
 										<div className="flex items-center gap-2" title={integrationName}>
 											{logo ? (
 												<IconSvg
@@ -204,7 +204,7 @@ export const ConnectionsTable = () => {
 												/>
 											) : null}
 
-											{integrationName}
+											<div className="truncate">{integrationName}</div>
 										</div>
 									</Td>
 

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -36,13 +36,13 @@ const useTableHeaders = (t: (key: string) => string): TableHeader[] => {
 			{
 				key: "sourceType",
 				label: t("table.columns.type"),
-				className: "w-2/12",
+				className: "w-3/12",
 				sortable: true,
 			},
 			{
 				key: "entrypoint",
 				label: t("table.columns.call"),
-				className: "w-4/12",
+				className: "w-3/12",
 				sortable: true,
 			},
 			{
@@ -191,20 +191,22 @@ export const TriggersTable = () => {
 								<Td className="w-4/12 pl-4 font-semibold" title={trigger.name}>
 									<div className="w-full overflow-hidden pr-2">{trigger.name}</div>
 								</Td>
-								<Td className="-ml-2 w-2/12 capitalize">
-									<Popover animation="slideFromBottom" interactionType="hover">
-										<PopoverTrigger>
-											<IconButton>
-												<IconSvg className="size-4" src={InfoIcon} />
-											</IconButton>
-										</PopoverTrigger>
-										<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
-											<InformationPopoverContent trigger={trigger} />
-										</PopoverContent>
-									</Popover>
-									{trigger?.sourceType}
+								<Td className="-ml-2 w-3/12 pr-2 capitalize">
+									<div className="flex items-center">
+										<Popover animation="slideFromBottom" interactionType="hover">
+											<PopoverTrigger>
+												<IconButton>
+													<IconSvg className="size-4" src={InfoIcon} />
+												</IconButton>
+											</PopoverTrigger>
+											<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
+												<InformationPopoverContent trigger={trigger} />
+											</PopoverContent>
+										</Popover>
+										<div className="truncate">{trigger?.sourceType}</div>
+									</div>
 								</Td>
-								<Td className="w-4/12 pl-2">{trigger.entrypoint}</Td>
+								<Td className="w-3/12 pl-2">{trigger.entrypoint}</Td>
 								<Td className="w-2/12 pr-0">
 									<div className="flex">
 										<IconButton

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -189,7 +189,7 @@ export const TriggersTable = () => {
 						{sortedTriggers.map((trigger) => (
 							<Tr className="group" key={trigger.triggerId}>
 								<Td className="w-4/12 pl-4 font-semibold" title={trigger.name}>
-									<div className="w-full overflow-hidden pr-2">{trigger.name}</div>
+									<div className="w-full overflow-hidden truncate pr-2">{trigger.name}</div>
 								</Td>
 								<Td className="-ml-2 w-3/12 pr-2 capitalize">
 									<div className="flex items-center">


### PR DESCRIPTION
## Description
Triggers: the type is not aligned with the information icon:

![image](https://github.com/user-attachments/assets/476a442e-7e24-40f7-997b-e0c1f35d1ef3)

In connections, the App column isn't truncated properly:

![image](https://github.com/user-attachments/assets/f4e97285-18ab-43f7-9904-b2bd4e97234b)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1114/align-triggers-and-connections-tables

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
