### PR TITLE
refactor(UI-1174): remove close icon session and event viewer component

### DIFF
--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -21,16 +21,14 @@ import { SessionState } from "@src/enums";
 import { ViewerSession } from "@src/interfaces/models/session.interface";
 import { useActivitiesCacheStore, useOutputsCacheStore, useToastStore } from "@src/store";
 
-import { Frame, IconButton, IconSvg, Loader, LogoCatLarge, Tab } from "@components/atoms";
+import { Frame, IconSvg, Loader, LogoCatLarge, Tab } from "@components/atoms";
 import { Accordion, CopyButton, RefreshButton } from "@components/molecules";
 import { SessionsTableState } from "@components/organisms/deployments";
 
-import { ArrowRightIcon, CircleMinusIcon, CirclePlusIcon, Close } from "@assets/image/icons";
+import { ArrowRightIcon, CircleMinusIcon, CirclePlusIcon } from "@assets/image/icons";
 
 export const SessionViewer = () => {
-	const { deploymentId, projectId, sessionId } = useParams<{
-		deploymentId: string;
-		projectId: string;
+	const { sessionId } = useParams<{
 		sessionId: string;
 	}>();
 	const { t } = useTranslation("deployments", { keyPrefix: "sessions.viewer" });
@@ -46,15 +44,6 @@ export const SessionViewer = () => {
 
 	const { loading: loadingOutputs, reload: reloadOutputs } = useOutputsCacheStore();
 	const { loading: loadingActivities, reload: reloadActivities } = useActivitiesCacheStore();
-
-	const closeEditor = useCallback(() => {
-		if (deploymentId) {
-			navigate(`/projects/${projectId}/deployments/${deploymentId}/sessions`);
-
-			return;
-		}
-		navigate(`/projects/${projectId}/sessions`);
-	}, [navigate, projectId, deploymentId]);
 
 	const fetchSessionInfo = useCallback(async () => {
 		if (!sessionId) return;
@@ -135,20 +124,7 @@ export const SessionViewer = () => {
 	) : (
 		<Frame className="overflow-y-auto overflow-x-hidden rounded-l-none pb-3 font-fira-code">
 			<div className="flex items-center justify-end border-b border-gray-950 pb-3.5">
-				<div className="flex items-center gap-3">
-					<RefreshButton
-						disabled={!isRefreshButtonDisabled}
-						isLoading={isLoading}
-						onRefresh={fetchSessions}
-					/>
-					<IconButton
-						ariaLabel={t("buttons.ariaCloseEditor")}
-						className="size-7 bg-gray-1100 p-0.5"
-						onClick={closeEditor}
-					>
-						<Close className="size-3 fill-white" />
-					</IconButton>
-				</div>
+				<RefreshButton disabled={!isRefreshButtonDisabled} isLoading={isLoading} onRefresh={fetchSessions} />
 			</div>
 
 			<div className="mt-2.5 flex justify-between">

--- a/src/components/organisms/events/viewer.tsx
+++ b/src/components/organisms/events/viewer.tsx
@@ -4,40 +4,22 @@ import JsonView from "@uiw/react-json-view";
 import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
 import moment from "moment";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
-import { useEventsDrawer } from "@contexts";
 import { EventsService, LoggerService } from "@services";
 import { dateTimeFormat, namespaces } from "@src/constants";
 import { useToastStore } from "@src/store";
 import { EnrichedEvent } from "@src/types/models";
 
-import { Frame, IconButton, Loader, Typography } from "@components/atoms";
+import { Frame, Loader, Typography } from "@components/atoms";
 import { CopyButton } from "@components/molecules";
-
-import { Close } from "@assets/image/icons";
 
 export const EventViewer = () => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [eventInfo, setEventInfo] = useState<EnrichedEvent | null>(null);
-	const { isDrawer } = useEventsDrawer();
 
 	const { eventId } = useParams();
-	const navigate = useNavigate();
 
-	const closeViewer = useCallback(() => {
-		if (!isDrawer) {
-			navigate("/events");
-
-			return;
-		}
-
-		const parts = location.pathname.split("/");
-		parts.pop();
-		const newPath = parts.join("/");
-		navigate(newPath);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [location.pathname]);
 	const addToast = useToastStore((state) => state.addToast);
 	const { t } = useTranslation("events", { keyPrefix: "viewer" });
 	const { t: tErrors } = useTranslation("errors");
@@ -73,11 +55,6 @@ export const EventViewer = () => {
 		<Loader size="xl" />
 	) : (
 		<Frame className="overflow-y-auto overflow-x-hidden rounded-l-none pb-3 font-fira-code">
-			<div className="flex items-center justify-between border-b border-gray-950 pb-3.5">
-				<IconButton className="ml-auto size-7 bg-gray-1100 p-0.5" onClick={closeViewer}>
-					<Close className="size-3 fill-white" />
-				</IconButton>
-			</div>
 			{eventInfo ? (
 				<div className="mt-3 flex justify-between border-b border-gray-950 pb-3.5">
 					<div className="flex flex-col gap-0.5 leading-6">


### PR DESCRIPTION
## Description
viewers (events, sessions) - remove Close (X)
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1174/viewers-events-sessions-remove-close-x
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
