### PR TITLE
feat(UI-1242): add warning modal for organization deletion

### DIFF
--- a/src/components/organisms/settings/organization/deleteModal.tsx
+++ b/src/components/organisms/settings/organization/deleteModal.tsx
@@ -17,6 +17,7 @@ export const DeleteOrganizationModal = ({ onDelete, isDeleting }: DeleteOrganiza
 	const organization = useModalStore((state) => state.data) as EnrichedOrganization;
 
 	if (!organization) return null;
+
 	return (
 		<Modal name={ModalName.deleteOrganization}>
 			<div className="mx-6">

--- a/src/components/organisms/settings/user/organizations/table.tsx
+++ b/src/components/organisms/settings/user/organizations/table.tsx
@@ -4,15 +4,16 @@ import omit from "lodash/omit";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
-import { LoggerService } from "@services";
+import { LoggerService, ProjectsService } from "@services";
 import { namespaces } from "@src/constants";
 import { MemberRole } from "@src/enums";
 import { ModalName } from "@src/enums/components";
 import { useModalStore, useOrganizationStore, useToastStore } from "@src/store";
 import { EnrichedOrganization } from "@src/types/models";
 
-import { Button, Typography, IconButton, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
+import { Button, Typography, IconButton, TBody, THead, Table, Td, Th, Tr, Spinner } from "@components/atoms";
 import { DeleteOrganizationModal } from "@components/organisms/settings/organization";
+import { WarningDeleteOrganizationModal } from "@components/organisms/settings/user/organizations/warningDeleteModal";
 
 import { TrashIcon } from "@assets/image/icons";
 
@@ -32,6 +33,10 @@ export const UserOrganizationsTable = () => {
 	const addToast = useToastStore((state) => state.addToast);
 	const navigate = useNavigate();
 	const [organizationsList, setOrganizationsList] = useState<EnrichedOrganization[]>();
+	const [openDeleteOrganizaton, setOpenDeleteOrganizaton] = useState({
+		organizationId: "",
+		isLoading: false,
+	});
 
 	useEffect(() => {
 		getOrganizations();
@@ -89,8 +94,33 @@ export const UserOrganizationsTable = () => {
 		!!(
 			isLoading.updatingOrganization ||
 			user?.defaultOrganizationId === organizationId ||
-			organizationRole !== MemberRole.admin
+			organizationRole !== MemberRole.admin ||
+			openDeleteOrganizaton.isLoading
 		);
+
+	const handleDeleteOrganization = async (organization: EnrichedOrganization) => {
+		setOpenDeleteOrganizaton({ organizationId: organization.id, isLoading: true });
+		const { data: orgProjectList, error } = await ProjectsService.list(organization.id);
+		if (error || !orgProjectList) {
+			addToast({
+				message: t("errors.deleteFailed", {
+					name: organization?.displayName,
+					organizationId: organization?.id,
+				}),
+				type: "error",
+			});
+			return;
+		}
+		const hasProjects = orgProjectList?.length > 0;
+		setOpenDeleteOrganizaton({ organizationId: organization.id, isLoading: false });
+
+		if (!hasProjects) {
+			openModal(ModalName.deleteOrganization, organization);
+			return;
+		}
+
+		openModal(ModalName.warningDeleteOrganization, { name: organization.displayName });
+	};
 
 	return (
 		<div className="w-3/4">
@@ -126,10 +156,15 @@ export const UserOrganizationsTable = () => {
 								<IconButton
 									className="mr-1"
 									disabled={isNameInputDisabled(organization.id, organization.currentMember?.role)}
-									onClick={() => openModal(ModalName.deleteOrganization, organization)}
+									onClick={async () => handleDeleteOrganization(organization)}
 									title={t("table.actions.delete", { name: organization.displayName })}
 								>
-									<TrashIcon className="size-4 stroke-white" />
+									{openDeleteOrganizaton.isLoading &&
+									openDeleteOrganizaton.organizationId === organization.id ? (
+										<Spinner className="size-4" />
+									) : (
+										<TrashIcon className="size-4 stroke-white" />
+									)}
 								</IconButton>
 							</Td>
 						</Tr>
@@ -137,6 +172,7 @@ export const UserOrganizationsTable = () => {
 				</TBody>
 			</Table>
 			<DeleteOrganizationModal isDeleting={isLoading.deletingOrganization} onDelete={onDelete} />
+			<WarningDeleteOrganizationModal />
 		</div>
 	);
 };

--- a/src/components/organisms/settings/user/organizations/warningDeleteModal.tsx
+++ b/src/components/organisms/settings/user/organizations/warningDeleteModal.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import { useTranslation } from "react-i18next";
+
+import { ModalName } from "@enums/components";
+
+import { useModalStore } from "@store";
+
+import { Button } from "@components/atoms";
+import { Modal } from "@components/molecules";
+
+export const WarningDeleteOrganizationModal = () => {
+	const { t } = useTranslation("settings", { keyPrefix: "organization.modal" });
+	const { closeModal } = useModalStore();
+	const organization = useModalStore((state) => state.data) as { name: string };
+
+	if (!organization) return null;
+
+	return (
+		<Modal name={ModalName.warningDeleteOrganization}>
+			<div className="mx-6">
+				<h3 className="mb-5 text-xl font-bold">{t("warning")}</h3>
+				<p className="font-light">{t("organizationDeleteWarning", { name: organization.name })}</p>
+			</div>
+
+			<div className="mt-14 flex justify-end gap-1">
+				<Button
+					ariaLabel={t("buttons.close")}
+					className="w-auto px-4 py-3 font-semibold hover:text-white"
+					onClick={() => closeModal(ModalName.warningDeleteOrganization)}
+				>
+					{t("buttons.close")}
+				</Button>
+			</div>
+		</Modal>
+	);
+};

--- a/src/enums/components/modal.enum.ts
+++ b/src/enums/components/modal.enum.ts
@@ -18,5 +18,6 @@ export enum ModalName {
 	organizationCreated = "organizationCreated",
 	organizationMemberCreate = "organizationMemberCreate",
 	deleteOrganization = "deleteOrganization",
+	warningDeleteOrganization = "warningDeleteOrganization",
 	invitedUser = "invitedUser",
 }

--- a/src/locales/en/settings/translation.json
+++ b/src/locales/en/settings/translation.json
@@ -110,6 +110,8 @@
 			}
 		},
 		"modal": {
+			"warning": "Warning",
+			"organizationDeleteWarning": "To delete the organization {{name}}, you have to delete all projects in it first",
 			"organizationCreated": "Organization {{name}} created",
 			"addMember": "Add new member to organization",
 			"line1": "The action is irreversible.",
@@ -126,6 +128,7 @@
 				"open": "Open {{name}}",
 				"create": "Create",
 				"cancel": "Cancel",
+				"close": "Close",
 				"delete": "Delete"
 			}
 		},


### PR DESCRIPTION
## Description
If the user has projects (1 or more) in the deleted organization, display an error modal - "To delete the organization, you have to delete all projects in it first".

If the user has 0 projects in the organization, display the regular delete modal.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1242/block-organization-delete-if-it-has-active-projects
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
