### PR TITLE
refactor(UI-1115): move the info icon to the actions column in triggers table

### DIFF
--- a/src/components/atoms/table/tD.tsx
+++ b/src/components/atoms/table/tD.tsx
@@ -20,7 +20,7 @@ export const Td = ({ children, className, onClick, title }: TableProps) => {
 	return (
 		<div aria-label={cellTitle} className={tdStyle} role="cell" title={cellTitle}>
 			<div className="flex w-full items-center" onClick={onClick} onKeyDown={handleKeyDown}>
-				<div className="w-full truncate">{children}</div>
+				<div className="w-full truncate pr-2">{children}</div>
 			</div>
 		</div>
 	);

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -191,36 +191,34 @@ export const TriggersTable = () => {
 								<Td className="w-4/12 pl-4 font-semibold">{trigger.name}</Td>
 								<Td className="w-2/12 pr-2 capitalize">{trigger?.sourceType}</Td>
 								<Td className="w-4/12">{trigger.entrypoint}</Td>
-								<Td className="w-2/12 pr-0">
-									<div className="flex">
-										<Popover animation="slideFromBottom" interactionType="hover">
-											<PopoverTrigger>
-												<IconButton>
-													<IconSvg className="size-4" src={InfoIcon} />
-												</IconButton>
-											</PopoverTrigger>
-											<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
-												<InformationPopoverContent trigger={trigger} />
-											</PopoverContent>
-										</Popover>
-										<IconButton
-											ariaLabel={t("table.buttons.ariaModifyTrigger", {
-												name: trigger.name,
-											})}
-											className="size-8"
-											onClick={() => handleAction("edit", trigger.triggerId!)}
-										>
-											<EditIcon className="size-3 fill-white" />
-										</IconButton>
-										<IconButton
-											ariaLabel={t("table.buttons.ariaDeleteTrigger", {
-												name: trigger.name,
-											})}
-											onClick={() => handleOpenModalDeleteTrigger(trigger.triggerId!)}
-										>
-											<TrashIcon className="size-4 stroke-white" />
-										</IconButton>
-									</div>
+								<Td className="w-2/12">
+									<Popover animation="slideFromBottom" interactionType="hover">
+										<PopoverTrigger>
+											<IconButton>
+												<IconSvg className="size-4" src={InfoIcon} />
+											</IconButton>
+										</PopoverTrigger>
+										<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
+											<InformationPopoverContent trigger={trigger} />
+										</PopoverContent>
+									</Popover>
+									<IconButton
+										ariaLabel={t("table.buttons.ariaModifyTrigger", {
+											name: trigger.name,
+										})}
+										className="size-8"
+										onClick={() => handleAction("edit", trigger.triggerId!)}
+									>
+										<EditIcon className="size-3 fill-white" />
+									</IconButton>
+									<IconButton
+										ariaLabel={t("table.buttons.ariaDeleteTrigger", {
+											name: trigger.name,
+										})}
+										onClick={() => handleOpenModalDeleteTrigger(trigger.triggerId!)}
+									>
+										<TrashIcon className="size-4 stroke-white" />
+									</IconButton>
 								</Td>
 							</Tr>
 						))}

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -36,13 +36,13 @@ const useTableHeaders = (t: (key: string) => string): TableHeader[] => {
 			{
 				key: "sourceType",
 				label: t("table.columns.type"),
-				className: "w-3/12",
+				className: "w-2/12",
 				sortable: true,
 			},
 			{
 				key: "entrypoint",
 				label: t("table.columns.call"),
-				className: "w-3/12",
+				className: "w-4/12",
 				sortable: true,
 			},
 			{
@@ -188,11 +188,9 @@ export const TriggersTable = () => {
 					<TBody>
 						{sortedTriggers.map((trigger) => (
 							<Tr className="group" key={trigger.triggerId}>
-								<Td className="w-4/12 pl-4 font-semibold" title={trigger.name}>
-									<div className="w-full overflow-hidden truncate pr-2">{trigger.name}</div>
-								</Td>
-								<Td className="-ml-2 w-3/12 pr-2 capitalize">{trigger?.sourceType}</Td>
-								<Td className="w-4/12 pl-2">{trigger.entrypoint}</Td>
+								<Td className="w-4/12 pl-4 font-semibold">{trigger.name}</Td>
+								<Td className="w-2/12 pr-2 capitalize">{trigger?.sourceType}</Td>
+								<Td className="w-4/12">{trigger.entrypoint}</Td>
 								<Td className="w-2/12 pr-0">
 									<div className="flex">
 										<Popover animation="slideFromBottom" interactionType="hover">

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -189,7 +189,7 @@ export const TriggersTable = () => {
 						{sortedTriggers.map((trigger) => (
 							<Tr className="group" key={trigger.triggerId}>
 								<Td className="w-4/12 pl-4 font-semibold">{trigger.name}</Td>
-								<Td className="w-2/12 pr-2 capitalize">{trigger?.sourceType}</Td>
+								<Td className="w-2/12 capitalize">{trigger?.sourceType}</Td>
 								<Td className="w-4/12">{trigger.entrypoint}</Td>
 								<Td className="w-2/12">
 									<Popover animation="slideFromBottom" interactionType="hover">

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -191,8 +191,10 @@ export const TriggersTable = () => {
 								<Td className="w-4/12 pl-4 font-semibold" title={trigger.name}>
 									<div className="w-full overflow-hidden truncate pr-2">{trigger.name}</div>
 								</Td>
-								<Td className="-ml-2 w-3/12 pr-2 capitalize">
-									<div className="flex items-center">
+								<Td className="-ml-2 w-3/12 pr-2 capitalize">{trigger?.sourceType}</Td>
+								<Td className="w-4/12 pl-2">{trigger.entrypoint}</Td>
+								<Td className="w-2/12 pr-0">
+									<div className="flex">
 										<Popover animation="slideFromBottom" interactionType="hover">
 											<PopoverTrigger>
 												<IconButton>
@@ -203,12 +205,6 @@ export const TriggersTable = () => {
 												<InformationPopoverContent trigger={trigger} />
 											</PopoverContent>
 										</Popover>
-										<div className="truncate">{trigger?.sourceType}</div>
-									</div>
-								</Td>
-								<Td className="w-3/12 pl-2">{trigger.entrypoint}</Td>
-								<Td className="w-2/12 pr-0">
-									<div className="flex">
 										<IconButton
 											ariaLabel={t("table.buttons.ariaModifyTrigger", {
 												name: trigger.name,


### PR DESCRIPTION
## Description
Triggers - Move the information icon with popper to the actions columns

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1115/triggers-move-the-information-icon-with-popper-to-the-actions-columns

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
