### PR TITLE
feat(UI-840): setup is autosave in user settings

### DIFF
--- a/src/components/atoms/checkbox.tsx
+++ b/src/components/atoms/checkbox.tsx
@@ -8,7 +8,7 @@ import { Loader } from "@components/atoms/loader";
 
 import { Check, Square } from "@assets/image/icons";
 
-export const Checkbox = ({ checked, className, isLoading, label, onChange, title }: CheckboxProps) => {
+export const Checkbox = ({ checked, className, isLoading, label, labelClassName, onChange, title }: CheckboxProps) => {
 	const id = useId();
 
 	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -19,6 +19,10 @@ export const Checkbox = ({ checked, className, isLoading, label, onChange, title
 	};
 
 	const checkboxClass = cn("inline-flex cursor-pointer items-center h-6 justify-center px-2", className);
+	const labelClass = cn(
+		"flex cursor-pointer items-center justify-center gap-2 text-sm text-gray-250",
+		labelClassName
+	);
 
 	return (
 		<div className={checkboxClass} title={title}>
@@ -32,11 +36,7 @@ export const Checkbox = ({ checked, className, isLoading, label, onChange, title
 
 			<div className="relative flex select-none items-center" onKeyDown={handleKeyDown} role="presentation">
 				{label ? (
-					<label
-						aria-checked={checked}
-						className="flex cursor-pointer items-center justify-center gap-2 text-sm text-gray-250"
-						htmlFor={id}
-					>
+					<label aria-checked={checked} className={labelClass} htmlFor={id}>
 						{isLoading ? (
 							<Loader size="sm" />
 						) : (

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 
 import Editor, { Monaco } from "@monaco-editor/react";
-import Cookies from "js-cookie";
 import { debounce, last } from "lodash";
 import moment from "moment";
 import { useTranslation } from "react-i18next";
@@ -33,7 +32,7 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 	const languageEditor = monacoLanguages[fileExtension as keyof typeof monacoLanguages];
 
 	const [content, setContent] = useState("");
-	const autosaveMode = Cookies.get("codeManualSave") === "false";
+	const autosaveMode = localStorage.getItem("codeManualSave") === "false";
 	const [loadingSave, setLoadingSave] = useState(false);
 	const [lastSaved, setLastSaved] = useState<string>();
 

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 
 import Editor, { Monaco } from "@monaco-editor/react";
+import Cookies from "js-cookie";
 import { debounce, last } from "lodash";
 import moment from "moment";
 import { useTranslation } from "react-i18next";
@@ -13,7 +14,7 @@ import { cn } from "@utilities";
 
 import { useFileOperations } from "@hooks";
 
-import { Button, Checkbox, IconButton, IconSvg, Loader, Spinner, Tab } from "@components/atoms";
+import { Button, IconButton, IconSvg, Loader, Spinner, Tab, Typography } from "@components/atoms";
 
 import { AKRoundLogo } from "@assets/image";
 import { Close, CompressIcon, ExpandIcon, SaveIcon } from "@assets/image/icons";
@@ -32,7 +33,7 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 	const languageEditor = monacoLanguages[fileExtension as keyof typeof monacoLanguages];
 
 	const [content, setContent] = useState("");
-	const [autosaveMode, setAutosaveMode] = useState(true);
+	const autosaveMode = Cookies.get("codeManualSave") === "false";
 	const [loadingSave, setLoadingSave] = useState(false);
 	const [lastSaved, setLastSaved] = useState<string>();
 
@@ -231,7 +232,17 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 								title={lastSaved ? `${t("lastSaved")}:${lastSaved}` : ""}
 							>
 								<div className="inline-flex items-center gap-2 rounded-3xl border border-gray-1000 p-1">
-									{autosaveMode ? null : (
+									{autosaveMode ? (
+										<Button
+											className="py-1"
+											disabled={loadingSave}
+											onClick={() => debouncedManualSave(content)}
+											variant="flatText"
+										>
+											{loadingSave ? <Loader className="mr-1" size="sm" /> : null}
+											<Typography size="small">{t("autoSave")}</Typography>
+										</Button>
+									) : (
 										<Button
 											className="h-6 whitespace-nowrap px-4 py-1"
 											disabled={loadingSave}
@@ -243,12 +254,6 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 											<div className="mt-0.5">{t("buttons.save")}</div>
 										</Button>
 									)}
-									<Checkbox
-										checked={autosaveMode}
-										isLoading={autosaveMode ? loadingSave : false}
-										label={t("autoSave")}
-										onChange={() => setAutosaveMode((prevAutosave) => !prevAutosave)}
-									/>
 								</div>
 								<IconButton className="hover:bg-gray-1100" onClick={onExpand}>
 									{isExpanded ? (

--- a/src/components/organisms/settings/profile/profile.tsx
+++ b/src/components/organisms/settings/profile/profile.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
+import Cookies from "js-cookie";
 import { useTranslation } from "react-i18next";
 
 import { version } from "@constants";
@@ -7,7 +8,7 @@ import { ModalName } from "@enums/components";
 
 import { useModalStore, useToastStore, useUserStore } from "@store";
 
-import { Button, Typography } from "@components/atoms";
+import { Button, Checkbox, Typography } from "@components/atoms";
 import { DeleteAccountModal } from "@components/organisms/settings/profile";
 
 import { TrashIcon } from "@assets/image/icons";
@@ -17,6 +18,8 @@ export const Profile = () => {
 	const { getLoggedInUser, user } = useUserStore();
 	const { closeModal, openModal } = useModalStore();
 	const addToast = useToastStore((state) => state.addToast);
+	const codeManualSave = Cookies.get("codeManualSave") === "true";
+	const [codeManualSaveChecked, setcodeManualSaveChecked] = useState(!!codeManualSave);
 
 	const loadUser = async () => {
 		const error = await getLoggedInUser();
@@ -44,6 +47,11 @@ export const Profile = () => {
 		openModal(ModalName.deleteAccount, {});
 	};
 
+	const handleCodeManualSaveChange = (checked: boolean) => {
+		Cookies.set("codeManualSave", checked.toString());
+		setcodeManualSaveChecked(checked);
+	};
+
 	return (
 		<div className="flex h-full flex-col font-averta">
 			<Typography className="mb-9 font-bold" element="h1" size="2xl">
@@ -66,6 +74,19 @@ export const Profile = () => {
 			</Typography>
 			<Typography className="mt-1.5" element="p" size="1.5xl">
 				{t("retentionPolicyDescription")}
+			</Typography>
+			<Typography className="mt-9" element="p">
+				{t("codeManualSaveTitle")}
+			</Typography>
+			<Typography className="mt-1.5" element="p" size="1.5xl">
+				<Checkbox
+					checked={!!codeManualSaveChecked}
+					className="-ml-2"
+					isLoading={false}
+					label={t("codeManualSaveDescription")}
+					labelClassName="text-1.5xl"
+					onChange={handleCodeManualSaveChange}
+				/>
 			</Typography>
 			<div className="mt-9">
 				<Button

--- a/src/components/organisms/settings/profile/profile.tsx
+++ b/src/components/organisms/settings/profile/profile.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 
-import Cookies from "js-cookie";
 import { useTranslation } from "react-i18next";
 
 import { version } from "@constants";
@@ -18,7 +17,7 @@ export const Profile = () => {
 	const { getLoggedInUser, user } = useUserStore();
 	const { closeModal, openModal } = useModalStore();
 	const addToast = useToastStore((state) => state.addToast);
-	const codeManualSave = Cookies.get("codeManualSave") === "true";
+	const codeManualSave = localStorage.getItem("codeManualSave") === "true";
 	const [codeManualSaveChecked, setcodeManualSaveChecked] = useState(!!codeManualSave);
 
 	const loadUser = async () => {
@@ -48,7 +47,7 @@ export const Profile = () => {
 	};
 
 	const handleCodeManualSaveChange = (checked: boolean) => {
-		Cookies.set("codeManualSave", checked.toString());
+		localStorage.setItem("codeManualSave", checked.toString());
 		setcodeManualSaveChecked(checked);
 	};
 

--- a/src/interfaces/components/checkbox.interface.ts
+++ b/src/interfaces/components/checkbox.interface.ts
@@ -5,4 +5,5 @@ export interface CheckboxProps {
 	title?: string;
 	className?: string;
 	isLoading: boolean;
+	labelClassName?: string;
 }

--- a/src/locales/en/settings/translation.json
+++ b/src/locales/en/settings/translation.json
@@ -31,7 +31,9 @@
 		"deleteAccount": "Delete My Account",
 		"accountFetchError": "Error occurred during the account fetch, try again later",
 		"retentionPolicyTitle": "Retention Policy",
-		"retentionPolicyDescription": "We will keep your data for 3 days"
+		"retentionPolicyDescription": "We will keep your data for 3 days",
+		"codeManualSaveTitle": "Code Manual Save",
+		"codeManualSaveDescription": "Save your code manually instead of autosave"
 	},
 	"topbar": {
 		"personalSettings": "Personal Settings",


### PR DESCRIPTION
## Description
Autosave - Move the definition to user setting, save the definition in cookies, and display only the selected variant - autosave or manual save.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-840/autosave-move-the-definition-to-user-setting

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
