### PR TITLE
fix(UI-1300): add required fields for entry function and file path in trigger form

### DIFF
--- a/src/components/organisms/triggers/formParts/fileAndFunction.tsx
+++ b/src/components/organisms/triggers/formParts/fileAndFunction.tsx
@@ -110,6 +110,7 @@ export const TriggerSpecificFields = ({
 			<div className="relative">
 				<Input
 					aria-label={t("placeholders.functionName")}
+					isRequired
 					{...register("entryFunction")}
 					isError={!!errors.entryFunction}
 					label={t("placeholders.functionName")}

--- a/src/components/organisms/triggers/formParts/nameAndConnection.tsx
+++ b/src/components/organisms/triggers/formParts/nameAndConnection.tsx
@@ -40,6 +40,7 @@ export const NameAndConnectionFields = ({ isEdit }: { isEdit?: boolean }) => {
 					{...register("name")}
 					disabled={isEdit}
 					isError={!!errors.name}
+					isRequired
 					label={t("placeholders.name")}
 					value={watchedName}
 				/>

--- a/src/locales/en/tabs/translation.json
+++ b/src/locales/en/tabs/translation.json
@@ -157,8 +157,8 @@
 				"nameRequired": "Name is required",
 				"connectionRequired": "Connection is required",
 				"invalidCron": "Cron expression is required and must be valid for schedule triggers",
-				"functionRequired": "Entry function is required when file path is specified",
-				"fileRequired": "File path is required when entry function is specified"
+				"functionRequired": "Entry function is required",
+				"fileRequired": "File path is required"
 			}
 		},
 		"table": {

--- a/src/validations/trigger.schema.ts
+++ b/src/validations/trigger.schema.ts
@@ -16,41 +16,20 @@ const cronFormat =
 	")$";
 
 i18n.on("initialized", () => {
-	triggerSchema = z
-		.object({
-			name: z.string().min(1, i18n.t("triggers.form.validations.nameRequired", { ns: "tabs" })),
-			connection: selectSchema.refine((value) => value.label, {
-				message: i18n.t("triggers.form.validations.connectionRequired", { ns: "tabs" }),
-			}),
-			filePath: z
-				.union([selectSchema, z.object({ label: z.string().optional(), value: z.string().optional() })])
-				.optional(),
-			entryFunction: z.string().optional(),
-			eventType: z.string().optional(),
-			eventTypeSelect: selectSchema.optional(),
-			filter: z.string().optional(),
-			cron: z.string().optional(),
-		})
-		.superRefine((data, ctx) => {
-			if (data.entryFunction?.trim() && !data.filePath?.value) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: i18n.t("triggers.form.validations.fileRequired", { ns: "tabs" }),
-					path: ["filePath"],
-				});
-			}
-
-			if (!data.filePath?.value) {
-				return;
-			}
-			if (!data.entryFunction || data.entryFunction.trim() === "") {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: i18n.t("triggers.form.validations.functionRequired", { ns: "tabs" }),
-					path: ["entryFunction"],
-				});
-			}
-		});
+	triggerSchema = z.object({
+		name: z.string().min(1, i18n.t("triggers.form.validations.nameRequired", { ns: "tabs" })),
+		connection: selectSchema.refine((value) => value.label, {
+			message: i18n.t("triggers.form.validations.connectionRequired", { ns: "tabs" }),
+		}),
+		filePath: selectSchema.refine((value) => value.label, {
+			message: i18n.t("triggers.form.validations.fileRequired", { ns: "tabs" }),
+		}),
+		entryFunction: z.string().min(1, i18n.t("triggers.form.validations.functionRequired", { ns: "tabs" })),
+		eventType: z.string().optional(),
+		eventTypeSelect: selectSchema.optional(),
+		filter: z.string().optional(),
+		cron: z.string().optional(),
+	});
 });
 
 export type TriggerFormData = z.infer<typeof triggerSchema>;


### PR DESCRIPTION
## Description
The user shouldn't be able to save a trigger without file and function.

Check on all trigger types: connection, scheduler, webhook
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1300/disable-trigger-save-without-file-and-function
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
