### PR TITLE
feat(UI-1315): update refresh organizations list on any page

### DIFF
--- a/src/components/organisms/sidebar/userMenu.tsx
+++ b/src/components/organisms/sidebar/userMenu.tsx
@@ -20,12 +20,13 @@ import { AnnouncementIcon, LogoutIcon } from "@assets/image/icons/sidebar";
 
 export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void }) => {
 	const { t } = useTranslation("sidebar");
-	const { logoutFunction, user } = useOrganizationStore();
 	const { close } = usePopoverContext();
 	const {
+		logoutFunction,
 		getEnrichedOrganizations,
 		isLoading,
 		currentOrganization,
+		user,
 		updateMemberStatus,
 		getCurrentOrganizationEnriched,
 	} = useOrganizationStore();

--- a/src/store/useOrganizationStore.ts
+++ b/src/store/useOrganizationStore.ts
@@ -180,7 +180,9 @@ const store: StateCreator<OrganizationStore> = (set, get) => ({
 		return { data: undefined, error: undefined };
 	},
 
-	getEnrichedOrganizations: () => {
+	getEnrichedOrganizations: async () => {
+		await get().getOrganizations();
+
 		const { organizations, members, user, currentOrganization } = get();
 		if (!user?.id || !currentOrganization || !Object.keys(organizations).length || !Object.keys(members).length) {
 			LoggerService.error(


### PR DESCRIPTION
## Description
If we add someone to a new organization, we want him/her to see the new organization in his/her organizations list on the next refresh.

Every open user settings popover refresh organizations
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1315/refresh-organizations-list-on-any-page-refresh
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
