### PR TITLE
refactor(UI-1151): remove unused feature flags and clean up user menu

### DIFF
--- a/src/components/organisms/sidebar/sidebar.tsx
+++ b/src/components/organisms/sidebar/sidebar.tsx
@@ -5,7 +5,7 @@ import Avatar from "react-avatar";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
 
-import { descopeProjectId, featureFlags, sentryDsn, userMenuItems } from "@constants";
+import { descopeProjectId } from "@constants";
 import { cn } from "@src/utilities";
 
 import { useLoggerStore, useOrganizationStore } from "@store";
@@ -20,12 +20,12 @@ import { UserMenu } from "@components/organisms/sidebar";
 
 import { IconLogo, IconLogoName } from "@assets/image";
 import { EventsFlag } from "@assets/image/icons";
-import { AnnouncementIcon, CircleQuestionIcon, FileIcon, LogoutIcon } from "@assets/image/icons/sidebar";
+import { CircleQuestionIcon, FileIcon } from "@assets/image/icons/sidebar";
 
 export const Sidebar = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
-	const { logoutFunction, user } = useOrganizationStore();
+	const { user } = useOrganizationStore();
 	const { isNewLogs, setSystemLogHeight, systemLogHeight } = useLoggerStore();
 	const location = useLocation();
 	const { t } = useTranslation("sidebar");
@@ -191,57 +191,11 @@ export const Sidebar = () => {
 									</AnimatePresence>
 								</PopoverTrigger>
 								<PopoverContent className="z-40 min-w-56 rounded-2xl border border-gray-950 bg-white px-3.5 py-2.5 font-averta shadow-2xl">
-									{featureFlags.enableNewOrgsAndUsersDesign ? (
-										<UserMenu openFeedbackForm={() => setIsFeedbackOpen(true)} />
-									) : (
-										<>
-											<div className="flex items-center gap-2 border-b border-b-gray-950 pb-2 pl-2">
-												<Avatar color="black" name={`${user?.name}`} round={true} size="28" />
-												<span className="font-medium text-black">{user?.email}</span>
-											</div>
-											<div className="mt-1">
-												{sentryDsn ? (
-													<Button
-														className="w-full rounded-md px-2.5 text-lg hover:bg-gray-250"
-														onClick={() => setIsFeedbackOpen(true)}
-													>
-														<AnnouncementIcon className="size-6" fill="black" />
-														{t("menu.userSettings.feedback")}
-													</Button>
-												) : null}
-												{userMenuItems.map(({ href, icon, label, stroke }, index) => (
-													<Button
-														className="w-full rounded-md px-2.5 text-lg hover:bg-gray-250"
-														href={href}
-														key={index}
-														title={t("userSettings.settings")}
-													>
-														<IconSvg
-															className={cn({
-																"fill-black": !stroke,
-																"stroke-black": stroke,
-															})}
-															size="lg"
-															src={icon}
-														/>
-														{t(label)}
-													</Button>
-												))}
-												<Button
-													className="w-full rounded-md px-2.5 text-lg hover:bg-gray-250"
-													onClick={() => logoutFunction(true)}
-												>
-													<LogoutIcon className="size-5" fill="black" />
-													{t("menu.userSettings.logout")}
-												</Button>
-											</div>
-										</>
-									)}
+									<UserMenu openFeedbackForm={() => setIsFeedbackOpen(true)} />
 								</PopoverContent>
 							</Popover>
 						) : null}
 					</div>
-					{/* TODO: remove UserFeedbackForm from component after change to new menu enableNewOrgsAndUsersDesign: */}
 					<UserFeedbackForm
 						className="absolute bottom-0 left-20"
 						isOpen={isFeedbackOpen}

--- a/src/components/organisms/sidebar/userMenu.tsx
+++ b/src/components/organisms/sidebar/userMenu.tsx
@@ -132,7 +132,7 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 					<span className="font-medium text-black">{user?.email}</span>
 				</div>
 				<div className="mt-2 flex flex-col gap-1">
-					{sentryDsn ? (
+					{!sentryDsn ? (
 						<Button
 							className="w-full rounded-md px-2.5 text-sm hover:bg-gray-250"
 							onClick={() => openFeedbackFormClick()}

--- a/src/components/organisms/sidebar/userMenu.tsx
+++ b/src/components/organisms/sidebar/userMenu.tsx
@@ -132,7 +132,7 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 					<span className="font-medium text-black">{user?.email}</span>
 				</div>
 				<div className="mt-2 flex flex-col gap-1">
-					{!sentryDsn ? (
+					{sentryDsn ? (
 						<Button
 							className="w-full rounded-md px-2.5 text-sm hover:bg-gray-250"
 							onClick={() => openFeedbackFormClick()}

--- a/src/constants/featureFlags.constants.ts
+++ b/src/constants/featureFlags.constants.ts
@@ -1,5 +1,4 @@
 export const featureFlags = {
 	displayDiscordIntegration: import.meta.env.DISPLAY_DISCORD_INTEGRATION,
 	displaySlackSocketIntegration: import.meta.env.DISPLAY_SLACK_SOCKET_INTEGRATION,
-	enableNewOrgsAndUsersDesign: import.meta.env.ENABLE_NEW_ORGS_AND_USERS_DESIGN,
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -11,7 +11,6 @@ interface ImportMetaEnv {
 	readonly VITE_HOST_URL: string;
 	readonly DISPLAY_DISCORD_INTEGRATION: boolean;
 	readonly DISPLAY_SLACK_SOCKET_INTEGRATION: boolean;
-	readonly ENABLE_NEW_ORGS_AND_USERS_DESIGN: boolean;
 	readonly VITE_GTM_ID: string;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,6 @@ export default defineConfig({
 		"import.meta.env.DISPLAY_SLACK_SOCKET_INTEGRATION": process.env.DISPLAY_SLACK_SOCKET_INTEGRATION,
 		"import.meta.env.SENTRY_DSN": JSON.stringify(process.env.SENTRY_DSN),
 		"import.meta.env.TESTS_JWT_AUTH_TOKEN": JSON.stringify(process.env.TESTS_JWT_AUTH_TOKEN),
-		"import.meta.env.ENABLE_NEW_ORGS_AND_USERS_DESIGN": process.env.ENABLE_NEW_ORGS_AND_USERS_DESIGN,
 		"import.meta.env.VITE_GTM_ID": JSON.stringify(process.env.VITE_GTM_ID),
 	},
 	optimizeDeps: {


### PR DESCRIPTION
## Description
Remove enableNewOrgsAndUsersDesign
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1151/when-enableneworgsandusersdesign-feature-flag-removed-move-feedback
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
