### PR TITLE
fix(UI-1268): enhance connection ID display in popover

### DIFF
--- a/src/components/organisms/triggers/table/popoverContent.tsx
+++ b/src/components/organisms/triggers/table/popoverContent.tsx
@@ -52,8 +52,16 @@ export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => 
 				value: triggerConnection?.name,
 			},
 			{
-				label: t("connectionId"),
-				value: <IdCopyButton displayFullLength id={triggerConnection!.connectionId} />,
+				label: triggerConnection?.connectionId ? (
+					t("connectionId")
+				) : (
+					<div className="text-error">{t("connectionNotFound")}</div>
+				),
+				value: triggerConnection?.connectionId ? (
+					<IdCopyButton displayFullLength id={triggerConnection.connectionId} />
+				) : (
+					" "
+				),
 			},
 			...baseDetails,
 			{ label: t("eventType"), value: trigger.eventType },
@@ -87,10 +95,13 @@ export const InformationPopoverContent = ({ trigger }: { trigger: Trigger }) => 
 				<div className="w-full" />
 			</div>
 			{details.map(
-				({ label, value }) =>
+				({ label, value }, index) =>
 					value && (
-						<div className="flex items-center gap-x-1" key={label}>
-							<div className="font-semibold">{label}:</div>
+						<div className="flex items-center gap-x-1" key={index}>
+							<div className="font-semibold">
+								{label}
+								{value.toString().trim() ? ":" : null}
+							</div>
 							{value}
 						</div>
 					)

--- a/src/locales/en/tabs/translation.json
+++ b/src/locales/en/tabs/translation.json
@@ -87,7 +87,8 @@
 			"eventType": "Event type",
 			"filter": "Filter",
 			"connection": "Connection",
-			"connectionId": "Connection ID"
+			"connectionId": "Connection ID",
+			"connectionNotFound": "Connection not found"
 		},
 		"form": {
 			"createdSuccessfully": "Trigger created successfully",

--- a/src/types/components/tables/triggersTable.type.ts
+++ b/src/types/components/tables/triggersTable.type.ts
@@ -4,6 +4,6 @@ export type SortableColumns = keyof Pick<Trigger, "name" | "sourceType" | "entry
 
 export type TriggerPopoverInformation = {
 	icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-	label: string;
+	label: string | React.ReactNode;
 	value?: string | React.ReactNode;
 };


### PR DESCRIPTION
## Description
In the trigger info popover - check if connectionId is not defined, show error message
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1268/trigger-connectionid-not-defined-error
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
