### PR TITLE
fix(UI-1209): move add organization page to user settings

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -258,6 +258,7 @@ export const App = () => {
 				<Route element={<Profile />} index />
 				<Route element={<ClientConfiguration />} path="client-configuration" />
 				<Route element={<UserOrganizationsTable />} path="organizations" />
+				<Route element={<AddOrganization />} path="add-organization" />
 
 				<Route element={<Navigate replace to="/404" />} path="*" />
 			</Route>
@@ -271,7 +272,6 @@ export const App = () => {
 				path="organization-settings"
 			>
 				<Route element={<OrganizationSettings />} index />
-				<Route element={<AddOrganization />} path="add" />
 				<Route element={<OrganizationMembersTable />} path="members" />
 
 				<Route element={<Navigate replace to="/404" />} path="*" />

--- a/src/components/organisms/settings/user/organizations/table.tsx
+++ b/src/components/organisms/settings/user/organizations/table.tsx
@@ -76,7 +76,7 @@ export const UserOrganizationsTable = () => {
 			</Typography>
 			<Button
 				className="ml-auto border-black bg-white px-5 text-base font-medium hover:bg-gray-950 hover:text-white"
-				onClick={() => navigate("/organization-settings/add")}
+				onClick={() => navigate("/settings/add-organization")}
 				variant="outline"
 			>
 				{t("buttons.addOrganization")}

--- a/src/components/organisms/sidebar/userMenu.tsx
+++ b/src/components/organisms/sidebar/userMenu.tsx
@@ -115,7 +115,7 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 
 	const createNewOrganization = () => {
 		close();
-		navigate("/organization-settings/add");
+		navigate("/settings/add-organization");
 	};
 
 	const menuItemClick = (href: string) => {


### PR DESCRIPTION
## Description
Move add organization page under myOrganizations in userSettings

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1209/move-add-organization-page-under-myorganizations-in-usersettings

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
