### PR TITLE
feat(UI-1050): id copy button breakdown to suffix and prefix

### DIFF
--- a/src/components/molecules/idCopyButton.tsx
+++ b/src/components/molecules/idCopyButton.tsx
@@ -19,11 +19,15 @@ export const IdCopyButton = ({
 	const { t } = useTranslation("components", { keyPrefix: "buttons" });
 
 	const successMessage = t("copied");
+	const idPrefix = id.split("_")[0];
+	const idSuffix = id.split("_")[1];
+	const idSuffixEnd = idSuffix.substring(idSuffix.length - 3, idSuffix.length);
+	const idStr = `${idPrefix}...${idSuffixEnd}`;
 
 	return (
 		<div className="flex flex-row items-center">
 			<Button className={buttonClassName} variant={variant}>
-				{id.substring(0, 8)}...
+				{idStr}
 			</Button>
 			<CopyButton className="mb-0.5" size="sm" successMessage={successMessage} text={id} />
 		</div>


### PR DESCRIPTION
## Description
It is not useful to display just a few letters from the ID, which are the same for all entities anyway. 
Display the prefix, and the last three characters instead.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1050/events-page-badly-truncated-columns

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
