### PR TITLE
perf(UI-1132): load deployments in projects table once instead of twice

### DIFF
--- a/src/store/useProjectStore.ts
+++ b/src/store/useProjectStore.ts
@@ -1,4 +1,5 @@
 import i18n from "i18next";
+import isEqual from "lodash/isEqual";
 import { StateCreator, create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
@@ -203,6 +204,10 @@ const store: StateCreator<ProjectStore> = (set, get) => ({
 			set((state) => ({ ...state, isLoadingProjectsList: false, projectsList: [] }));
 
 			return { data: undefined, error };
+		}
+
+		if (isEqual(projects, projectsList)) {
+			return { data: projectsList, error: undefined };
 		}
 
 		set((state) => ({ ...state, projectsList: projects, isLoadingProjectsList: false }));


### PR DESCRIPTION
## Description
Optimize projects table to fetch deployments per project only once instead of twice

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1132/optimize-projects-table-to-fetch-deployments-per-project-only-once

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [x] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
