### PR TITLE
fix(UI-1202): when we invite user, we shouldnt display error if he is not exist

### DIFF
--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -26,11 +26,7 @@ export class UsersService {
 			});
 
 			if (!user) {
-				throw new Error(
-					i18n.t("userNotFound", {
-						ns: "services",
-					})
-				);
+				return { data: undefined, error: undefined };
 			}
 			const convertedUser = convertUserProtoToModel(user);
 

--- a/src/store/useOrganizationStore.ts
+++ b/src/store/useOrganizationStore.ts
@@ -129,10 +129,10 @@ const store: StateCreator<OrganizationStore> = (set, get) => ({
 		const organizationId = get().currentOrganization?.id;
 		let userId;
 
-		const { data: existingUser, error: userCheckError } = await useUserStore.getState().getUser({ email });
+		const { data: existingUser } = await useUserStore.getState().getUser({ email });
 
-		if (!userCheckError) {
-			userId = existingUser!.id;
+		if (existingUser) {
+			userId = existingUser.id;
 		} else {
 			const { data: createUserId, error: userCreationError } = await useUserStore
 				.getState()


### PR DESCRIPTION
## Description
Don't show error toast when getUser not finding the user

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1202/dont-show-error-toast-when-getuser-not-finding-user

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
