### PR TITLE
fix(UI-1289): fix deployment row click handling in table

### DIFF
--- a/src/components/organisms/deployments/sessionStats.tsx
+++ b/src/components/organisms/deployments/sessionStats.tsx
@@ -58,21 +58,22 @@ export const DeploymentSessionStats = ({
 	};
 
 	return sessionStatsOrdered.map(({ count, state }) => (
-		<div
-			aria-label={`${count} ${t(state?.toString() || "")}`}
-			className={countStyle(state)}
-			key={state}
-			onClick={(event) => {
-				handleOpenProjectFilteredSessions(event, state);
-			}}
-			onKeyDown={(event) => {
-				handleOpenProjectFilteredSessions(event, state);
-			}}
-			role="button"
-			tabIndex={0}
-			title={`${count} ${t(state?.toString() || "")}`}
-		>
-			<div className="inline-block min-w-12 truncate rounded-3xl px-2.5 py-1 hover:bg-gray-1100">{count}</div>
+		<div className={countStyle(state)} key={state}>
+			<div
+				aria-label={`${count} ${t(state?.toString() || "")}`}
+				className="inline-block min-w-12 truncate rounded-3xl px-2.5 py-1 hover:bg-gray-1100"
+				onClick={(event) => {
+					handleOpenProjectFilteredSessions(event, state);
+				}}
+				onKeyDown={(event) => {
+					handleOpenProjectFilteredSessions(event, state);
+				}}
+				role="button"
+				tabIndex={0}
+				title={`${count} ${t(state?.toString() || "")}`}
+			>
+				{count}
+			</div>
 		</div>
 	));
 };

--- a/src/components/organisms/deployments/tableContent.tsx
+++ b/src/components/organisms/deployments/tableContent.tsx
@@ -198,11 +198,12 @@ export const DeploymentsTableContent = ({
 
 				<TBody>
 					{sortedDeployments.map(({ buildId, createdAt, deploymentId, sessionStats, state }) => (
-						<Tr className="hover:bg-gray-1300" key={deploymentId}>
-							<Td
-								className="w-1/8 cursor-pointer pl-4"
-								onClick={() => goToDeploymentSessions(deploymentId)}
-							>
+						<Tr
+							className="hover:bg-gray-1300"
+							key={deploymentId}
+							onClick={() => goToDeploymentSessions(deploymentId)}
+						>
+							<Td className="w-1/8 cursor-pointer pl-4">
 								{moment(createdAt).local().format(dateTimeFormat)}
 							</Td>
 							<Td className="w-1/12" />
@@ -218,10 +219,7 @@ export const DeploymentsTableContent = ({
 								<IdCopyButton id={buildId} />
 							</Td>
 
-							<Td
-								className="w-1/8 cursor-pointer border-r-0"
-								onClick={() => goToDeploymentSessions(deploymentId)}
-							>
+							<Td className="w-1/8 cursor-pointer border-r-0">
 								<StatusBadge deploymentStatus={state} />
 							</Td>
 


### PR DESCRIPTION
## Description
click between statuses or near the status (when we don't see the hover) should take us to all sessions filter and not by status
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1289/session-stats-click-on-empty-space
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
