### PR TITLE
fix(UI-1180): adjust column widths in projects table for better layout

### DIFF
--- a/src/components/organisms/dashboard/projectsTable.tsx
+++ b/src/components/organisms/dashboard/projectsTable.tsx
@@ -110,7 +110,7 @@ export const DashboardProjectsTable = () => {
 					<THead className="mr-0">
 						<Tr className="border-none pl-4">
 							<Th
-								className="group h-11 w-2/3 cursor-pointer font-normal sm:w-1/5"
+								className="group h-11 w-5/12 cursor-pointer font-normal"
 								onClick={() => requestSort("name")}
 							>
 								{t("table.columns.projectName")}
@@ -183,7 +183,7 @@ export const DashboardProjectsTable = () => {
 							}) => (
 								<Tr className="cursor-pointer pl-4 hover:bg-black" key={id}>
 									<Td
-										className="w-2/3 pr-4 hover:font-bold sm:w-1/5"
+										className="w-5/12 pr-4 hover:font-bold"
 										onClick={() => navigate(`/${SidebarHrefMenu.projects}/${id}`)}
 										title={name}
 									>
@@ -193,7 +193,7 @@ export const DashboardProjectsTable = () => {
 										className="hidden w-1/6 sm:flex"
 										onClick={() => navigate(`/${SidebarHrefMenu.projects}/${id}`)}
 									>
-										<div className="max-w-16 pr-4 md:max-w-28">
+										<div className="pr-4">
 											<StatusBadge deploymentStatus={status} />
 										</div>
 									</Td>

--- a/src/components/organisms/dashboard/projectsTable.tsx
+++ b/src/components/organisms/dashboard/projectsTable.tsx
@@ -110,7 +110,7 @@ export const DashboardProjectsTable = () => {
 					<THead className="mr-0">
 						<Tr className="border-none pl-4">
 							<Th
-								className="group h-11 w-5/12 cursor-pointer font-normal"
+								className="group h-11 w-[30%] cursor-pointer font-normal"
 								onClick={() => requestSort("name")}
 							>
 								{t("table.columns.projectName")}
@@ -122,7 +122,7 @@ export const DashboardProjectsTable = () => {
 								/>
 							</Th>
 							<Th
-								className="group hidden h-11 w-1/6 cursor-pointer font-normal sm:flex"
+								className="group hidden h-11 w-[12%] cursor-pointer font-normal sm:flex"
 								onClick={() => requestSort("status")}
 							>
 								<div className="w-full">
@@ -136,7 +136,7 @@ export const DashboardProjectsTable = () => {
 								</div>
 							</Th>
 							<Th
-								className="group hidden h-11 w-1/6 cursor-pointer font-normal sm:flex"
+								className="group hidden h-11 w-[10%] cursor-pointer font-normal sm:flex"
 								onClick={() => requestSort("totalDeployments")}
 							>
 								<div className="w-full text-center">
@@ -149,11 +149,11 @@ export const DashboardProjectsTable = () => {
 									/>
 								</div>
 							</Th>
-							<Th className="group hidden h-11 w-2/6 font-normal sm:flex">
+							<Th className="group hidden h-11 w-1/4 font-normal sm:flex">
 								{t("table.columns.sessions")}
 							</Th>
 							<Th
-								className="group hidden h-11 w-2/6 cursor-pointer font-normal sm:flex"
+								className="group hidden h-11 w-[15%] cursor-pointer font-normal sm:flex"
 								onClick={() => requestSort("lastDeployed")}
 							>
 								{t("table.columns.lastDeployed")}
@@ -164,7 +164,7 @@ export const DashboardProjectsTable = () => {
 									sortDirection={sortConfig.direction}
 								/>
 							</Th>
-							<Th className="group h-11 w-1/3 font-normal sm:w-1/6">{t("table.columns.actions")}</Th>
+							<Th className="group h-11 w-[8%] font-normal">{t("table.columns.actions")}</Th>
 						</Tr>
 					</THead>
 
@@ -183,14 +183,14 @@ export const DashboardProjectsTable = () => {
 							}) => (
 								<Tr className="cursor-pointer pl-4 hover:bg-black" key={id}>
 									<Td
-										className="w-5/12 pr-4 hover:font-bold"
+										className="w-[30%] pr-4 hover:font-bold"
 										onClick={() => navigate(`/${SidebarHrefMenu.projects}/${id}`)}
 										title={name}
 									>
 										<div className="truncate">{name}</div>
 									</Td>
 									<Td
-										className="hidden w-1/6 sm:flex"
+										className="hidden w-[12%] sm:flex"
 										onClick={() => navigate(`/${SidebarHrefMenu.projects}/${id}`)}
 									>
 										<div className="pr-4">
@@ -198,14 +198,14 @@ export const DashboardProjectsTable = () => {
 										</div>
 									</Td>
 									<Td
-										className="hidden w-1/6 sm:flex"
+										className="hidden w-[10%] sm:flex"
 										onClick={() => navigate(`/${SidebarHrefMenu.projects}/${id}`)}
 										title={`${totalDeployments} ${t("table.columns.totalDeployments")}`}
 									>
 										<div className="w-full pr-6 text-center">{totalDeployments}</div>
 									</Td>
 									<Td
-										className="-ml-1 hidden w-2/6 pr-2 sm:flex"
+										className="-ml-1 hidden w-1/4 pr-2 sm:flex"
 										onClick={() => navigate(`/${SidebarHrefMenu.projects}/${id}`)}
 									>
 										<div
@@ -279,7 +279,7 @@ export const DashboardProjectsTable = () => {
 									</Td>
 
 									<Td
-										className="hidden w-2/6 sm:flex"
+										className="hidden w-[15%] sm:flex"
 										onClick={() => navigate(`/${SidebarHrefMenu.projects}/${id}`)}
 									>
 										{lastDeployed
@@ -287,7 +287,7 @@ export const DashboardProjectsTable = () => {
 											: t("never")}
 									</Td>
 
-									<Td className="w-1/3 sm:w-1/6">
+									<Td className="w-[8%]">
 										<div className="flex">
 											<IconButton className="group" onClick={() => downloadProjectExport(id)}>
 												<IconSvg


### PR DESCRIPTION
## Description
The "Last Deployed" field takes too much available space even though its width should constant.

Instead, the "Project Name" field should be largest, and grow if there's extra space left.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1180/project-dashboard-name-should-be-largerst-not-date
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
