### PR TITLE
fix(UI-1379): hide create and import buttons on mobile

### DIFF
--- a/src/components/organisms/topbar/dashboard.tsx
+++ b/src/components/organisms/topbar/dashboard.tsx
@@ -30,7 +30,7 @@ export const DashboardTopbar = () => {
 					{t("welcome")}
 				</Typography>
 
-				<div className="relative flex h-8 gap-1.5 self-center rounded-3xl border border-gray-750 p-1 transition hover:border-white">
+				<div className="relative hidden h-8 gap-1.5 self-center rounded-3xl border border-gray-750 p-1 transition hover:border-white md:block ">
 					<Button
 						ariaLabel={t("buttons.newProject")}
 						className="group h-full gap-2 whitespace-nowrap p-1 hover:bg-gray-1050 active:bg-black"

--- a/src/components/organisms/topbar/dashboard.tsx
+++ b/src/components/organisms/topbar/dashboard.tsx
@@ -30,7 +30,7 @@ export const DashboardTopbar = () => {
 					{t("welcome")}
 				</Typography>
 
-				<div className="relative hidden h-8 gap-1.5 self-center rounded-3xl border border-gray-750 p-1 transition hover:border-white md:block ">
+				<div className="relative hidden h-8 gap-1.5 self-center rounded-3xl border border-gray-750 p-1 transition hover:border-white md:flex ">
 					<Button
 						ariaLabel={t("buttons.newProject")}
 						className="group h-full gap-2 whitespace-nowrap p-1 hover:bg-gray-1050 active:bg-black"


### PR DESCRIPTION
## Description

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1379/remove-addimport-project-buttons-from-mobile-introlanding-page

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
