### PR TITLE
fix(UI-1123): fix quickstart creation on intro page

### DIFF
--- a/src/hooks/useCreateProjectFromTemplate.tsx
+++ b/src/hooks/useCreateProjectFromTemplate.tsx
@@ -17,7 +17,7 @@ export const useCreateProjectFromTemplate = () => {
 	const addToast = useToastStore((state) => state.addToast);
 	const { createProjectFromManifest, getProjectsList } = useProjectStore();
 	const navigate = useNavigate();
-	const { findTemplateByAssetDirectory, templateStorage } = useTemplatesStore();
+	const { findTemplateByAssetDirectory, getTemplateStorage } = useTemplatesStore();
 	const [isCreating, setIsCreating] = useState(false);
 
 	const [projectId, setProjectId] = useState<string | null>(null);
@@ -53,7 +53,8 @@ export const useCreateProjectFromTemplate = () => {
 
 	const createProjectFromTemplate = async (template: TemplateMetadata, projectName?: string) => {
 		try {
-			const files = await templateStorage?.getTemplateFiles(template.assetDirectory);
+			const templateStorage = getTemplateStorage();
+			const files = await templateStorage.getTemplateFiles(template.assetDirectory);
 			const manifestData = files?.["autokitteh.yaml"];
 			if (!manifestData) {
 				addToast({


### PR DESCRIPTION
## Description
When we click on quickstart in the welcome page, we get an error.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1123/fix-project-creation-on-quickstart-click

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
