### PR TITLE
feat(UI-1376): fix filtering for connection type options on edit form

### DIFF
--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -10,7 +10,7 @@ import {
 	defaultGoogleConnectionName,
 	isGoogleIntegration,
 	isLegacyIntegration,
-	hasDuplicateSelectConnectionType,
+	hasLegacyConnectionType,
 } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { SelectOption } from "@src/interfaces/components";
@@ -97,7 +97,7 @@ export const IntegrationEditForm = ({
 	);
 
 	const filteredSelectOptions = useMemo(() => {
-		if (hasDuplicateSelectConnectionType(integrationType) && !connectionType) {
+		if (hasLegacyConnectionType(integrationType) && !connectionType) {
 			return selectOptions.filter((authMethod) => authMethod.value !== ConnectionAuthType.Oauth);
 		}
 

--- a/src/components/organisms/connections/integrations/integrationEditForm.tsx
+++ b/src/components/organisms/connections/integrations/integrationEditForm.tsx
@@ -10,6 +10,7 @@ import {
 	defaultGoogleConnectionName,
 	isGoogleIntegration,
 	isLegacyIntegration,
+	hasDuplicateSelectConnectionType,
 } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { SelectOption } from "@src/interfaces/components";
@@ -95,6 +96,14 @@ export const IntegrationEditForm = ({
 		[connectionType, selectOptions]
 	);
 
+	const filteredSelectOptions = useMemo(() => {
+		if (hasDuplicateSelectConnectionType(integrationType) && !connectionType) {
+			return selectOptions.filter((authMethod) => authMethod.value !== ConnectionAuthType.Oauth);
+		}
+
+		return selectOptions;
+	}, [connectionType, selectOptions, integrationType]);
+
 	const onSubmit = () => {
 		if (
 			connectionId &&
@@ -140,7 +149,7 @@ export const IntegrationEditForm = ({
 				disabled={initialConnectionType}
 				label={t("placeholders.connectionType")}
 				onChange={handleConnectionTypeChange}
-				options={selectOptions}
+				options={filteredSelectOptions}
 				placeholder={t("placeholders.selectConnectionType")}
 				value={selectConnectionTypeValue}
 			/>

--- a/src/enums/components/connection.enum.ts
+++ b/src/enums/components/connection.enum.ts
@@ -84,7 +84,7 @@ export function isLegacyIntegration(integration: Integrations) {
 	);
 }
 
-export function hasDuplicateSelectConnectionType(integration: Integrations): integration is GoogleIntegrationType {
+export function hasLegacyConnectionType(integration: Integrations): integration is GoogleIntegrationType {
 	return [Integrations.github, Integrations.slack].includes(integration);
 }
 

--- a/src/enums/components/connection.enum.ts
+++ b/src/enums/components/connection.enum.ts
@@ -84,6 +84,10 @@ export function isLegacyIntegration(integration: Integrations) {
 	);
 }
 
+export function hasDuplicateSelectConnectionType(integration: Integrations): integration is GoogleIntegrationType {
+	return [Integrations.github, Integrations.slack].includes(integration);
+}
+
 export enum IntegrationForTemplates {
 	githubcopilot = "githubcopilot",
 	sqlite3 = "sqlite3",

--- a/src/enums/components/index.ts
+++ b/src/enums/components/index.ts
@@ -8,7 +8,7 @@ export {
 	fitleredIntegrationsMap,
 	HiddenIntegrationsForTemplates,
 	defaultAtlassianConnectionName,
-	hasDuplicateSelectConnectionType,
+	hasLegacyConnectionType,
 } from "@enums/components/connection.enum";
 export { DrawerName } from "@enums/components/drawer.enum";
 export { InputVariant } from "@enums/components/input.enum";

--- a/src/enums/components/index.ts
+++ b/src/enums/components/index.ts
@@ -8,6 +8,7 @@ export {
 	fitleredIntegrationsMap,
 	HiddenIntegrationsForTemplates,
 	defaultAtlassianConnectionName,
+	hasDuplicateSelectConnectionType,
 } from "@enums/components/connection.enum";
 export { DrawerName } from "@enums/components/drawer.enum";
 export { InputVariant } from "@enums/components/input.enum";


### PR DESCRIPTION
## Description
Fix Slack and GitHub edit mode - (when auth_type select is not disabled) - don’t show “oauth” option, only “oauthXXX”
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1376/fix-slack-and-github-edit-mode-when-auth-type-select-is-not-disabled
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
