### PR TITLE
refactor(UI-1241): improve styling for session stats and table content circle

### DIFF
--- a/src/components/organisms/dashboard/projectsTable.tsx
+++ b/src/components/organisms/dashboard/projectsTable.tsx
@@ -221,7 +221,7 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${running} ${t("table.sessionTypes.running")}`}
 										>
-											<div className="truncate">{running}</div>
+											<div className="w-full truncate text-center">{running}</div>
 										</div>
 										<div
 											aria-label={t("table.sessionTypes.stopped")}
@@ -236,7 +236,7 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${stopped} ${t("table.sessionTypes.stopped")}`}
 										>
-											<div className="truncate">{stopped}</div>
+											<div className="w-full truncate text-center">{stopped}</div>
 										</div>
 										<div
 											aria-label={t("table.sessionTypes.completed")}
@@ -259,7 +259,7 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${completed} ${t("table.sessionTypes.completed")}`}
 										>
-											<div className="truncate">{completed}</div>
+											<div className="w-full truncate text-center">{completed}</div>
 										</div>
 										<div
 											aria-label={t("table.sessionTypes.error")}
@@ -274,7 +274,7 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${error} ${t("table.sessionTypes.error")}`}
 										>
-											<div className="truncate"> {error}</div>
+											<div className="w-full truncate text-center"> {error}</div>
 										</div>
 									</Td>
 

