### PR TITLE
fix(UI-1139): display sessions in created status in deployments table

### DIFF
--- a/src/components/organisms/deployments/sessionStats.tsx
+++ b/src/components/organisms/deployments/sessionStats.tsx
@@ -27,8 +27,10 @@ export const DeploymentSessionStats = ({
 		);
 
 	const sessionStatsOrdered = [
-		sessionStats?.find(({ state }) => state === SessionStateType.running) || {
-			count: 0,
+		{
+			count:
+				(sessionStats?.find(({ state }) => state === SessionStateType.running)?.count || 0) +
+				(sessionStats?.find(({ state }) => state === SessionStateType.created)?.count || 0),
 			state: SessionStateType.running,
 		},
 		sessionStats?.find(({ state }) => state === SessionStateType.stopped) || {


### PR DESCRIPTION
## Description

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1139/sessions-in-created-status-arent-displayed-in-the-deployments-table

## What type of PR is this? (check all applicable)

-   [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
-   [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
-   [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
-   [ ] 🏎 (perf) - Optimization
-   [ ] 📄 (docs) - Documentation - Documentation only changes
-   [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
-   [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
-   [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
