### PR TITLE
fix(UI-1277): update height dashboard and intro components

### DIFF
--- a/src/components/pages/dashboard.tsx
+++ b/src/components/pages/dashboard.tsx
@@ -37,7 +37,7 @@ export const Dashboard = () => {
 	}, [isLoadingProjectsList, projectsList]);
 
 	return (
-		<div className="flex w-full overflow-hidden rounded-none md:mt-1.5 md:rounded-2xl">
+		<div className="flex size-full overflow-hidden rounded-none md:mt-1.5 md:rounded-2xl">
 			<div className="relative flex w-2/3 flex-col" style={{ width: `${!isMobile ? leftSideWidth : 100}%` }}>
 				<Frame className="flex-1 rounded-none bg-gray-1100 md:rounded-r-none md:pb-0">
 					<DashboardTopbar />

--- a/src/components/pages/intro.tsx
+++ b/src/components/pages/intro.tsx
@@ -12,7 +12,7 @@ export const Intro = () => {
 	const { isIOS, isMobile } = useWindowDimensions();
 
 	return (
-		<div className="my-0 flex w-full overflow-hidden rounded-none md:mt-1.5 md:rounded-2xl">
+		<div className="flex size-full overflow-hidden rounded-none md:mt-1.5 md:rounded-2xl">
 			<div
 				className="relative flex w-2/3 flex-col"
 				style={{ width: `${!(isIOS || isMobile) ? leftSideWidth : 100}%` }}


### PR DESCRIPTION
## Description
When we log in (we can see that on staging/production where the loading is slower), the projects table homepage "jumps" from 70% height to 100%.

Also, when we filter templates category to a category with a small number of templates 1-4 on large screens, the homepage height becomes partial (around 70%) height and it looks bad.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1277/stretch-the-homepage-to-full-height-on-login-and-templates-filter
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
