### PR TITLE
fix(UI-1196): adjust active tab in sessions page

### DIFF
--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -94,13 +94,24 @@ export const SessionViewer = () => {
 	}, [sessionInfo, fetchSessionInfo, reloadOutputs, reloadActivities]);
 
 	useEffect(() => {
-		const activeTabIndex = location.pathname.split("/").filter(Boolean)[deploymentId ? 6 : 4] || defaultSessionTab;
-		setActiveTab(activeTabIndex);
-	}, [location, deploymentId]);
+		const pathSegments = location.pathname.split("/");
+		const lastSegment = pathSegments[pathSegments.length - 1];
+
+		const activeTabValue = sessionTabs.some((tab) => tab.value.toLowerCase() === lastSegment)
+			? lastSegment
+			: defaultSessionTab;
+
+		setActiveTab(activeTabValue);
+	}, [location.pathname]);
 
 	const goTo = useCallback(
 		(path: string) => {
-			navigate(path === defaultSessionTab ? "" : path.toLowerCase());
+			if (path === defaultSessionTab) {
+				navigate(".");
+				return;
+			}
+
+			navigate(path.toLowerCase());
 		},
 		[navigate]
 	);

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -94,9 +94,9 @@ export const SessionViewer = () => {
 	}, [sessionInfo, fetchSessionInfo, reloadOutputs, reloadActivities]);
 
 	useEffect(() => {
-		const activeTabIndex = location.pathname.split("/").filter(Boolean)[6] || defaultSessionTab;
+		const activeTabIndex = location.pathname.split("/").filter(Boolean)[deploymentId ? 6 : 4] || defaultSessionTab;
 		setActiveTab(activeTabIndex);
-	}, [location]);
+	}, [location, deploymentId]);
 
 	const goTo = useCallback(
 		(path: string) => {


### PR DESCRIPTION
## Description
Fix execution Flow tab in the session viewer not marked as chosen, but the outputs tab is marked instead.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1196/execution-flow-tab-in-sessions-doesnt-marked-as-active
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
