### PR TITLE
feat(UI-1147): focus trap in modals

### DIFF
--- a/src/components/molecules/modal.tsx
+++ b/src/components/molecules/modal.tsx
@@ -36,24 +36,42 @@ export const Modal = ({ children, className, hideCloseButton, name }: ModalProps
 
 	useEffect(() => {
 		if (isOpen && modalRef.current) {
-			const firstInput = modalRef.current.querySelector("input, textarea, select");
-			if (!firstInput) return;
+			const buttons = modalRef.current.querySelectorAll("button");
+			if (!buttons.length) return;
+			(buttons[buttons.length - 1] as HTMLElement).focus();
 
-			(firstInput as HTMLElement).focus();
+			const focusableElements = modalRef.current.querySelectorAll(
+				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+			);
+			const firstElement = focusableElements[0];
+			const lastElement = focusableElements[focusableElements.length - 1];
+
+			const handleKeyDown = (event: KeyboardEvent) => {
+				event.preventDefault();
+				if (event.key === "Tab") {
+					if (event.shiftKey && document.activeElement === firstElement) {
+						(lastElement as HTMLElement).focus();
+
+						return;
+					}
+					if (!event.shiftKey && document.activeElement === lastElement) {
+						(firstElement as HTMLElement).focus();
+
+						return;
+					}
+				}
+
+				if (event.key === "Escape" && isOpen) {
+					onClose(name);
+				}
+			};
+
+			document.addEventListener("keydown", handleKeyDown);
+
+			return () => {
+				document.removeEventListener("keydown", handleKeyDown);
+			};
 		}
-
-		const handleKeyDown = (event: KeyboardEvent) => {
-			event.stopPropagation();
-			if (event.key === "Escape" && isOpen) {
-				onClose(name);
-			}
-		};
-
-		document.addEventListener("keydown", handleKeyDown);
-
-		return () => {
-			document.removeEventListener("keydown", handleKeyDown);
-		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isOpen]);
 

--- a/src/components/molecules/modal.tsx
+++ b/src/components/molecules/modal.tsx
@@ -47,21 +47,23 @@ export const Modal = ({ children, className, hideCloseButton, name }: ModalProps
 			const lastElement = focusableElements[focusableElements.length - 1];
 
 			const handleKeyDown = (event: KeyboardEvent) => {
-				event.preventDefault();
 				if (event.key === "Tab") {
 					if (event.shiftKey && document.activeElement === firstElement) {
 						(lastElement as HTMLElement).focus();
+						event.preventDefault();
 
 						return;
 					}
 					if (!event.shiftKey && document.activeElement === lastElement) {
 						(firstElement as HTMLElement).focus();
+						event.preventDefault();
 
 						return;
 					}
 				}
 
 				if (event.key === "Escape" && isOpen) {
+					event.preventDefault();
 					onClose(name);
 				}
 			};


### PR DESCRIPTION
## Description
Modals - focus on approval button when modal is opened & implement focus trap

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1147/modals-focus-on-approval-button-when-modal-is-opened-and-implement

## What type of PR is this? (check all applicable)

- [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
