### PR TITLE
fix(UI-1258): save the manual run configuration on deploy action

### DIFF
--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -67,7 +67,7 @@ export const ManualRunSettingsDrawer = () => {
 			})) || [];
 		setFileFunctions(processedFileFunctions);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filePath]);
+	}, [filePath, files]);
 
 	useEffect(() => {
 		setValue("entrypointFunction", entrypointFunction);

--- a/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSettingsDrawer.tsx
@@ -92,7 +92,7 @@ export const ManualRunSettingsDrawer = () => {
 
 		setSendingManualRun(true);
 		const { params } = getValues();
-
+		updateManualRunConfiguration(projectId, { params });
 		const { data: sessionId, error } = await saveAndExecuteManualRun(projectId, params);
 		setSendingManualRun(false);
 		handleManualRun();

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -66,6 +66,7 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 		projectId,
 		{ activeDeployment, entrypointFunction, filePath, files, isJson, isManualRunEnabled, params }
 	) => {
+		const { entrypointFunction: currentEntrypoint, filePath: currentFile } = get().projectManualRun[projectId];
 		set((state) => {
 			const projectData = {
 				...defaultManualRunState,
@@ -78,13 +79,19 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 					value: file,
 				}));
 
-				Object.assign(projectData, {
-					files,
-					fileOptions,
-					filePath: fileOptions[0],
-					entrypointFunction: null,
-					params: [],
-				});
+				if (!files[currentFile?.value].includes(currentEntrypoint?.value)) {
+					Object.assign(projectData, {
+						files,
+						fileOptions,
+						filePath: fileOptions[0],
+						entrypointFunction: null,
+					});
+				} else {
+					Object.assign(projectData, {
+						files,
+						fileOptions,
+					});
+				}
 			}
 
 			Object.assign(projectData, {

--- a/src/store/useManualRunStore.ts
+++ b/src/store/useManualRunStore.ts
@@ -72,25 +72,17 @@ const store: StateCreator<ManualRunStore> = (set, get) => ({
 				...defaultManualRunState,
 				...state.projectManualRun[projectId],
 			};
-
 			if (files) {
 				const fileOptions = Object.keys(files).map((file) => ({
 					label: file,
 					value: file,
 				}));
 
-				if (!files[currentFile?.value].includes(currentEntrypoint?.value)) {
-					Object.assign(projectData, {
-						files,
-						fileOptions,
-						filePath: fileOptions[0],
-						entrypointFunction: null,
-					});
-				} else {
-					Object.assign(projectData, {
-						files,
-						fileOptions,
-					});
+				projectData.files = files;
+				projectData.fileOptions = fileOptions;
+
+				if (!files[currentFile?.value]?.includes(currentEntrypoint?.value)) {
+					Object.assign(projectData, { filePath: fileOptions[0], entrypointFunction: null });
 				}
 			}
 


### PR DESCRIPTION
## Description
Don't reset the manual run configuration on Deploy

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1258/dont-reset-manual-run-configuration-on-deploy

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
