### PR TITLE
feat(UI-1369): add size prop to TemplateIntegrationsIcon

### DIFF
--- a/src/components/molecules/templateIntegrationsIcons.tsx
+++ b/src/components/molecules/templateIntegrationsIcons.tsx
@@ -30,10 +30,12 @@ const TemplateIntegrationsIcon = ({
 	totalIntegrationsInTemplate,
 	iconClassName,
 	wrapperClassName,
+	size,
 }: {
 	iconClassName?: string;
 	index: number;
 	integration: string;
+	size?: "2xl" | "xl";
 	totalIntegrationsInTemplate: number;
 	wrapperClassName?: string;
 }) => {
@@ -44,15 +46,16 @@ const TemplateIntegrationsIcon = ({
 
 	const { icon, label } = enrichedIntegration;
 
-	const iconClass = cn("z-10 rounded-full p-1", iconClassName);
+	const iconClass = cn("z-10 rounded-full p-0.5", iconClassName);
 	const wrapperClass = cn(
-		"relative flex size-10 items-center justify-center rounded-full bg-gray-1400",
+		"relative flex size-8 items-center justify-center rounded-full bg-gray-1400",
+		{ "size-10": size === "2xl" },
 		wrapperClassName
 	);
 
 	return (
 		<div className={wrapperClass} key={index} title={label}>
-			<IconSvg className={iconClass} size="2xl" src={icon} />
+			<IconSvg className={iconClass} size={size} src={icon} />
 			<ConnectorIcon show={index < totalIntegrationsInTemplate - 1} />
 		</div>
 	);
@@ -63,9 +66,11 @@ export const TemplateIntegrationsIcons = ({
 	className,
 	iconClassName,
 	wrapperClassName,
+	size = "xl",
 }: {
 	className?: string;
 	iconClassName?: string;
+	size?: "2xl" | "xl";
 	template?: TemplateMetadata;
 	wrapperClassName?: string;
 }) => {
@@ -79,6 +84,7 @@ export const TemplateIntegrationsIcons = ({
 					index={index}
 					integration={integration}
 					key={index}
+					size={size}
 					totalIntegrationsInTemplate={template.integrations.length}
 					wrapperClassName={wrapperClassName}
 				/>

--- a/src/components/organisms/templateStart.tsx
+++ b/src/components/organisms/templateStart.tsx
@@ -67,6 +67,7 @@ export const TemplateStart = ({ assetDir }: { assetDir: string }) => {
 							<div className="space-y-6">
 								<TemplateIntegrationsIcons
 									iconClassName="bg-white/90 hover:bg-white transition-colors duration-200"
+									size="2xl"
 									template={selectedTemplate}
 									wrapperClassName="shadow-[0_0_15px_-3px_rgba(188,248,112,0.5)] hover:shadow-[0_0_20px_-3px_rgba(188,248,112,0.7)]
 									  transition-shadow duration-200"


### PR DESCRIPTION
## Description

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1369/change-size-integration-icons
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
