### PR TITLE
fix(UI-1133): manual run config on deployments change

### DIFF
--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -24,7 +24,7 @@ export const DeploymentsTableContent = ({
 	updateDeployments,
 }: {
 	deployments: Deployment[];
-	updateDeployments: () => void;
+	updateDeployments: () => Promise<void | Deployment[]>;
 }) => {
 	const { t } = useTranslation("deployments", { keyPrefix: "history" });
 	const navigate = useNavigate();
@@ -72,8 +72,6 @@ export const DeploymentsTableContent = ({
 				return;
 			}
 
-			fetchManualRunConfiguration(projectId!);
-
 			if (action === "activate") {
 				addToast({
 					message: t("actions.deploymentActivatedSuccessfully"),
@@ -105,7 +103,8 @@ export const DeploymentsTableContent = ({
 				);
 			}
 
-			updateDeployments();
+			await updateDeployments();
+			fetchManualRunConfiguration(projectId!);
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[]

--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -11,7 +11,7 @@ import { dateTimeFormat, namespaces } from "@src/constants";
 import { Deployment } from "@type/models";
 
 import { useSort } from "@hooks";
-import { useModalStore, useProjectStore, useToastStore } from "@store";
+import { useManualRunStore, useModalStore, useProjectStore, useToastStore } from "@store";
 
 import { IconButton, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import { IdCopyButton, SortButton } from "@components/molecules";
@@ -36,6 +36,7 @@ export const DeploymentsTableContent = ({
 	const [isDeleting, setIsDeleting] = useState(false);
 	const { t: tSessionsStats } = useTranslation("deployments", { keyPrefix: "sessionStats" });
 	const { setLatestOpened } = useProjectStore();
+	const { fetchManualRunConfiguration } = useManualRunStore();
 
 	const showDeleteModal = (event: React.MouseEvent, id: string) => {
 		event.stopPropagation();
@@ -70,6 +71,8 @@ export const DeploymentsTableContent = ({
 
 				return;
 			}
+
+			fetchManualRunConfiguration(projectId!);
 
 			if (action === "activate") {
 				addToast({

--- a/src/components/organisms/topbar/project/buttons.tsx
+++ b/src/components/organisms/topbar/project/buttons.tsx
@@ -82,7 +82,7 @@ export const ProjectTopbarButtons = () => {
 				return;
 			}
 			await fetchDeployments(projectId!, true);
-			await fetchManualRunConfiguration(projectId!);
+			fetchManualRunConfiguration(projectId!);
 			addToast({
 				message: t("topbar.deployedProjectSuccess"),
 				type: "success",

--- a/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
@@ -21,9 +21,9 @@ export const ManualRunButtons = () => {
 	const { fetchDeployments } = useCacheStore();
 	const [savingManualRun, setSavingManualRun] = useState(false);
 
-	const { entrypointFunction, isManualRunEnabled, lastDeploymentStore, saveProjectManualRun } = useManualRunStore(
+	const { activeDeploymentStore, entrypointFunction, isManualRunEnabled, saveProjectManualRun } = useManualRunStore(
 		(state) => ({
-			lastDeploymentStore: state.projectManualRun[projectId!]?.lastDeployment,
+			activeDeploymentStore: state.projectManualRun[projectId!]?.activeDeployment,
 			entrypointFunction: state.projectManualRun[projectId!]?.entrypointFunction,
 			isManualRunEnabled: state.projectManualRun[projectId!]?.isManualRunEnabled,
 			saveProjectManualRun: state.saveAndExecuteManualRun,
@@ -54,7 +54,7 @@ export const ManualRunButtons = () => {
 			addToast({
 				message: (
 					<ManualRunSuccessToastMessage
-						deploymentId={lastDeploymentStore?.deploymentId}
+						deploymentId={activeDeploymentStore?.deploymentId}
 						projectId={projectId}
 						sessionId={sessionId}
 					/>

--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -33,7 +33,7 @@ export const ManualRunSettingsDrawer = () => {
 		saveAndExecuteManualRun: state.saveAndExecuteManualRun,
 	}));
 
-	const { entrypointFunction, fileOptions, filePath, files, lastDeployment, params } = projectManualRun || {};
+	const { activeDeployment, entrypointFunction, fileOptions, filePath, files, params } = projectManualRun || {};
 
 	const methods = useForm({
 		resolver: zodResolver(manualRunSchema),
@@ -108,7 +108,7 @@ export const ManualRunSettingsDrawer = () => {
 		addToast({
 			message: (
 				<ManualRunSuccessToastMessage
-					deploymentId={lastDeployment?.deploymentId}
+					deploymentId={activeDeployment?.deploymentId}
 					projectId={projectId}
 					sessionId={sessionId}
 				/>

--- a/src/interfaces/store/manualRunStore.interface.ts
+++ b/src/interfaces/store/manualRunStore.interface.ts
@@ -9,7 +9,7 @@ export interface ManualProjectData {
 	entrypointFunction: { label: string; value: string };
 	params: { key: string; value: string }[];
 	isJson: boolean;
-	lastDeployment?: Deployment;
+	activeDeployment?: Deployment;
 	selectedEntrypoint?: SessionEntrypoint;
 	isManualRunEnabled?: boolean;
 }

--- a/src/locales/en/deployments/translation.json
+++ b/src/locales/en/deployments/translation.json
@@ -56,7 +56,7 @@
 			"executionFailedExtended": "Session execution failed, projectID - {{projectId}}, error - {{error}}",
 			"executionSucceed": "Session execution succeed",
 			"showMore": "Show more",
-			"missingLastDeployment": "Missing last deployment",
+			"missingactiveDeployment": "Missing last deployment",
 			"useJsonEditor": "Use JSON editor"
 
 		},

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -27,21 +27,13 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 
 	fetchManualRunConfiguration: async (projectId: string) => {
 		const deployments = useCacheStore.getState().deployments;
+		const activeDeployment = deployments?.find((deployment) => deployment.state === DeploymentStateVariant.active);
 
-		if (!deployments?.length || deployments[0].state !== DeploymentStateVariant.active) {
+		if (!deployments?.length || !activeDeployment) {
 			get().updateManualRunConfiguration(projectId!, { isManualRunEnabled: false });
 
 			return;
 		}
-
-		const activeDeployment = deployments.find((deployment) => deployment.state === DeploymentStateVariant.active);
-
-		if (!activeDeployment) {
-			get().updateManualRunConfiguration(projectId!, { isManualRunEnabled: false });
-
-			return;
-		}
-
 		if (activeDeployment.buildId === get().projectManualRun[projectId]?.lastDeployment?.buildId) {
 			get().updateManualRunConfiguration(projectId!, { isManualRunEnabled: true });
 

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -34,7 +34,7 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 
 			return;
 		}
-		if (activeDeployment.buildId === get().projectManualRun[projectId]?.lastDeployment?.buildId) {
+		if (activeDeployment.buildId === get().projectManualRun[projectId]?.activeDeployment?.buildId) {
 			get().updateManualRunConfiguration(projectId!, { isManualRunEnabled: true });
 
 			return;
@@ -57,14 +57,14 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 
 		get().updateManualRunConfiguration(projectId!, {
 			files,
-			lastDeployment: activeDeployment,
+			activeDeployment,
 			isManualRunEnabled: true,
 		});
 	},
 
 	updateManualRunConfiguration: (
 		projectId,
-		{ entrypointFunction, filePath, files, isJson, isManualRunEnabled, lastDeployment, params }
+		{ activeDeployment, entrypointFunction, filePath, files, isJson, isManualRunEnabled, params }
 	) => {
 		set((state) => {
 			const projectData = {
@@ -92,7 +92,7 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 				...(filePath && { filePath }),
 				...(entrypointFunction !== undefined && { entrypointFunction }),
 				...(params && { params: [...params] }),
-				...(lastDeployment && { lastDeployment }),
+				...(activeDeployment && { activeDeployment }),
 				...(isJson !== undefined && { isJson }),
 			});
 
@@ -105,10 +105,10 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 	saveAndExecuteManualRun: async (projectId, params) => {
 		const project = get().projectManualRun[projectId];
 
-		if (!project?.lastDeployment) {
+		if (!project?.activeDeployment) {
 			return {
 				data: undefined,
-				error: i18n.t("history.manualRun.missingLastDeployment", { ns: "deployments" }),
+				error: i18n.t("history.manualRun.missingactiveDeployment", { ns: "deployments" }),
 			};
 		}
 
@@ -122,8 +122,8 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 		);
 
 		const sessionArgs = {
-			buildId: project.lastDeployment.buildId,
-			deploymentId: project.lastDeployment.deploymentId,
+			buildId: project.activeDeployment.buildId,
+			deploymentId: project.activeDeployment.deploymentId,
 			entrypoint: {
 				col: 0,
 				row: 0,


### PR DESCRIPTION
## Description
Bug - Start session always run on the last deployment

https://github.com/user-attachments/assets/74da5608-6981-4749-bb16-a78bd2d67bad


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1133/bug-start-session-always-run-on-the-last-deployment


## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
