### PR TITLE
fix(UI-1298): simplify run button disable logic

### DIFF
--- a/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from "react";
 
+import { isEqual } from "lodash";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
@@ -72,7 +73,7 @@ export const ManualRunButtons = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [projectId]);
 
-	const isRunDisabled = !isManualRunEnabled || entrypointFunction === emptySelectItem || savingManualRun;
+	const isRunDisabled = isEqual(entrypointFunction, emptySelectItem) || savingManualRun;
 
 	return (
 		<div className="relative flex h-8 gap-1.5 self-center rounded-3xl border border-gray-750 p-1 transition hover:border-white">


### PR DESCRIPTION
## Description
Fix - deployments table shows the new deployment, but manual run is disabled (as if there are no deployments)
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1298/cant-do-manual-run-after-deploying-from-cli
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
