### PR TITLE
fix(UI-1119): manual run activate previous project

### DIFF
--- a/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
@@ -69,7 +69,7 @@ export const ManualRunButtons = () => {
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [projectId]);
 
 	const isRunDisabled = !isManualRunEnabled || !entrypointFunction || savingManualRun;
 


### PR DESCRIPTION
## Description
Manual Run - Allow manual runs when moving between projects

The bug was that the start manual run function wasn't updating when we moved between project, since the projectId wasn't in the `useCallback` dependencies.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1119/manual-run-allow-manual-runs-when-moving-between-projects

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
