### PR TITLE
fix(UI-1299): fix translation keys in session outputs and activities

### DIFF
--- a/src/locales/en/deployments/translation.json
+++ b/src/locales/en/deployments/translation.json
@@ -172,7 +172,6 @@
 		},
 		"row": {
 			"functionName": "Function"
-
 		}
 	}
 }

--- a/src/locales/en/deployments/translation.json
+++ b/src/locales/en/deployments/translation.json
@@ -136,7 +136,9 @@
 			"invalidByteArray": "Invalid or missing byte array",
 			"errorDecodingText": "Error decoding text, {{error}}",
 			"activityLogsFetchError": "Couldn't fetch the activity logs",
-			"outputLogsFetchError": "Couldn't fetch the output logs"
+			"outputLogsFetchError": "Couldn't fetch the output logs",
+			"noActivitiesFound": "No activites found",
+			"noLogsFound": "No logs found"
 		},
 		"actions":{
 			"sessionStoppedSuccessfully": "Session request successfully sent",
@@ -172,9 +174,5 @@
 			"functionName": "Function"
 
 		}
-	},
-	"sessionAndActivities":{
-		"noActivitiesFound": "No activites found",
-		"noLogsFound": "No logs found"
 	}
 }


### PR DESCRIPTION
## Description
Translation bug on activities and sessions:
![image](https://github.com/user-attachments/assets/768a89ce-3a10-44e8-b75e-8ab489522070)

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1299/translation-bug-on-activities-and-sessions

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
