### PR TITLE
feat(UI-1068): add connection id in popover in connections table

### DIFF
--- a/src/components/atoms/buttons/button.tsx
+++ b/src/components/atoms/buttons/button.tsx
@@ -16,6 +16,7 @@ export const Button = ({
 	onClick,
 	onKeyPressed,
 	style,
+	tabIndex,
 	title,
 	type = "button",
 	variant,
@@ -50,6 +51,7 @@ export const Button = ({
 			onClick={onClick}
 			onKeyDown={onKeyDown}
 			style={style}
+			tabIndex={tabIndex}
 			title={title}
 			type={type}
 		>

--- a/src/components/molecules/copyButton.tsx
+++ b/src/components/molecules/copyButton.tsx
@@ -15,12 +15,14 @@ export const CopyButton = ({
 	className,
 	size = "md",
 	successMessage,
+	tabIndex = 0,
 	text,
 	title,
 }: {
 	className?: string;
 	size?: Extract<SystemSizes, "xs" | "sm" | "md">;
 	successMessage?: string;
+	tabIndex?: number;
 	text: string;
 	title?: string;
 }) => {
@@ -60,7 +62,7 @@ export const CopyButton = ({
 				copyTextToClipboard(text);
 			}}
 			onKeyPressed={() => copyTextToClipboard(text)}
-			tabIndex={0}
+			tabIndex={tabIndex}
 			title={title}
 			type="button"
 		>

--- a/src/components/molecules/idCopyButton.tsx
+++ b/src/components/molecules/idCopyButton.tsx
@@ -9,10 +9,12 @@ import { CopyButton } from "@components/molecules/copyButton";
 
 export const IdCopyButton = ({
 	buttonClassName,
+	displayFullLength,
 	id,
 	variant,
 }: {
 	buttonClassName?: string;
+	displayFullLength?: boolean;
 	id: string;
 	variant?: ButtonType;
 }) => {
@@ -27,7 +29,7 @@ export const IdCopyButton = ({
 	return (
 		<div className="flex flex-row items-center">
 			<Button className={buttonClassName} tabIndex={-1} variant={variant}>
-				{idStr}
+				{displayFullLength ? id : idStr}
 			</Button>
 			<CopyButton className="mb-0.5" size="sm" successMessage={successMessage} tabIndex={0} text={id} />
 		</div>

--- a/src/components/molecules/idCopyButton.tsx
+++ b/src/components/molecules/idCopyButton.tsx
@@ -26,10 +26,10 @@ export const IdCopyButton = ({
 
 	return (
 		<div className="flex flex-row items-center">
-			<Button className={buttonClassName} variant={variant}>
+			<Button className={buttonClassName} tabIndex={-1} variant={variant}>
 				{idStr}
 			</Button>
-			<CopyButton className="mb-0.5" size="sm" successMessage={successMessage} text={id} />
+			<CopyButton className="mb-0.5" size="sm" successMessage={successMessage} tabIndex={0} text={id} />
 		</div>
 	);
 };

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -230,7 +230,19 @@ export const ConnectionsTable = () => {
 													</IconButton>
 												</PopoverTrigger>
 												<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
-													<IdCopyButton id={connectionId} variant="flatText" />
+													<div className="flex flex-col">
+														<div className="mb-2 font-semibold">
+															{t("table.popover.titleInfo")}
+														</div>
+														<div className="flex items-center">
+															{t("table.popover.connectionId")}:
+															<IdCopyButton
+																displayFullLength
+																id={connectionId}
+																variant="flatText"
+															/>
+														</div>
+													</div>
 												</PopoverContent>
 											</Popover>
 											<IconButton

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -18,12 +18,19 @@ import {
 } from "@store";
 
 import { Button, IconButton, IconSvg, Loader, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
-import { ConnectionTableStatus, EmptyTableAddButton, SortButton } from "@components/molecules";
+import {
+	ConnectionTableStatus,
+	EmptyTableAddButton,
+	IdCopyButton,
+	PopoverTrigger,
+	SortButton,
+} from "@components/molecules";
+import { Popover, PopoverContent } from "@components/molecules/popover/index";
 import { ActiveDeploymentWarningModal } from "@components/organisms";
 import { DeleteConnectionModal } from "@components/organisms/connections";
 
 import { PlusCircle } from "@assets/image";
-import { EditIcon, TrashIcon } from "@assets/image/icons";
+import { EditIcon, InfoIcon, TrashIcon } from "@assets/image/icons";
 
 export const ConnectionsTable = () => {
 	const { t: tErrors } = useTranslation("errors");
@@ -216,6 +223,16 @@ export const ConnectionsTable = () => {
 
 									<Td className="w-2/12">
 										<div className="flex space-x-1">
+											<Popover animation="slideFromBottom" interactionType="hover">
+												<PopoverTrigger>
+													<IconButton>
+														<IconSvg className="size-4" src={InfoIcon} />
+													</IconButton>
+												</PopoverTrigger>
+												<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
+													<IdCopyButton id={connectionId} variant="flatText" />
+												</PopoverContent>
+											</Popover>
 											<IconButton
 												ariaLabel={t("table.buttons.titleEditConnection")}
 												className="size-8 p-1.5"

--- a/src/locales/en/tabs/translation.json
+++ b/src/locales/en/tabs/translation.json
@@ -50,6 +50,10 @@
 				"ok": "OK",
 				"unspecified": "Unspecified",
 				"warning": "Warning"
+			},
+			"popover": {
+				"titleInfo": "Connection Information",
+				"connectionId": "Connection ID"
 			}
 		},
 		"titleAvailable": "Connections",


### PR DESCRIPTION
## Description
Display Connection ID in the connections table as an information popover:
![image](https://github.com/user-attachments/assets/7565fbe4-5f38-449b-a2cc-05ef81321714)


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1068/connections-table-add-connection-id-column

## What type of PR is this? (check all applicable)

-   [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
