### PR TITLE
refactor(UI-1125): simplify IdCopyButton usage in ConnectionsTable component

### DIFF
--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -236,7 +236,11 @@ export const ConnectionsTable = () => {
 														</div>
 														<div className="flex items-center">
 															{t("table.popover.connectionId")}:
-															<IdCopyButton id={connectionId} variant="flatText" />
+															<IdCopyButton
+																displayFullLength
+																id={connectionId}
+																variant="flatText"
+															/>
 														</div>
 													</div>
 												</PopoverContent>

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -236,11 +236,7 @@ export const ConnectionsTable = () => {
 														</div>
 														<div className="flex items-center">
 															{t("table.popover.connectionId")}:
-															<IdCopyButton
-																displayFullLength
-																id={connectionId}
-																variant="flatText"
-															/>
+															<IdCopyButton id={connectionId} variant="flatText" />
 														</div>
 													</div>
 												</PopoverContent>

--- a/src/components/organisms/triggers/table/popoverContent.tsx
+++ b/src/components/organisms/triggers/table/popoverContent.tsx
@@ -11,7 +11,7 @@ import { Trigger } from "@src/types/models";
 import { cn, getApiBaseUrl, stripGoogleConnectionName } from "@src/utilities";
 
 import { IconSvg } from "@components/atoms";
-import { CopyButton } from "@components/molecules";
+import { CopyButton, IdCopyButton } from "@components/molecules";
 
 import { ClockIcon, WebhookIcon } from "@assets/image/icons";
 
@@ -53,7 +53,7 @@ export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => 
 			},
 			{
 				label: t("connectionId"),
-				value: triggerConnection?.connectionId,
+				value: <IdCopyButton displayFullLength id={triggerConnection!.connectionId} variant="flatText" />,
 			},
 			...baseDetails,
 			{ label: t("eventType"), value: trigger.eventType },

--- a/src/types/components/tables/triggersTable.type.ts
+++ b/src/types/components/tables/triggersTable.type.ts
@@ -5,5 +5,5 @@ export type SortableColumns = keyof Pick<Trigger, "name" | "sourceType" | "entry
 export type TriggerPopoverInformation = {
 	icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 	label: string;
-	value?: string;
+	value?: string | React.ReactNode;
 };


### PR DESCRIPTION
## Description
Change the connection ID in the trigger info popover to idCopyButton
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1125/change-the-connection-id-in-the-trigger-info-popover-to-idcopybutton
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [x] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
