### PR TITLE
fix(UI-1210): limit maximum width of table cell in variable value

### DIFF
--- a/src/components/organisms/systemLog.tsx
+++ b/src/components/organisms/systemLog.tsx
@@ -50,7 +50,8 @@ export const SystemLog = () => {
 						<span className="text-gray-250">{timestamp}</span>
 
 						<div className="ml-2 inline">
-							<span className={cn(ouputTextStyle[status])}>{status}</span>: {message}
+							<span className={cn(ouputTextStyle[status])}>{status}</span>:
+							<span className="break-all">{message}</span>
 						</div>
 					</div>
 				))}

--- a/src/components/organisms/variables/table.tsx
+++ b/src/components/organisms/variables/table.tsx
@@ -129,7 +129,10 @@ export const VariablesTable = () => {
 								/>
 							</Th>
 
-							<Th className="group w-3/6 cursor-pointer font-normal" onClick={() => requestSort("value")}>
+							<Th
+								className="group w-3/6 max-w-96 cursor-pointer font-normal"
+								onClick={() => requestSort("value")}
+							>
 								{t("table.columns.value")}
 
 								<SortButton
@@ -140,7 +143,9 @@ export const VariablesTable = () => {
 								/>
 							</Th>
 
-							<Th className="w-1/6 max-w-20 text-right font-normal">{t("table.columns.actions")}</Th>
+							<Th className="ml-auto w-1/6 max-w-20 text-right font-normal">
+								{t("table.columns.actions")}
+							</Th>
 						</Tr>
 					</THead>
 
@@ -161,7 +166,7 @@ export const VariablesTable = () => {
 									)}
 								</Td>
 
-								<Td className="w-1/6 max-w-20 pr-0">
+								<Td className="ml-auto w-1/6 max-w-20 pr-0">
 									<div className="flex size-8 space-x-1">
 										<IconButton
 											ariaLabel={t("table.buttons.ariaModifyVariable", { name })}

--- a/src/components/organisms/variables/table.tsx
+++ b/src/components/organisms/variables/table.tsx
@@ -149,7 +149,7 @@ export const VariablesTable = () => {
 							<Tr className="group" key={index}>
 								<Td className="w-2/6 pl-4 font-semibold">{name}</Td>
 
-								<Td className="w-3/6">
+								<Td className="w-3/6 max-w-96">
 									{!isSecret ? (
 										value
 									) : (


### PR DESCRIPTION
## Description
When variable value is very long, the screen is too large
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1210/when-variable-value-is-very-long-the-screen-is-too-large
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
