### PR TITLE
fix(UI-1118): enable working on multiple projects in different windows

### DIFF
--- a/src/components/organisms/dashboard/templates/tabs/createModal.tsx
+++ b/src/components/organisms/dashboard/templates/tabs/createModal.tsx
@@ -30,7 +30,7 @@ export const ProjectTemplateCreateModal = ({ cardTemplate, category }: CreatePro
 	const { closeModal } = useModalStore();
 	const { createProjectFromAsset } = useCreateProjectFromTemplate();
 	const { projectsList } = useProjectStore();
-	const { getTemplateFiles } = useTemplatesStore();
+	const { getFilesForTemplate } = useTemplatesStore();
 
 	const projectNamesSet = useMemo(() => new Set(projectsList.map((project) => project.name)), [projectsList]);
 
@@ -56,7 +56,7 @@ export const ProjectTemplateCreateModal = ({ cardTemplate, category }: CreatePro
 
 	const fetchManifestData = async () => {
 		if (!assetDirectory) return;
-		const content = await getTemplateFiles(assetDirectory);
+		const content = await getFilesForTemplate(assetDirectory);
 
 		if (!content["README.md"]) {
 			setReadme("");

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -42,8 +42,7 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 
 			return;
 		}
-		const byteArray = Array.from(resource);
-		setContent(new TextDecoder().decode(new Uint8Array(byteArray)));
+		setContent(new TextDecoder().decode(resource));
 	};
 
 	const location = useLocation();

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -72,6 +72,7 @@ export const EditorTabs = ({ isExpanded, onExpand }: { isExpanded: boolean; onEx
 	};
 
 	useEffect(() => {
+		if (!activeEditorFileName) return;
 		if (currentProjectId !== projectId) {
 			loadContent();
 

--- a/src/hooks/useCreateProjectFromTemplate.tsx
+++ b/src/hooks/useCreateProjectFromTemplate.tsx
@@ -53,8 +53,8 @@ export const useCreateProjectFromTemplate = () => {
 
 	const createProjectFromTemplate = async (template: TemplateMetadata, projectName?: string) => {
 		try {
-			const files = await templateStorage.getTemplateFiles(template.assetDirectory);
-			const manifestData = files["autokitteh.yaml"];
+			const files = await templateStorage?.getTemplateFiles(template.assetDirectory);
+			const manifestData = files?.["autokitteh.yaml"];
 			if (!manifestData) {
 				addToast({
 					message: tActions("projectCreationFailed"),

--- a/src/interfaces/store/cacheStore.interface.ts
+++ b/src/interfaces/store/cacheStore.interface.ts
@@ -56,4 +56,5 @@ export interface CacheStore {
 	fetchVariables: (projectId: string, force?: boolean) => Promise<void | Variable[]>;
 	fetchEvents: (force?: boolean) => Promise<void | BaseEvent[]>;
 	fetchConnections: (projectId: string, force?: boolean) => Promise<void | Connection[]>;
+	reset: (type: "resources" | "connections" | "deployments" | "triggers" | "variables") => void;
 }

--- a/src/interfaces/store/templates.interface.ts
+++ b/src/interfaces/store/templates.interface.ts
@@ -65,8 +65,10 @@ export interface TemplateState {
 	error: string | null;
 	lastCommitDate?: string;
 	lastCheckDate?: Date;
-	templateStorage: TemplateStorageService;
+	templateStorage: TemplateStorageService | undefined;
 	fetchTemplates: () => Promise<void>;
 	findTemplateByAssetDirectory: (assetDirectory: string) => TemplateMetadata | undefined;
-	getTemplateFiles: (assetDirectory: string) => Promise<Record<string, string>>;
+	getFilesForTemplate: (assetDirectory: string) => Promise<Record<string, string>>;
+	getTemplateStorage: () => TemplateStorageService;
+	reset: () => void;
 }

--- a/src/interfaces/store/templates.interface.ts
+++ b/src/interfaces/store/templates.interface.ts
@@ -65,7 +65,7 @@ export interface TemplateState {
 	error: string | null;
 	lastCommitDate?: string;
 	lastCheckDate?: Date;
-	templateStorage: TemplateStorageService | undefined;
+	templateStorage?: TemplateStorageService;
 	fetchTemplates: () => Promise<void>;
 	findTemplateByAssetDirectory: (assetDirectory: string) => TemplateMetadata | undefined;
 	getFilesForTemplate: (assetDirectory: string) => Promise<Record<string, string>>;

--- a/src/locales/en/dashboard/translation.json
+++ b/src/locales/en/dashboard/translation.json
@@ -31,7 +31,11 @@
         "deleteProjectSuccessExtended": "Project deletion completed successfully, project name: {{projectName}}, project ID: {{projectId}}"
 	},
 	"templates":{
-		"title": "Start From Template"
+		"title": "Start From Template",
+		"projectCreationFailedExtended": "Project creation failed, error: {{error}}",
+		"projectTemplateManifestNotFound": "Project template manifest not found"
+
+
 	},
 	"projects": {
 		"table": {

--- a/src/services/indexedDb.service.ts
+++ b/src/services/indexedDb.service.ts
@@ -14,7 +14,7 @@ export class IndexedDBService {
 
 	async InitDB(projectId: string) {
 		const storeName = this.storeName;
-		this.db = await openDB(this.dbName, 4, {
+		this.db = await openDB(this.dbName, 5, {
 			upgrade: async (db) => {
 				if (db.objectStoreNames.contains(storeName)) {
 					db.deleteObjectStore(storeName);

--- a/src/services/indexedDb.service.ts
+++ b/src/services/indexedDb.service.ts
@@ -14,7 +14,7 @@ export class IndexedDBService {
 
 	async InitDB(projectId: string) {
 		const storeName = this.storeName;
-		this.db = await openDB(this.dbName, 16, {
+		this.db = await openDB(this.dbName, 5, {
 			upgrade: async (db) => {
 				if (db.objectStoreNames.contains(storeName)) {
 					db.deleteObjectStore(storeName);
@@ -64,7 +64,13 @@ export class IndexedDBService {
 		await this.EnsureDBInitialized(projectId);
 		const existingProject = await this.db.get(this.storeName, projectId);
 		if (existingProject) {
-			const updatedFiles = [...existingProject.files, ...files];
+			const updatedFiles = existingProject.files
+				.filter(
+					(existingFile: { content: Uint8Array; name: string }) =>
+						!files.some((newFile) => newFile.name === existingFile.name)
+				)
+				.concat(files);
+
 			await this.db.put(this.storeName, { projectId, files: updatedFiles });
 
 			return;

--- a/src/services/indexedDb.service.ts
+++ b/src/services/indexedDb.service.ts
@@ -1,5 +1,7 @@
 import { openDB } from "idb";
 
+import { useCacheStore, useTemplatesStore } from "@src/store";
+
 export class IndexedDBService {
 	private dbName: string;
 	private storeName: string;
@@ -10,26 +12,44 @@ export class IndexedDBService {
 		this.storeName = storeName;
 	}
 
-	async InitDB() {
+	async InitDB(projectId: string) {
 		const storeName = this.storeName;
-		this.db = await openDB(this.dbName, 2, {
-			upgrade(db) {
-				if (!db.objectStoreNames.contains(storeName)) {
-					db.createObjectStore(storeName, { keyPath: "projectId" });
+		this.db = await openDB(this.dbName, 4, {
+			upgrade: async (db) => {
+				if (db.objectStoreNames.contains(storeName)) {
+					db.deleteObjectStore(storeName);
+					if (storeName === "templates") {
+						useTemplatesStore.getState().reset();
+					}
+					if (storeName === "resources") {
+						useCacheStore.getState().reset("resources");
+					}
+				}
+
+				db.createObjectStore(storeName, { keyPath: "projectId" });
+
+				if (storeName === "templates") {
+					const { fetchTemplates } = useTemplatesStore.getState();
+					await fetchTemplates();
+				}
+				if (storeName === "resources") {
+					const { fetchResources } = useCacheStore.getState();
+					await fetchResources(projectId);
 				}
 			},
 		});
 	}
 
-	async EnsureDBInitialized() {
+	async EnsureDBInitialized(projectId: string) {
 		if (!this.db) {
-			await this.InitDB();
+			await this.InitDB(projectId);
 		}
 	}
 
 	async getAll(projectId: string) {
-		await this.EnsureDBInitialized();
+		await this.EnsureDBInitialized(projectId);
 		if (!projectId) return;
+
 		const items = await this.db.get(this.storeName, projectId);
 		if (!items?.files) return;
 		const result: Record<string, Uint8Array> = {};
@@ -41,7 +61,7 @@ export class IndexedDBService {
 	}
 
 	async put(projectId: string, files: { content: Uint8Array; name: string }[]) {
-		await this.EnsureDBInitialized();
+		await this.EnsureDBInitialized(projectId);
 		const existingProject = await this.db.get(this.storeName, projectId);
 		if (existingProject) {
 			const updatedFiles = [...existingProject.files, ...files];
@@ -53,21 +73,21 @@ export class IndexedDBService {
 	}
 
 	async delete(projectId: string, name: string) {
-		await this.EnsureDBInitialized();
+		await this.EnsureDBInitialized(projectId);
 		const items = await this.db.get(this.storeName, projectId);
 		const updatedFiles = items.filter((item: { name: string }) => item.name !== name);
 		await this.db.put(this.storeName, { projectId, files: updatedFiles });
 	}
 
 	async clearStore() {
-		await this.EnsureDBInitialized();
+		await this.EnsureDBInitialized("");
 		const tx = this.db.transaction(this.storeName, "readwrite");
 		await tx.objectStore(this.storeName).clear();
 		await tx.done;
 	}
 
 	async getFilesByProjectId(projectId: string): Promise<{ content: Uint8Array; name: string }[]> {
-		await this.EnsureDBInitialized();
+		await this.EnsureDBInitialized(projectId);
 		const allEntries = await this.db.getAll(this.storeName);
 		const projectFiles = allEntries.find((entry: { projectId: string }) => entry.projectId === projectId);
 

--- a/src/services/indexedDb.service.ts
+++ b/src/services/indexedDb.service.ts
@@ -46,9 +46,10 @@ export class IndexedDBService {
 		if (existingProject) {
 			const updatedFiles = [...existingProject.files, ...files];
 			await this.db.put(this.storeName, { projectId, files: updatedFiles });
-		} else {
-			await this.db.put(this.storeName, { projectId, files });
+
+			return;
 		}
+		await this.db.put(this.storeName, { projectId, files });
 	}
 
 	async delete(projectId: string, name: string) {

--- a/src/services/indexedDb.service.ts
+++ b/src/services/indexedDb.service.ts
@@ -14,7 +14,7 @@ export class IndexedDBService {
 
 	async InitDB(projectId: string) {
 		const storeName = this.storeName;
-		this.db = await openDB(this.dbName, 5, {
+		this.db = await openDB(this.dbName, 16, {
 			upgrade: async (db) => {
 				if (db.objectStoreNames.contains(storeName)) {
 					db.deleteObjectStore(storeName);

--- a/src/store/cache/useCacheStore.ts
+++ b/src/store/cache/useCacheStore.ts
@@ -48,6 +48,7 @@ const initialState: Omit<
 	| "fetchResources"
 	| "initCache"
 	| "checkState"
+	| "reset"
 > = {
 	loading: {
 		deployments: false,
@@ -171,6 +172,14 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 				loading: { ...state.loading, resourses: false },
 			}));
 		}
+	},
+
+	reset: async (type: "resources" | "connections" | "deployments" | "triggers" | "variables") => {
+		set((state) => ({
+			...state,
+			loading: { ...state.loading, [type]: false },
+			[type]: undefined,
+		}));
 	},
 
 	fetchDeployments: async (projectId, force) => {

--- a/src/store/cache/useCacheStore.ts
+++ b/src/store/cache/useCacheStore.ts
@@ -119,7 +119,7 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 	fetchResources: async (projectId, force) => {
 		const dbService = new IndexedDBService("ProjectDB", "resources");
 
-		const resourcesDB = await dbService.getAll();
+		const resourcesDB = await dbService.getAll(projectId);
 		const { currentProjectId } = get();
 
 		if (currentProjectId === projectId && !force) {
@@ -142,10 +142,11 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 
 				return;
 			}
-			await dbService.clearStore();
+			const files = [];
 			for (const [name, content] of Object.entries(resources || {})) {
-				await dbService.put(name, new Uint8Array(content));
+				files.push({ name, content: new Uint8Array(content) });
 			}
+			await dbService.put(projectId, files);
 
 			if (resources) {
 				get().checkState(projectId, { resources });

--- a/src/store/cache/useCacheStore.ts
+++ b/src/store/cache/useCacheStore.ts
@@ -174,7 +174,7 @@ const store: StateCreator<CacheStore> = (set, get) => ({
 		}
 	},
 
-	reset: async (type: "resources" | "connections" | "deployments" | "triggers" | "variables") => {
+	reset: async (type) => {
 		set((state) => ({
 			...state,
 			loading: { ...state.loading, [type]: false },

--- a/src/store/useTemplatesStore.ts
+++ b/src/store/useTemplatesStore.ts
@@ -53,12 +53,13 @@ const store = (set: any, get: any): TemplateState => ({
 
 	getTemplateStorage: () => {
 		const { templateStorage } = get();
-		if (!templateStorage) {
-			const storage = new TemplateStorageService();
-			set({ templateStorage: storage });
+		if (templateStorage) {
+			return templateStorage;
 		}
+		const storage = new TemplateStorageService();
+		set({ templateStorage: storage });
 
-		return templateStorage;
+		return storage;
 	},
 
 	fetchTemplates: async () => {

--- a/src/store/useTemplatesStore.ts
+++ b/src/store/useTemplatesStore.ts
@@ -195,11 +195,11 @@ const store = (set: any, get: any): TemplateState => ({
 		}
 	},
 
-	findTemplateByAssetDirectory: (assetDirectory: string) => {
+	findTemplateByAssetDirectory: (assetDirectory) => {
 		return get().templateMap[assetDirectory];
 	},
 
-	getFilesForTemplate: async (assetDirectory: string) => {
+	getFilesForTemplate: async (assetDirectory) => {
 		const { getTemplateStorage } = get();
 		const templateStorage = getTemplateStorage();
 


### PR DESCRIPTION
## Description
Currently we keep only 1 project files in IndexedDB, but if we work with more than 1 window, we have to keep all files for all opened projects.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1118/enable-to-work-with-multiple-windows-on-multiple-projects

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
