### PR TITLE
fix(UI-1321): fix slack oauth edit

### DIFF
--- a/src/components/organisms/connections/integrations/slack/edit.tsx
+++ b/src/components/organisms/connections/integrations/slack/edit.tsx
@@ -12,7 +12,7 @@ export const SlackIntegrationEditForm = () => (
 		integrationType={Integrations.slack}
 		schemas={{
 			[ConnectionAuthType.Socket]: slackIntegrationSchema,
-			[ConnectionAuthType.Oauth]: oauthSchema,
+			[ConnectionAuthType.OauthDefault]: oauthSchema,
 		}}
 		selectOptions={selectIntegrationSlack}
 	/>


### PR DESCRIPTION
## Description
Can't edit Slack connections

Observed in my local server (head = main branch), not in prod.

After initializing a Slack OAuth connection, the auth_type is set (by the frontend, not the backend) to "oauthDefault". This is fine, but the web UI (v2.135.0) doesn't know this value yet, so if the user tries to edit the connection, they see this:

![image](https://github.com/user-attachments/assets/1567c692-78c1-4e36-96c4-dda6525e34a7)

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1321/cant-edit-slack-connections

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
