### PR TITLE
fix(UI-1173): close editor/viewer on fetch error in session and event viewers

### DIFF
--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -51,6 +51,7 @@ export const SessionViewer = () => {
 
 		if (error) {
 			addToast({ message: tErrors("fetchSessionFailed"), type: "error" });
+			closeEditor();
 
 			return;
 		}

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -28,7 +28,9 @@ import { SessionsTableState } from "@components/organisms/deployments";
 import { ArrowRightIcon, CircleMinusIcon, CirclePlusIcon } from "@assets/image/icons";
 
 export const SessionViewer = () => {
-	const { sessionId } = useParams<{
+	const { deploymentId, projectId, sessionId } = useParams<{
+		deploymentId: string;
+		projectId: string;
 		sessionId: string;
 	}>();
 	const { t } = useTranslation("deployments", { keyPrefix: "sessions.viewer" });
@@ -44,6 +46,15 @@ export const SessionViewer = () => {
 
 	const { loading: loadingOutputs, reload: reloadOutputs } = useOutputsCacheStore();
 	const { loading: loadingActivities, reload: reloadActivities } = useActivitiesCacheStore();
+
+	const closeEditor = useCallback(() => {
+		if (deploymentId) {
+			navigate(`/projects/${projectId}/deployments/${deploymentId}/sessions`);
+
+			return;
+		}
+		navigate(`/projects/${projectId}/sessions`);
+	}, [navigate, projectId, deploymentId]);
 
 	const fetchSessionInfo = useCallback(async () => {
 		if (!sessionId) return;

--- a/src/components/organisms/events/viewer.tsx
+++ b/src/components/organisms/events/viewer.tsx
@@ -4,8 +4,9 @@ import JsonView from "@uiw/react-json-view";
 import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
 import moment from "moment";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
+import { useEventsDrawer } from "@contexts";
 import { EventsService, LoggerService } from "@services";
 import { dateTimeFormat, namespaces } from "@src/constants";
 import { useToastStore } from "@src/store";
@@ -23,6 +24,22 @@ export const EventViewer = () => {
 	const addToast = useToastStore((state) => state.addToast);
 	const { t } = useTranslation("events", { keyPrefix: "viewer" });
 	const { t: tErrors } = useTranslation("errors");
+	const navigate = useNavigate();
+	const { isDrawer } = useEventsDrawer();
+
+	const closeViewer = useCallback(() => {
+		if (!isDrawer) {
+			navigate("/events");
+
+			return;
+		}
+
+		const parts = location.pathname.split("/");
+		parts.pop();
+		const newPath = parts.join("/");
+		navigate(newPath);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [location.pathname]);
 
 	const fetchEventInfo = useCallback(async () => {
 		if (!eventId) return;

--- a/src/components/organisms/events/viewer.tsx
+++ b/src/components/organisms/events/viewer.tsx
@@ -32,6 +32,7 @@ export const EventViewer = () => {
 
 		if (error) {
 			addToast({ message: tErrors("errorFetchingEvent"), type: "error" });
+			closeViewer();
 
 			return;
 		}


### PR DESCRIPTION
## Description
When there is a problem fetching an event, you should reset and display an error instead the viewer.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1173/events-sessions-when-there-is-an-error-reset-the-viewer-and-close-it
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