--- a/src/components/organisms/dashboard/projectsTable.tsx
+++ b/src/components/organisms/dashboard/projectsTable.tsx
@@ -76,7 +76,7 @@ export const DashboardProjectsTable = () => {
 
 	const countStyle = (state?: SessionStateType, className?: string) =>
 		cn(
-			"inline-block border-0 px-1 text-sm font-medium min-w-10 max-w-12 py-2 truncate sm:max-w-12 2xl:max-w-18 3xl:max-w-24",
+			"inline-block border-0 text-sm font-medium min-w-10 max-w-12 py-2 px-2.5 truncate sm:max-w-12 2xl:max-w-18 3xl:max-w-24",
 			"hover:bg-gray-1100 rounded-3xl inline-flex justify-center items-center min-w-12 h-7",
 			getSessionStateColor(state),
 			className

--- a/src/components/organisms/dashboard/projectsTable.tsx
+++ b/src/components/organisms/dashboard/projectsTable.tsx
@@ -76,8 +76,8 @@ export const DashboardProjectsTable = () => {
 
 	const countStyle = (state?: SessionStateType, className?: string) =>
 		cn(
-			"inline-block border-0 text-sm font-medium min-w-10 max-w-12 py-2 px-2.5 truncate sm:max-w-12 2xl:max-w-18 3xl:max-w-24",
-			"hover:bg-gray-1100 rounded-3xl inline-flex justify-center items-center min-w-12 h-7",
+			"border-0 text-sm font-medium max-w-12 py-2 px-2.5 sm:max-w-12 2xl:max-w-18 3xl:max-w-16",
+			"hover:bg-gray-1100 rounded-3xl inline-flex min-w-12 h-7 items-center truncate",
 			getSessionStateColor(state),
 			className
 		);
@@ -221,11 +221,11 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${running} ${t("table.sessionTypes.running")}`}
 										>
-											{running}
+											<div className="truncate">{running}</div>
 										</div>
 										<div
 											aria-label={t("table.sessionTypes.stopped")}
-											className={countStyle(SessionStateType.stopped, "justify-center")}
+											className={countStyle(SessionStateType.stopped)}
 											onClick={(event) =>
 												handleOpenProjectFilteredSessions(event, id, SessionStateType.stopped)
 											}
@@ -236,7 +236,7 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${stopped} ${t("table.sessionTypes.stopped")}`}
 										>
-											{stopped}
+											<div className="truncate">{stopped}</div>
 										</div>
 										<div
 											aria-label={t("table.sessionTypes.completed")}
@@ -259,7 +259,7 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${completed} ${t("table.sessionTypes.completed")}`}
 										>
-											{completed}
+											<div className="truncate">{completed}</div>
 										</div>
 										<div
 											aria-label={t("table.sessionTypes.error")}
@@ -274,7 +274,7 @@ export const DashboardProjectsTable = () => {
 											tabIndex={0}
 											title={`${error} ${t("table.sessionTypes.error")}`}
 										>
-											{error}
+											<div className="truncate"> {error}</div>
 										</div>
 									</Td>
 

--- a/src/components/organisms/deployments/sessionStats.tsx
+++ b/src/components/organisms/deployments/sessionStats.tsx
@@ -22,8 +22,7 @@ export const DeploymentSessionStats = ({
 	const { t } = useTranslation("deployments", { keyPrefix: "sessionStats" });
 	const countStyle = (state?: SessionStateType) =>
 		cn(
-			"min-w-12 max-w-12 sm:max-w-12 2xl:max-w-18 3xl:max-w-24 inline-block text-center border-0 p-0 text-sm font-medium",
-			"hover:bg-gray-1100 rounded-3xl inline-flex justify-center items-center h-7",
+			"w-1/4 text-sm font-medium truncate rounded-3xl flex justify-center",
 			getSessionStateColor(state),
 			className
 		);
@@ -73,7 +72,7 @@ export const DeploymentSessionStats = ({
 			tabIndex={0}
 			title={`${count} ${t(state?.toString() || "")}`}
 		>
-			{count}
+			<div className="inline-block min-w-12 rounded-3xl px-2.5 py-1 text-center hover:bg-gray-1100">{count}</div>
 		</div>
 	));
 };

--- a/src/components/organisms/deployments/sessionStats.tsx
+++ b/src/components/organisms/deployments/sessionStats.tsx
@@ -22,7 +22,7 @@ export const DeploymentSessionStats = ({
 	const { t } = useTranslation("deployments", { keyPrefix: "sessionStats" });
 	const countStyle = (state?: SessionStateType) =>
 		cn(
-			"w-1/4 text-sm font-medium truncate rounded-3xl flex justify-center",
+			"w-1/3 text-sm font-medium truncate rounded-3xl flex justify-center pl-1",
 			getSessionStateColor(state),
 			className
 		);
@@ -72,7 +72,7 @@ export const DeploymentSessionStats = ({
 			tabIndex={0}
 			title={`${count} ${t(state?.toString() || "")}`}
 		>
-			<div className="inline-block min-w-12 rounded-3xl px-2.5 py-1 text-center hover:bg-gray-1100">{count}</div>
+			<div className="inline-block min-w-12 truncate rounded-3xl px-2.5 py-1 hover:bg-gray-1100">{count}</div>
 		</div>
 	));
 };

--- a/src/components/organisms/deployments/sessionStats.tsx
+++ b/src/components/organisms/deployments/sessionStats.tsx
@@ -22,8 +22,8 @@ export const DeploymentSessionStats = ({
 	const { t } = useTranslation("deployments", { keyPrefix: "sessionStats" });
 	const countStyle = (state?: SessionStateType) =>
 		cn(
-			"2xl:w-22 inline-block w-1/4 text-center border-0 p-0 text-sm font-medium",
-			"hover:bg-gray-1100 rounded-3xl inline-flex justify-center items-center min-w-12 h-7",
+			"min-w-12 max-w-12 sm:max-w-12 2xl:max-w-18 3xl:max-w-24 inline-block text-center border-0 p-0 text-sm font-medium",
+			"hover:bg-gray-1100 rounded-3xl inline-flex justify-center items-center h-7",
 			getSessionStateColor(state),
 			className
 		);

--- a/src/components/organisms/deployments/sessionStats.tsx
+++ b/src/components/organisms/deployments/sessionStats.tsx
@@ -22,7 +22,7 @@ export const DeploymentSessionStats = ({
 	const { t } = useTranslation("deployments", { keyPrefix: "sessionStats" });
 	const countStyle = (state?: SessionStateType) =>
 		cn(
-			"w-1/3 text-sm font-medium truncate rounded-3xl flex justify-center pl-1",
+			"w-1/3 text-sm font-medium w-full truncate text-center rounded-3xl flex justify-center pl-1",
 			getSessionStateColor(state),
 			className
 		);

--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -157,7 +157,7 @@ export const DeploymentsTableContent = ({
 								</div>
 								<div
 									aria-label={tSessionsStats("error")}
-									className="w-1/4 truncate"
+									className="w-1/4 truncate pr-4"
 									title={tSessionsStats("error")}
 								>
 									{t("table.columns.error")}
@@ -208,7 +208,9 @@ export const DeploymentsTableContent = ({
 							<Td className="w-1/12" />
 
 							<Td className="w-1/3 cursor-pointer" onClick={() => goToDeploymentSessions(deploymentId)}>
-								<DeploymentSessionStats deploymentId={deploymentId} sessionStats={sessionStats} />
+								<div className="flex justify-around truncate">
+									<DeploymentSessionStats deploymentId={deploymentId} sessionStats={sessionStats} />
+								</div>
 							</Td>
 							<Td className="w-1/12" />
 

--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -133,7 +133,7 @@ export const DeploymentsTableContent = ({
 						<Th className="w-1/12" />
 
 						<Th className="group w-1/3 cursor-pointer font-normal">
-							<div className="flex w-full flex-row text-center">
+							<div className="flex w-full gap-1 text-center">
 								<div
 									aria-label={tSessionsStats("running")}
 									className="w-1/4 truncate"
@@ -208,7 +208,7 @@ export const DeploymentsTableContent = ({
 							<Td className="w-1/12" />
 
 							<Td className="w-1/3 cursor-pointer" onClick={() => goToDeploymentSessions(deploymentId)}>
-								<div className="flex justify-around truncate">
+								<div className="flex gap-1">
 									<DeploymentSessionStats deploymentId={deploymentId} sessionStats={sessionStats} />
 								</div>
 							</Td>

--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -207,8 +207,8 @@ export const DeploymentsTableContent = ({
 							</Td>
 							<Td className="w-1/12" />
 
-							<Td className="w-1/3 cursor-pointer" onClick={() => goToDeploymentSessions(deploymentId)}>
-								<div className="flex gap-1">
+							<Td className="w-1/3 cursor-pointer">
+								<div className="flex gap-1 pl-2">
 									<DeploymentSessionStats deploymentId={deploymentId} sessionStats={sessionStats} />
 								</div>
 							</Td>


### PR DESCRIPTION
## Description
On the home page it's almost round:
![image](https://github.com/user-attachments/assets/8d08b2e7-06e3-49a8-abf0-f7613b466f49)
On the deployments page it is an ellipse:
![image](https://github.com/user-attachments/assets/6814e561-e5f2-4bd5-96a7-1230bd2dfaf5)
In the design, it's almost round like on the home page:
https://www.figma.com/design/klCZL68fUd6pw0DEu0Sj7f/Autokitteh%3A-Look-%26-Feel-design-versions?node-id=3893-131806&t=gOCQGbQfhGCII5PY-4

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1241/hover-on-sessions-filter-should-be-circle-not-ellipse
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
