### PR TITLE
feat(UI-1364): disable input fields during loading state for various integrations

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
     "bracketSpacing": true,
     "jsxSingleQuote": false,
     "printWidth": 120,
-    "quoteProps": "consistent",
+    "quoteProps": "as-needed",
     "semi": true,
     "singleQuote": false,
     "tabWidth": 4,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,13 +63,13 @@ export default [
 		plugins: {
 			"react-refresh": reactRefresh,
 			unicorn,
-			"import": fixupPluginRules(_import),
+			import: fixupPluginRules(_import),
 			"@typescript-eslint": fixupPluginRules(typescriptEslint),
-			"promise": fixupPluginRules(promise),
+			promise: fixupPluginRules(promise),
 			"@liferay": fixupPluginRules(liferay),
 			"local-rules": localRules,
 			perfectionist,
-			"prettier": fixupPluginRules(prettier),
+			prettier: fixupPluginRules(prettier),
 		},
 
 		languageOptions: {
@@ -81,7 +81,7 @@ export default [
 		},
 
 		settings: {
-			"react": {
+			react: {
 				version: "detect",
 			},
 
@@ -165,7 +165,7 @@ export default [
 					bracketSpacing: true,
 					jsxSingleQuote: false,
 					printWidth: 120,
-					quoteProps: "consistent",
+					quoteProps: "as-needed",
 					semi: true,
 					singleQuote: false,
 					tabWidth: 4,
@@ -292,12 +292,12 @@ export default [
 			"import/order": [
 				"error",
 				{
-					"groups": [
+					groups: [
 						["builtin", "external"],
 						["internal", "parent", "sibling", "index"],
 					],
 
-					"pathGroups": [
+					pathGroups: [
 						{
 							pattern: "react",
 							group: "external",
@@ -325,10 +325,10 @@ export default [
 						},
 					],
 
-					"pathGroupsExcludedImportTypes": ["react"],
+					pathGroupsExcludedImportTypes: ["react"],
 					"newlines-between": "always",
 
-					"alphabetize": {
+					alphabetize: {
 						order: "asc",
 						caseInsensitive: true,
 					},

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 		<script>
 			(function (w, d, s, l, i) {
 				w[l] = w[l] || [];
-				w[l].push({ "gtm.start": new Date().getTime(), "event": "gtm.js" });
+				w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
 				var f = d.getElementsByTagName(s)[0],
 					j = d.createElement(s),
 					dl = l != "dataLayer" ? "&l=" + l : "";

--- a/src/components/atoms/icons/iconSvg.tsx
+++ b/src/components/atoms/icons/iconSvg.tsx
@@ -13,11 +13,11 @@ export const IconSvg = ({
 	withCircle,
 }: IconSvgProps) => {
 	const sizeClasses = {
-		"xs": "w-2 h-2",
-		"sm": "w-3 h-3",
-		"md": "w-4 h-4",
-		"lg": "w-5 h-5",
-		"xl": "w-6 h-6",
+		xs: "w-2 h-2",
+		sm: "w-3 h-3",
+		md: "w-4 h-4",
+		lg: "w-5 h-5",
+		xl: "w-6 h-6",
 		"2xl": "w-8 h-8",
 		"3xl": "w-10 h-10",
 		"36": "w-36 h-36",

--- a/src/components/atoms/secretInput.tsx
+++ b/src/components/atoms/secretInput.tsx
@@ -94,7 +94,7 @@ export const SecretInput = forwardRef<HTMLInputElement, SecretInputProps>((props
 
 	const inputClass = cn(
 		"h-12 w-full bg-transparent px-4 py-2.5 placeholder-gray-600 outline-none",
-		{ "text-gray-400": disabled },
+		{ "text-gray-750": disabled },
 		{ "text-white": variant === InputVariant.dark },
 		{ "placeholder-gray-1000": variant === InputVariant.light },
 		{ "autofill-black": variant === InputVariant.light && !disabled },

--- a/src/components/atoms/table/tR.tsx
+++ b/src/components/atoms/table/tR.tsx
@@ -26,10 +26,10 @@ export const Tr = ({ children, className, onClick, style }: TableProps) => {
 	const interactiveProps = onClick
 		? {
 				onClick,
-				"onKeyDown": handleKeyDown,
-				"tabIndex": 0,
+				onKeyDown: handleKeyDown,
+				tabIndex: 0,
 				"aria-label": "Select row",
-				"style": { ...style, cursor: "pointer" },
+				style: { ...style, cursor: "pointer" },
 			}
 		: { style };
 

--- a/src/components/atoms/typography.tsx
+++ b/src/components/atoms/typography.tsx
@@ -12,13 +12,13 @@ export const Typography = <E extends ElementType = "div">({
 }: TypographyProps<E>) => {
 	const Element = element || "div";
 	const sizeClasses = {
-		"default": "",
+		default: "",
 		"2xl": "text-2xl",
 		"1.5xl": "text-1.5xl",
-		"xl": "text-xl",
-		"large": "text-lg",
-		"medium": "text-base",
-		"small": "text-sm",
+		xl: "text-xl",
+		large: "text-lg",
+		medium: "text-base",
+		small: "text-sm",
 	};
 
 	const typographyClass = cn(sizeClasses[size], className);

--- a/src/components/organisms/connections/add.tsx
+++ b/src/components/organisms/connections/add.tsx
@@ -17,7 +17,7 @@ import { ActiveDeploymentWarning, Select, TabFormHeader } from "@components/mole
 
 export const AddConnection = () => {
 	const { t } = useTranslation("integrations");
-	const { connectionId, errors, handleSubmit, onSubmit, register, setValue, watch } = useConnectionForm(
+	const { connectionId, errors, handleSubmit, onSubmit, register, setValue, watch, isLoading } = useConnectionForm(
 		connectionSchema,
 		"create"
 	);
@@ -44,7 +44,7 @@ export const AddConnection = () => {
 					<Input
 						aria-label={t("placeholders.name")}
 						{...register("connectionName")}
-						disabled={!!connectionId}
+						disabled={!!connectionId || isLoading}
 						isError={!!errors.connectionName}
 						isRequired
 						label={t("placeholders.name")}
@@ -56,7 +56,7 @@ export const AddConnection = () => {
 				<Select
 					aria-label={t("placeholders.selectIntegration")}
 					dataTestid="select-integration"
-					disabled={!!connectionId}
+					disabled={!!connectionId || isLoading}
 					label={t("placeholders.integration")}
 					onChange={(selectedIntegration) => setValue("integration", selectedIntegration)}
 					options={integrationTypes}
@@ -69,6 +69,7 @@ export const AddConnection = () => {
 				{SelectedIntegrationComponent ? (
 					<SelectedIntegrationComponent
 						connectionId={connectionId}
+						isCreatingConnection={isLoading}
 						triggerParentFormSubmit={handleSubmit(onSubmit)}
 						type={selectedIntegration?.value}
 					/>

--- a/src/components/organisms/connections/add.tsx
+++ b/src/components/organisms/connections/add.tsx
@@ -69,7 +69,6 @@ export const AddConnection = () => {
 				{SelectedIntegrationComponent ? (
 					<SelectedIntegrationComponent
 						connectionId={connectionId}
-						isCreatingConnection={isLoading}
 						triggerParentFormSubmit={handleSubmit(onSubmit)}
 						type={selectedIntegration?.value}
 					/>

--- a/src/components/organisms/connections/integrations/asana/add.tsx
+++ b/src/components/organisms/connections/integrations/asana/add.tsx
@@ -16,8 +16,10 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const AsanaIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -40,6 +42,7 @@ export const AsanaIntegrationAddForm = ({
 				<Input
 					{...register("pat")}
 					aria-label={t("asana.placeholders.pat")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.pat}
 					isRequired
 					label={t("asana.placeholders.pat")}
@@ -63,11 +66,15 @@ export const AsanaIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
+				disabled={isCreatingConnection || isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+				{isCreatingConnection || isLoading ? (
+					<Spinner />
+				) : (
+					<FloppyDiskIcon className="size-5 fill-white transition" />
+				)}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/asana/add.tsx
+++ b/src/components/organisms/connections/integrations/asana/add.tsx
@@ -16,10 +16,8 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const AsanaIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -42,7 +40,7 @@ export const AsanaIntegrationAddForm = ({
 				<Input
 					{...register("pat")}
 					aria-label={t("asana.placeholders.pat")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.pat}
 					isRequired
 					label={t("asana.placeholders.pat")}
@@ -66,15 +64,11 @@ export const AsanaIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isCreatingConnection || isLoading ? (
-					<Spinner />
-				) : (
-					<FloppyDiskIcon className="size-5 fill-white transition" />
-				)}
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/asana/edit.tsx
+++ b/src/components/organisms/connections/integrations/asana/edit.tsx
@@ -34,6 +34,7 @@ export const AsanaIntegrationEditForm = () => {
 					type="password"
 					{...register("pat")}
 					aria-label={t("asana.placeholders.pat")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("pat", newValue)}
 					handleLockAction={setLockState}
 					isError={!!errors.pat}

--- a/src/components/organisms/connections/integrations/auth0/add.tsx
+++ b/src/components/organisms/connections/integrations/auth0/add.tsx
@@ -6,7 +6,7 @@ import { Integrations } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { auth0IntegrationSchema } from "@validations";
 
-import { Button, ErrorMessage, Input, Link, Loader } from "@components/atoms";
+import { Button, ErrorMessage, Input, Link, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -85,12 +85,12 @@ export const Auth0IntegrationAddForm = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/auth0/add.tsx
+++ b/src/components/organisms/connections/integrations/auth0/add.tsx
@@ -14,10 +14,8 @@ import { ExternalLinkIcon } from "@assets/image/icons";
 export const Auth0IntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -40,7 +38,7 @@ export const Auth0IntegrationAddForm = ({
 				<Input
 					{...register("client_id")}
 					aria-label={t("auth0.placeholders.client_id")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.client_id}
 					isRequired
 					label={t("auth0.placeholders.client_id")}
@@ -52,7 +50,7 @@ export const Auth0IntegrationAddForm = ({
 				<Input
 					{...register("client_secret")}
 					aria-label={t("auth0.placeholders.client_secret")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.client_secret}
 					isRequired
 					label={t("auth0.placeholders.client_secret")}
@@ -64,7 +62,7 @@ export const Auth0IntegrationAddForm = ({
 				<Input
 					{...register("auth0_domain")}
 					aria-label={t("auth0.placeholders.auth0_domain")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.auth0_domain}
 					isRequired
 					label={t("auth0.placeholders.auth0_domain")}
@@ -88,11 +86,11 @@ export const Auth0IntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isCreatingConnection || isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/auth0/add.tsx
+++ b/src/components/organisms/connections/integrations/auth0/add.tsx
@@ -14,8 +14,10 @@ import { ExternalLinkIcon } from "@assets/image/icons";
 export const Auth0IntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -38,6 +40,7 @@ export const Auth0IntegrationAddForm = ({
 				<Input
 					{...register("client_id")}
 					aria-label={t("auth0.placeholders.client_id")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.client_id}
 					isRequired
 					label={t("auth0.placeholders.client_id")}
@@ -49,6 +52,7 @@ export const Auth0IntegrationAddForm = ({
 				<Input
 					{...register("client_secret")}
 					aria-label={t("auth0.placeholders.client_secret")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.client_secret}
 					isRequired
 					label={t("auth0.placeholders.client_secret")}
@@ -60,6 +64,7 @@ export const Auth0IntegrationAddForm = ({
 				<Input
 					{...register("auth0_domain")}
 					aria-label={t("auth0.placeholders.auth0_domain")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.auth0_domain}
 					isRequired
 					label={t("auth0.placeholders.auth0_domain")}
@@ -83,11 +88,11 @@ export const Auth0IntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
-				disabled={isLoading}
+				disabled={isCreatingConnection || isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isCreatingConnection || isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/auth0/edit.tsx
+++ b/src/components/organisms/connections/integrations/auth0/edit.tsx
@@ -42,6 +42,7 @@ export const Auth0IntegrationEditForm = () => {
 				<Input
 					{...register("client_id")}
 					aria-label={t("auth0.placeholders.client_id")}
+					disabled={isLoading}
 					isError={!!errors.client_id}
 					isRequired
 					label={t("auth0.placeholders.client_id")}
@@ -54,6 +55,7 @@ export const Auth0IntegrationEditForm = () => {
 				<SecretInput
 					{...register("client_secret")}
 					aria-label={t("auth0.placeholders.client_secret")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("client_secret", newValue)}
 					handleLockAction={setLockState}
 					isError={!!errors.client_secret}
@@ -70,6 +72,7 @@ export const Auth0IntegrationEditForm = () => {
 				<Input
 					{...register("auth0_domain")}
 					aria-label={t("auth0.placeholders.auth0_domain")}
+					disabled={isLoading}
 					isError={!!errors.auth0_domain}
 					isRequired
 					label={t("auth0.placeholders.auth0_domain")}

--- a/src/components/organisms/connections/integrations/auth0/edit.tsx
+++ b/src/components/organisms/connections/integrations/auth0/edit.tsx
@@ -10,7 +10,7 @@ import { useConnectionForm } from "@src/hooks";
 import { setFormValues } from "@src/utilities";
 import { auth0IntegrationSchema } from "@validations";
 
-import { Button, ErrorMessage, Input, Loader, SecretInput } from "@components/atoms";
+import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -96,12 +96,12 @@ export const Auth0IntegrationEditForm = () => {
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/aws/add.tsx
+++ b/src/components/organisms/connections/integrations/aws/add.tsx
@@ -16,8 +16,10 @@ import { FloppyDiskIcon } from "@assets/image/icons";
 export const AwsIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -39,6 +41,7 @@ export const AwsIntegrationAddForm = ({
 			<div className="relative">
 				<Select
 					aria-label={t("aws.placeholders.region")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.region}
 					label={t("aws.placeholders.region")}
 					onChange={(selectedRegion) => {
@@ -56,6 +59,7 @@ export const AwsIntegrationAddForm = ({
 				<Input
 					{...register("access_key")}
 					aria-label={t("aws.placeholders.accessKey")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.access_key}
 					isRequired
 					label={t("aws.placeholders.accessKey")}
@@ -68,6 +72,7 @@ export const AwsIntegrationAddForm = ({
 				<Input
 					{...register("secret_key")}
 					aria-label={t("aws.placeholders.secretKey")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.secret_key}
 					isRequired
 					label={t("aws.placeholders.secretKey")}
@@ -80,6 +85,7 @@ export const AwsIntegrationAddForm = ({
 				<Input
 					{...register("token")}
 					aria-label={t("aws.placeholders.token")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.token}
 					isRequired
 					label={t("aws.placeholders.token")}
@@ -91,11 +97,15 @@ export const AwsIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
+				disabled={isCreatingConnection || isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+				{isCreatingConnection || isLoading ? (
+					<Spinner />
+				) : (
+					<FloppyDiskIcon className="size-5 fill-white transition" />
+				)}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/aws/add.tsx
+++ b/src/components/organisms/connections/integrations/aws/add.tsx
@@ -16,10 +16,8 @@ import { FloppyDiskIcon } from "@assets/image/icons";
 export const AwsIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -41,7 +39,7 @@ export const AwsIntegrationAddForm = ({
 			<div className="relative">
 				<Select
 					aria-label={t("aws.placeholders.region")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.region}
 					label={t("aws.placeholders.region")}
 					onChange={(selectedRegion) => {
@@ -59,7 +57,7 @@ export const AwsIntegrationAddForm = ({
 				<Input
 					{...register("access_key")}
 					aria-label={t("aws.placeholders.accessKey")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.access_key}
 					isRequired
 					label={t("aws.placeholders.accessKey")}
@@ -72,7 +70,7 @@ export const AwsIntegrationAddForm = ({
 				<Input
 					{...register("secret_key")}
 					aria-label={t("aws.placeholders.secretKey")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.secret_key}
 					isRequired
 					label={t("aws.placeholders.secretKey")}
@@ -85,7 +83,7 @@ export const AwsIntegrationAddForm = ({
 				<Input
 					{...register("token")}
 					aria-label={t("aws.placeholders.token")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.token}
 					isRequired
 					label={t("aws.placeholders.token")}
@@ -97,15 +95,11 @@ export const AwsIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isCreatingConnection || isLoading ? (
-					<Spinner />
-				) : (
-					<FloppyDiskIcon className="size-5 fill-white transition" />
-				)}
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/aws/edit.tsx
+++ b/src/components/organisms/connections/integrations/aws/edit.tsx
@@ -43,6 +43,7 @@ export const AwsIntegrationEditForm = () => {
 						<Select
 							{...field}
 							aria-label={t("aws.placeholders.region")}
+							disabled={isLoading}
 							isError={!!errors.region}
 							label={t("aws.placeholders.region")}
 							options={selectIntegrationAws}
@@ -58,6 +59,7 @@ export const AwsIntegrationEditForm = () => {
 					type="password"
 					{...register("access_key")}
 					aria-label={t("aws.placeholders.accessKey")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("access_key", newValue)}
 					handleLockAction={(newLockState: boolean) =>
 						setLockState((prevState) => ({ ...prevState, access_key: newLockState }))
@@ -76,6 +78,7 @@ export const AwsIntegrationEditForm = () => {
 					type="password"
 					{...register("secret_key")}
 					aria-label={t("aws.placeholders.secretKey")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("secret_key", newValue)}
 					handleLockAction={(newLockState: boolean) =>
 						setLockState((prevState) => ({ ...prevState, secret_key: newLockState }))
@@ -95,6 +98,7 @@ export const AwsIntegrationEditForm = () => {
 					type="password"
 					{...register("token")}
 					aria-label={t("aws.placeholders.token")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("token", newValue)}
 					handleLockAction={(newLockState: boolean) =>
 						setLockState((prevState) => ({ ...prevState, token: newLockState }))

--- a/src/components/organisms/connections/integrations/confluence/add.tsx
+++ b/src/components/organisms/connections/integrations/confluence/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const ConfluenceIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -76,6 +78,7 @@ export const ConfluenceIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={selectIntegrationConfluence}
@@ -87,7 +90,7 @@ export const ConfluenceIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						register={register}
 					/>
 				) : null}

--- a/src/components/organisms/connections/integrations/confluence/add.tsx
+++ b/src/components/organisms/connections/integrations/confluence/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const ConfluenceIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -78,7 +76,7 @@ export const ConfluenceIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={selectIntegrationConfluence}
@@ -90,7 +88,7 @@ export const ConfluenceIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						register={register}
 					/>
 				) : null}

--- a/src/components/organisms/connections/integrations/confluence/authMethods/apiToken.tsx
+++ b/src/components/organisms/connections/integrations/confluence/authMethods/apiToken.tsx
@@ -39,6 +39,7 @@ export const ConfluenceApiTokenForm = ({
 				<Input
 					{...register("base_url")}
 					aria-label={t("confluence.placeholders.baseUrl")}
+					disabled={isLoading}
 					isError={!!errors.base_url}
 					isRequired
 					label={t("confluence.placeholders.baseUrl")}
@@ -53,6 +54,7 @@ export const ConfluenceApiTokenForm = ({
 						type="password"
 						{...register("token")}
 						aria-label={t("confluence.placeholders.pat")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("token", newValue)}
 						handleLockAction={(newLockState) => setLockState(newLockState)}
 						isError={!!errors.token}
@@ -65,6 +67,7 @@ export const ConfluenceApiTokenForm = ({
 					<Input
 						{...register("token")}
 						aria-label={t("confluence.placeholders.pat")}
+						disabled={isLoading}
 						isError={!!errors.token}
 						isRequired
 						label={t("confluence.placeholders.pat")}
@@ -77,6 +80,7 @@ export const ConfluenceApiTokenForm = ({
 				<Input
 					{...register("email")}
 					aria-label={t("confluence.placeholders.email")}
+					disabled={isLoading}
 					isError={!!errors.email}
 					label={t("confluence.placeholders.email")}
 					placeholder={t("confluence.placeholders.emailSample")}

--- a/src/components/organisms/connections/integrations/confluence/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/confluence/authMethods/oauth.tsx
@@ -2,12 +2,12 @@ import React from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { Button, Link } from "@components/atoms";
+import { Button, Link, Loader } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
 
-export const ConfluenceOauthForm = () => {
+export const ConfluenceOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
 
 	return (
@@ -27,9 +27,11 @@ export const ConfluenceOauthForm = () => {
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</div>

--- a/src/components/organisms/connections/integrations/confluence/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/confluence/authMethods/oauth.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { Button, Link, Loader } from "@components/atoms";
+import { Button, Link, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -26,12 +26,12 @@ export const ConfluenceOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</div>

--- a/src/components/organisms/connections/integrations/discord/add.tsx
+++ b/src/components/organisms/connections/integrations/discord/add.tsx
@@ -16,10 +16,8 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const DiscordIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -42,7 +40,7 @@ export const DiscordIntegrationAddForm = ({
 				<Input
 					{...register("botToken")}
 					aria-label={t("discord.placeholders.botToken")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.botToken}
 					isRequired
 					label={t("discord.placeholders.botToken")}
@@ -66,15 +64,11 @@ export const DiscordIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isCreatingConnection || isLoading ? (
-					<Spinner />
-				) : (
-					<FloppyDiskIcon className="size-5 fill-white transition" />
-				)}
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/discord/add.tsx
+++ b/src/components/organisms/connections/integrations/discord/add.tsx
@@ -16,8 +16,10 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const DiscordIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -40,6 +42,7 @@ export const DiscordIntegrationAddForm = ({
 				<Input
 					{...register("botToken")}
 					aria-label={t("discord.placeholders.botToken")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.botToken}
 					isRequired
 					label={t("discord.placeholders.botToken")}
@@ -63,11 +66,15 @@ export const DiscordIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
+				disabled={isCreatingConnection || isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+				{isCreatingConnection || isLoading ? (
+					<Spinner />
+				) : (
+					<FloppyDiskIcon className="size-5 fill-white transition" />
+				)}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/discord/edit.tsx
+++ b/src/components/organisms/connections/integrations/discord/edit.tsx
@@ -35,6 +35,7 @@ export const DiscordIntegrationEditForm = () => {
 					type="password"
 					{...register("botToken")}
 					aria-label={t("discord.placeholders.botToken")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("botToken", newValue)}
 					handleLockAction={setLockState}
 					isError={!!errors.botToken}

--- a/src/components/organisms/connections/integrations/github/add.tsx
+++ b/src/components/organisms/connections/integrations/github/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const GithubIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -93,7 +91,7 @@ export const GithubIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={filteredAuthMethods}
@@ -106,7 +104,7 @@ export const GithubIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/github/add.tsx
+++ b/src/components/organisms/connections/integrations/github/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const GithubIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -91,6 +93,7 @@ export const GithubIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={filteredAuthMethods}
@@ -103,7 +106,7 @@ export const GithubIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/github/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/oauth.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
-import { Button } from "@components/atoms";
+import { Button, Loader } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
 
-export const OauthForm = () => {
+export const OauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
 
 	return (
@@ -39,9 +39,11 @@ export const OauthForm = () => {
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/github/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/oauth.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
-import { Button, Loader } from "@components/atoms";
+import { Button, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -38,12 +38,12 @@ export const OauthForm = ({ isLoading }: { isLoading: boolean }) => {
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
@@ -43,6 +43,7 @@ export const OauthPrivateForm = ({
 				<Input
 					{...register("client_id")}
 					aria-label={t("github.placeholders.clientId")}
+					disabled={isLoading}
 					isError={!!errors.client_id}
 					isRequired
 					label={t("github.placeholders.clientId")}
@@ -56,6 +57,7 @@ export const OauthPrivateForm = ({
 						type="password"
 						{...register("client_secret")}
 						aria-label={t("github.placeholders.clientSecret")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("client_secret", newValue)}
 						handleLockAction={(newLockState) =>
 							setLockState((prevState) => ({ ...prevState, clientSecret: newLockState }))
@@ -70,6 +72,7 @@ export const OauthPrivateForm = ({
 					<Input
 						{...register("client_secret")}
 						aria-label={t("github.placeholders.clientSecret")}
+						disabled={isLoading}
 						isError={!!errors.client_secret}
 						isRequired
 						label={t("github.placeholders.clientSecret")}
@@ -82,6 +85,7 @@ export const OauthPrivateForm = ({
 				<Input
 					{...register("app_id")}
 					aria-label={t("github.placeholders.appId")}
+					disabled={isLoading}
 					isError={!!errors.app_id}
 					isRequired
 					label={t("github.placeholders.appId")}
@@ -94,6 +98,7 @@ export const OauthPrivateForm = ({
 					type="password"
 					{...register("webhook_secret")}
 					aria-label={t("github.placeholders.webhookSercet")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("webhook_secret", newValue)}
 					handleLockAction={(newLockState) =>
 						setLockState((prevState) => ({ ...prevState, webhookSecret: newLockState }))
@@ -106,6 +111,7 @@ export const OauthPrivateForm = ({
 				<Input
 					{...register("webhook_secret")}
 					aria-label={t("github.placeholders.webhookSercet")}
+					disabled={isLoading}
 					label={t("github.placeholders.webhookSercet")}
 					value={webhookSecret}
 				/>
@@ -114,6 +120,7 @@ export const OauthPrivateForm = ({
 			<Input
 				{...register("enterprise_url")}
 				aria-label={t("github.placeholders.enterpriseUrl")}
+				disabled={isLoading}
 				label={t("github.placeholders.enterpriseUrl")}
 				value={enterpriseUrl}
 			/>
@@ -133,6 +140,7 @@ export const OauthPrivateForm = ({
 						rows={5}
 						{...register("private_key")}
 						aria-label={t("github.placeholders.privateKey")}
+						disabled={isLoading}
 						isError={!!errors.private_key}
 						isRequired
 						label={t("github.placeholders.privateKey")}
@@ -145,6 +153,7 @@ export const OauthPrivateForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import { Button, Checkbox, ErrorMessage, Input, SecretInput, Spinner, Textarea } from "@components/atoms";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 export const OauthPrivateForm = ({
 	control,
 	errors,
@@ -152,12 +154,12 @@ export const OauthPrivateForm = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
@@ -123,7 +123,6 @@ export const PatForm = ({
 					aria-label={t("github.placeholders.webhookUrl")}
 					className="w-full"
 					disabled={isLoading}
-					disabled
 					label={t("github.placeholders.webhookUrl")}
 					value={webhook}
 				/>

--- a/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/pat.tsx
@@ -94,6 +94,7 @@ export const PatForm = ({
 						type="password"
 						{...register("pat")}
 						aria-label={t("github.placeholders.pat")}
+						disabled={isLoading}
 						handleInputChange={(newPatValue) => setValue("pat", newPatValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, pat: newLockState }))
@@ -108,6 +109,7 @@ export const PatForm = ({
 					<Input
 						{...register("pat")}
 						aria-label={t("github.placeholders.pat")}
+						disabled={isLoading}
 						isError={!!errors.pat}
 						isRequired
 						label={t("github.placeholders.pat")}
@@ -120,6 +122,7 @@ export const PatForm = ({
 					{...register("webhook")}
 					aria-label={t("github.placeholders.webhookUrl")}
 					className="w-full"
+					disabled={isLoading}
 					disabled
 					label={t("github.placeholders.webhookUrl")}
 					value={webhook}
@@ -128,6 +131,7 @@ export const PatForm = ({
 				<Button
 					aria-label={t("buttons.copy")}
 					className="w-fit rounded-md border-black bg-white px-5 font-semibold hover:bg-gray-950"
+					disabled={isLoading}
 					onClick={() => copyToClipboard(webhook)}
 					variant="outline"
 				>
@@ -141,6 +145,7 @@ export const PatForm = ({
 						type="password"
 						{...register("secret")}
 						aria-label={t("github.placeholders.secret")}
+						disabled={isLoading}
 						handleInputChange={(newSecretValue) => setValue("secret", newSecretValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, secret: newLockState }))
@@ -154,6 +159,7 @@ export const PatForm = ({
 					<Input
 						{...register("secret")}
 						aria-label={t("github.placeholders.secret")}
+						disabled={isLoading}
 						isError={!!errors.secret}
 						label={t("github.placeholders.secret")}
 					/>

--- a/src/components/organisms/connections/integrations/google/add.tsx
+++ b/src/components/organisms/connections/integrations/google/add.tsx
@@ -17,10 +17,8 @@ export const GoogleIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
 	type,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 	type: string;
 }) => {
@@ -90,7 +88,7 @@ export const GoogleIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				noOptionsLabel={t("placeholders.noConnectionTypesAvailable")}
 				onChange={(option) => setConnectionType(option)}
@@ -103,7 +101,7 @@ export const GoogleIntegrationAddForm = ({
 				{ConnectionTypeComponent ? (
 					<ConnectionTypeComponent
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/google/add.tsx
+++ b/src/components/organisms/connections/integrations/google/add.tsx
@@ -17,8 +17,10 @@ export const GoogleIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
 	type,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 	type: string;
 }) => {
@@ -88,6 +90,7 @@ export const GoogleIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				noOptionsLabel={t("placeholders.noConnectionTypesAvailable")}
 				onChange={(option) => setConnectionType(option)}
@@ -100,7 +103,7 @@ export const GoogleIntegrationAddForm = ({
 				{ConnectionTypeComponent ? (
 					<ConnectionTypeComponent
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/google/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/google/authMethods/jsonKey.tsx
@@ -28,6 +28,7 @@ export const JsonKeyGoogleForm = ({
 					rows={5}
 					{...register("json")}
 					aria-label={t("google.placeholders.jsonKey")}
+					disabled={isLoading}
 					isError={!!errors.json}
 					placeholder={t("google.placeholders.jsonKey")}
 				/>

--- a/src/components/organisms/connections/integrations/google/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/google/authMethods/oauth.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { infoGoogleUserLinks } from "@constants/lists";
 
-import { Button, Link, Loader } from "@components/atoms";
+import { Button, Link, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -33,12 +33,12 @@ export const OauthGoogleForm = ({ isLoading }: { isLoading: boolean }) => {
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/google/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/google/authMethods/oauth.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from "react-i18next";
 
 import { infoGoogleUserLinks } from "@constants/lists";
 
-import { Button, Link } from "@components/atoms";
+import { Button, Link, Loader } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
 
-export const OauthGoogleForm = () => {
+export const OauthGoogleForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
 
 	return (
@@ -34,9 +34,11 @@ export const OauthGoogleForm = () => {
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/googleGemini/add.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/add.tsx
@@ -16,10 +16,8 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const GoogleGeminiIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -42,7 +40,7 @@ export const GoogleGeminiIntegrationAddForm = ({
 				<Input
 					{...register("key")}
 					aria-label={t("gemini.placeholders.key")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.key}
 					isRequired
 					label={t("gemini.placeholders.key")}
@@ -82,11 +80,7 @@ export const GoogleGeminiIntegrationAddForm = ({
 				type="submit"
 				variant="outline"
 			>
-				{isCreatingConnection || isLoading ? (
-					<Spinner />
-				) : (
-					<FloppyDiskIcon className="size-5 fill-white transition" />
-				)}
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/googleGemini/add.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/add.tsx
@@ -16,8 +16,10 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const GoogleGeminiIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -40,6 +42,7 @@ export const GoogleGeminiIntegrationAddForm = ({
 				<Input
 					{...register("key")}
 					aria-label={t("gemini.placeholders.key")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.key}
 					isRequired
 					label={t("gemini.placeholders.key")}
@@ -79,7 +82,11 @@ export const GoogleGeminiIntegrationAddForm = ({
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+				{isCreatingConnection || isLoading ? (
+					<Spinner />
+				) : (
+					<FloppyDiskIcon className="size-5 fill-white transition" />
+				)}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/googleGemini/add.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/add.tsx
@@ -81,7 +81,6 @@ export const GoogleGeminiIntegrationAddForm = ({
 				variant="outline"
 			>
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
 				{t("buttons.saveConnection")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/googleGemini/edit.tsx
+++ b/src/components/organisms/connections/integrations/googleGemini/edit.tsx
@@ -34,6 +34,7 @@ export const GoogleGeminiIntegrationEditForm = () => {
 					type="password"
 					{...register("key")}
 					aria-label={t("gemini.placeholders.key")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("key", newValue)}
 					handleLockAction={setLockState}
 					isError={!!errors.key}

--- a/src/components/organisms/connections/integrations/googlecalendar/add.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/add.tsx
@@ -17,10 +17,8 @@ export const GoogleCalendarIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
 	type,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 	type: string;
 }) => {
@@ -90,7 +88,7 @@ export const GoogleCalendarIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				noOptionsLabel={t("placeholders.noConnectionTypesAvailable")}
 				onChange={(option) => setConnectionType(option)}
@@ -103,7 +101,7 @@ export const GoogleCalendarIntegrationAddForm = ({
 				{ConnectionTypeComponent ? (
 					<ConnectionTypeComponent
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/googlecalendar/add.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/add.tsx
@@ -17,8 +17,10 @@ export const GoogleCalendarIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
 	type,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 	type: string;
 }) => {
@@ -88,6 +90,7 @@ export const GoogleCalendarIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				noOptionsLabel={t("placeholders.noConnectionTypesAvailable")}
 				onChange={(option) => setConnectionType(option)}
@@ -100,7 +103,7 @@ export const GoogleCalendarIntegrationAddForm = ({
 				{ConnectionTypeComponent ? (
 					<ConnectionTypeComponent
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/googlecalendar/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/authMethods/jsonKey.tsx
@@ -70,7 +70,6 @@ export const JsonKeyGoogleCalendarForm = ({
 				variant="outline"
 			>
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
 				{t("buttons.saveConnection")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/googlecalendar/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/authMethods/jsonKey.tsx
@@ -28,6 +28,7 @@ export const JsonKeyGoogleCalendarForm = ({
 					label={t("google.placeholders.calendarId")}
 					{...register("cal_id")}
 					aria-label={t("google.placeholders.calendarId")}
+					disabled={isLoading}
 					placeholder={t("google.placeholders.calendarId")}
 				/>
 			</div>
@@ -36,6 +37,7 @@ export const JsonKeyGoogleCalendarForm = ({
 					rows={5}
 					{...register("json")}
 					aria-label={t("google.placeholders.jsonKey")}
+					disabled={isLoading}
 					isError={!!errors.json}
 					placeholder={t("google.placeholders.jsonKey")}
 				/>

--- a/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
@@ -50,13 +50,12 @@ export const OauthGoogleCalendarForm = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
-
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { infoGoogleUserLinks } from "@constants/lists";
 
-import { Button, Input, Link } from "@components/atoms";
+import { Button, Input, Link, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -55,6 +55,8 @@ export const OauthGoogleCalendarForm = ({
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Spinner /> : null}
+
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googlecalendar/authMethods/oauth.tsx
@@ -10,7 +10,13 @@ import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
 
-export const OauthGoogleCalendarForm = ({ register }: { register: UseFormRegister<{ [x: string]: any }> }) => {
+export const OauthGoogleCalendarForm = ({
+	register,
+	isLoading,
+}: {
+	isLoading: boolean;
+	register: UseFormRegister<{ [x: string]: any }>;
+}) => {
 	const { t } = useTranslation("integrations");
 
 	return (
@@ -20,6 +26,7 @@ export const OauthGoogleCalendarForm = ({ register }: { register: UseFormRegiste
 					label={t("google.placeholders.calendarId")}
 					{...register("cal_id")}
 					aria-label={t("google.placeholders.calendarId")}
+					disabled={isLoading}
 					placeholder={t("google.placeholders.calendarId")}
 				/>
 			</div>
@@ -44,6 +51,7 @@ export const OauthGoogleCalendarForm = ({ register }: { register: UseFormRegiste
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/googleforms/add.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/add.tsx
@@ -17,8 +17,10 @@ export const GoogleFormsIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
 	type,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 	type: string;
 }) => {
@@ -94,13 +96,14 @@ export const GoogleFormsIntegrationAddForm = ({
 				options={selectIntegrationGoogle}
 				placeholder={t("placeholders.selectConnectionType")}
 				value={connectionType}
+				disabled={isCreatingConnection || isLoading}
 			/>
 
 			<form className="mt-6 flex w-full flex-col gap-6" onSubmit={handleSubmit(triggerParentFormSubmit)}>
 				{ConnectionTypeComponent ? (
 					<ConnectionTypeComponent
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/googleforms/add.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/add.tsx
@@ -17,10 +17,8 @@ export const GoogleFormsIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
 	type,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 	type: string;
 }) => {
@@ -90,20 +88,20 @@ export const GoogleFormsIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				noOptionsLabel={t("placeholders.noConnectionTypesAvailable")}
 				onChange={(option) => setConnectionType(option)}
 				options={selectIntegrationGoogle}
 				placeholder={t("placeholders.selectConnectionType")}
 				value={connectionType}
-				disabled={isCreatingConnection || isLoading}
 			/>
 
 			<form className="mt-6 flex w-full flex-col gap-6" onSubmit={handleSubmit(triggerParentFormSubmit)}>
 				{ConnectionTypeComponent ? (
 					<ConnectionTypeComponent
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/googleforms/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/jsonKey.tsx
@@ -28,6 +28,7 @@ export const JsonKeyGoogleFormsForm = ({
 					label={t("google.labels.formId")}
 					{...register("form_id")}
 					aria-label={t("google.placeholders.formId")}
+					disabled={isLoading}
 					placeholder={t("google.placeholders.formId")}
 				/>
 			</div>
@@ -36,6 +37,7 @@ export const JsonKeyGoogleFormsForm = ({
 					rows={5}
 					{...register("json")}
 					aria-label={t("google.placeholders.jsonKey")}
+					disabled={isLoading}
 					isError={!!errors.json}
 					placeholder={t("google.placeholders.jsonKey")}
 				/>

--- a/src/components/organisms/connections/integrations/googleforms/authMethods/jsonKey.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/jsonKey.tsx
@@ -70,7 +70,6 @@ export const JsonKeyGoogleFormsForm = ({
 				variant="outline"
 			>
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
 				{t("buttons.saveConnection")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
@@ -10,7 +10,13 @@ import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
 
-export const OauthGoogleFormsForm = ({ register }: { register: UseFormRegister<{ [x: string]: any }> }) => {
+export const OauthGoogleFormsForm = ({
+	register,
+	isLoading,
+}: {
+	isLoading: boolean;
+	register: UseFormRegister<{ [x: string]: any }>;
+}) => {
 	const { t } = useTranslation("integrations");
 
 	return (
@@ -20,6 +26,7 @@ export const OauthGoogleFormsForm = ({ register }: { register: UseFormRegister<{
 					label={t("google.labels.formId")}
 					{...register("form_id")}
 					aria-label={t("google.placeholders.formId")}
+					disabled={isLoading}
 					placeholder={t("google.placeholders.formId")}
 				/>
 			</div>
@@ -44,6 +51,7 @@ export const OauthGoogleFormsForm = ({ register }: { register: UseFormRegister<{
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { infoGoogleUserLinks } from "@constants/lists";
 
-import { Button, Input, Link } from "@components/atoms";
+import { Button, Input, Link, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -55,6 +55,7 @@ export const OauthGoogleFormsForm = ({
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Spinner /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/googleforms/authMethods/oauth.tsx
@@ -50,12 +50,12 @@ export const OauthGoogleFormsForm = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/height/add.tsx
+++ b/src/components/organisms/connections/integrations/height/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const HeightIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -89,6 +91,7 @@ export const HeightIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={heightIntegrationAuthMethods}
@@ -101,7 +104,7 @@ export const HeightIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/height/add.tsx
+++ b/src/components/organisms/connections/integrations/height/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const HeightIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -91,7 +89,7 @@ export const HeightIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={heightIntegrationAuthMethods}
@@ -104,7 +102,7 @@ export const HeightIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/height/authMethods/apiKey.tsx
+++ b/src/components/organisms/connections/integrations/height/authMethods/apiKey.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import { Button, ErrorMessage, Input, Spinner } from "@components/atoms";
 
+import { FloppyDiskIcon } from "@assets/image/icons";
+
 export const HeightApiKeyForm = ({
 	control,
 	errors,
@@ -39,12 +41,12 @@ export const HeightApiKeyForm = ({
 
 			<Button
 				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 				{t("buttons.saveConnection")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/height/authMethods/apiKey.tsx
+++ b/src/components/organisms/connections/integrations/height/authMethods/apiKey.tsx
@@ -28,6 +28,7 @@ export const HeightApiKeyForm = ({
 				<Input
 					{...register("api_key")}
 					aria-label={t("height.placeholders.apiKey")}
+					disabled={isLoading}
 					isError={!!errors.api_key}
 					isRequired
 					label={t("height.placeholders.apiKey")}
@@ -39,6 +40,7 @@ export const HeightApiKeyForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/height/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/height/authMethods/oauth.tsx
@@ -2,18 +2,20 @@ import React from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { Button } from "@components/atoms";
+import { Button, Loader } from "@components/atoms";
 
-export const HeightOauthForm = () => {
+export const HeightOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
 
 	return (
 		<Button
 			aria-label={t("buttons.startOAuthFlow")}
 			className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+			disabled={isLoading}
 			type="submit"
 			variant="outline"
 		>
+			{isLoading ? <Loader size="sm" /> : null}
 			{t("buttons.startOAuthFlow")}
 		</Button>
 	);

--- a/src/components/organisms/connections/integrations/height/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/height/authMethods/oauth.tsx
@@ -2,7 +2,9 @@ import React from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { Button, Loader } from "@components/atoms";
+import { Button, Spinner } from "@components/atoms";
+
+import { ExternalLinkIcon } from "@assets/image/icons";
 
 export const HeightOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
@@ -10,12 +12,12 @@ export const HeightOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	return (
 		<Button
 			aria-label={t("buttons.startOAuthFlow")}
-			className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+			className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 			disabled={isLoading}
 			type="submit"
 			variant="outline"
 		>
-			{isLoading ? <Loader size="sm" /> : null}
+			{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 			{t("buttons.startOAuthFlow")}
 		</Button>
 	);

--- a/src/components/organisms/connections/integrations/height/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/height/authMethods/oauthPrivate.tsx
@@ -36,6 +36,7 @@ export const HeightOauthPrivateForm = ({
 				<Input
 					{...register("client_id")}
 					aria-label={t("height.placeholders.clientId")}
+					disabled={isLoading}
 					isError={!!errors.client_id}
 					isRequired
 					label={t("height.placeholders.clientId")}
@@ -49,6 +50,7 @@ export const HeightOauthPrivateForm = ({
 						type="password"
 						{...register("client_secret")}
 						aria-label={t("height.placeholders.clientSecret")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("client_secret", newValue)}
 						handleLockAction={(newLockState) =>
 							setLockState((prevState) => ({ ...prevState, clientSecret: newLockState }))
@@ -63,6 +65,7 @@ export const HeightOauthPrivateForm = ({
 					<Input
 						{...register("client_secret")}
 						aria-label={t("height.placeholders.clientSecret")}
+						disabled={isLoading}
 						isError={!!errors.client_secret}
 						isRequired
 						label={t("height.placeholders.clientSecret")}
@@ -74,6 +77,7 @@ export const HeightOauthPrivateForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/height/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/height/authMethods/oauthPrivate.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 export const HeightOauthPrivateForm = ({
 	control,
 	errors,
@@ -76,12 +78,12 @@ export const HeightOauthPrivateForm = ({
 			</div>
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/hubspot/add.tsx
+++ b/src/components/organisms/connections/integrations/hubspot/add.tsx
@@ -7,7 +7,7 @@ import { Integrations } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { oauthSchema } from "@validations";
 
-import { Button, Loader } from "@components/atoms";
+import { Button, Loader, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -45,12 +45,12 @@ export const HubspotIntegrationAddForm = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/hubspot/add.tsx
+++ b/src/components/organisms/connections/integrations/hubspot/add.tsx
@@ -7,7 +7,7 @@ import { Integrations } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { oauthSchema } from "@validations";
 
-import { Button } from "@components/atoms";
+import { Button, Loader } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -15,13 +15,15 @@ import { ExternalLinkIcon } from "@assets/image/icons";
 export const HubspotIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
 
-	const { handleLegacyOAuth } = useConnectionForm(oauthSchema, "create");
+	const { handleLegacyOAuth, isLoading } = useConnectionForm(oauthSchema, "create");
 
 	useEffect(() => {
 		if (connectionId) {
@@ -46,9 +48,11 @@ export const HubspotIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isCreatingConnection || isLoading}
 				type="submit"
 				variant="outline"
 			>
+				{isCreatingConnection || isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/hubspot/add.tsx
+++ b/src/components/organisms/connections/integrations/hubspot/add.tsx
@@ -7,7 +7,7 @@ import { Integrations } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { oauthSchema } from "@validations";
 
-import { Button, Loader, Spinner } from "@components/atoms";
+import { Button, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";

--- a/src/components/organisms/connections/integrations/hubspot/add.tsx
+++ b/src/components/organisms/connections/integrations/hubspot/add.tsx
@@ -15,10 +15,8 @@ import { ExternalLinkIcon } from "@assets/image/icons";
 export const HubspotIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -48,11 +46,11 @@ export const HubspotIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isCreatingConnection || isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/hubspot/edit.tsx
+++ b/src/components/organisms/connections/integrations/hubspot/edit.tsx
@@ -7,7 +7,7 @@ import { Integrations } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { oauthSchema } from "@validations";
 
-import { Button } from "@components/atoms";
+import { Button, Loader } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -15,7 +15,7 @@ import { ExternalLinkIcon } from "@assets/image/icons";
 export const HubspotIntegrationEditForm = () => {
 	const { t } = useTranslation("integrations");
 	const { connectionId } = useParams();
-	const { handleLegacyOAuth, handleSubmit } = useConnectionForm(oauthSchema, "edit");
+	const { handleLegacyOAuth, handleSubmit, isLoading } = useConnectionForm(oauthSchema, "edit");
 
 	return (
 		<form
@@ -36,9 +36,11 @@ export const HubspotIntegrationEditForm = () => {
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/hubspot/edit.tsx
+++ b/src/components/organisms/connections/integrations/hubspot/edit.tsx
@@ -7,7 +7,7 @@ import { Integrations } from "@src/enums/components";
 import { useConnectionForm } from "@src/hooks";
 import { oauthSchema } from "@validations";
 
-import { Button, Loader } from "@components/atoms";
+import { Button, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -35,12 +35,12 @@ export const HubspotIntegrationEditForm = () => {
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/jira/add.tsx
+++ b/src/components/organisms/connections/integrations/jira/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const JiraIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -78,7 +76,7 @@ export const JiraIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={selectIntegrationJira}
@@ -90,7 +88,7 @@ export const JiraIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						register={register}
 					/>
 				) : null}

--- a/src/components/organisms/connections/integrations/jira/add.tsx
+++ b/src/components/organisms/connections/integrations/jira/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const JiraIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -76,6 +78,7 @@ export const JiraIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={selectIntegrationJira}
@@ -87,7 +90,7 @@ export const JiraIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						register={register}
 					/>
 				) : null}

--- a/src/components/organisms/connections/integrations/jira/authMethods/apiToken.tsx
+++ b/src/components/organisms/connections/integrations/jira/authMethods/apiToken.tsx
@@ -39,6 +39,7 @@ export const ApiTokenJiraForm = ({
 				<Input
 					{...register("base_url")}
 					aria-label={t("jira.placeholders.baseUrl")}
+					disabled={isLoading}
 					isError={!!errors.base_url}
 					isRequired
 					label={t("jira.placeholders.baseUrl")}
@@ -53,6 +54,7 @@ export const ApiTokenJiraForm = ({
 						type="password"
 						{...register("token")}
 						aria-label={t("jira.placeholders.pat")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("token", newValue)}
 						handleLockAction={(newLockState) => setLockState(newLockState)}
 						isError={!!errors.token}
@@ -65,6 +67,7 @@ export const ApiTokenJiraForm = ({
 					<Input
 						{...register("token")}
 						aria-label={t("jira.placeholders.pat")}
+						disabled={isLoading}
 						isError={!!errors.token}
 						isRequired
 						label={t("jira.placeholders.pat")}
@@ -76,6 +79,7 @@ export const ApiTokenJiraForm = ({
 				<Input
 					{...register("email")}
 					aria-label={t("jira.placeholders.email")}
+					disabled={isLoading}
 					isError={!!errors.email}
 					label={t("jira.placeholders.email")}
 					placeholder={t("jira.placeholders.emailSample")}

--- a/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
@@ -26,12 +26,12 @@ export const OauthJiraForm = ({ isLoading }: { isLoading: boolean }) => {
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</div>

--- a/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { Button, Link } from "@components/atoms";
+import { Button, Link, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -31,6 +31,7 @@ export const OauthJiraForm = ({ isLoading }: { isLoading: boolean }) => {
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Spinner /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</div>

--- a/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/jira/authMethods/oauth.tsx
@@ -7,7 +7,7 @@ import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
 
-export const OauthJiraForm = () => {
+export const OauthJiraForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
 
 	return (
@@ -27,6 +27,7 @@ export const OauthJiraForm = () => {
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/linear/add.tsx
+++ b/src/components/organisms/connections/integrations/linear/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const LinearIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -91,7 +89,7 @@ export const LinearIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={linearIntegrationAuthMethods}
@@ -105,7 +103,7 @@ export const LinearIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/linear/add.tsx
+++ b/src/components/organisms/connections/integrations/linear/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const LinearIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -89,6 +91,7 @@ export const LinearIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={linearIntegrationAuthMethods}
@@ -102,7 +105,7 @@ export const LinearIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/linear/authMethods/apiKey.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/apiKey.tsx
@@ -51,6 +51,7 @@ export const LinearApiKeyForm = ({
 					<Input
 						{...register("api_key")}
 						aria-label={t("linear.placeholders.apiKey")}
+						disabled={isLoading}
 						isError={!!errors.api_key}
 						isRequired
 						label={t("linear.placeholders.apiKey")}

--- a/src/components/organisms/connections/integrations/linear/authMethods/apiKey.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/apiKey.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 
+import { FloppyDiskIcon } from "@assets/image/icons";
+
 export const LinearApiKeyForm = ({
 	control,
 	errors,
@@ -64,12 +66,12 @@ export const LinearApiKeyForm = ({
 
 			<Button
 				aria-label={t("buttons.saveConnection")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 				{t("buttons.saveConnection")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/linear/authMethods/apiKey.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/apiKey.tsx
@@ -36,6 +36,7 @@ export const LinearApiKeyForm = ({
 						type="password"
 						{...register("api_key")}
 						aria-label={t("linear.placeholders.apiKey")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("api_key", newValue)}
 						handleLockAction={(newLockState) =>
 							setLockState((prevState) => ({ ...prevState, apiKey: newLockState }))
@@ -63,6 +64,7 @@ export const LinearApiKeyForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/linear/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/oauth.tsx
@@ -34,6 +34,7 @@ export const LinearOauthForm = ({
 						<Select
 							{...field}
 							aria-label={t("linear.placeholders.actor")}
+							disabled={isLoading}
 							isError={!!errors.actor}
 							label={t("linear.placeholders.actor")}
 							onChange={(selected) => {
@@ -51,6 +52,7 @@ export const LinearOauthForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/linear/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/oauth.tsx
@@ -7,6 +7,7 @@ import { selectIntegrationLinearActor } from "@src/constants/lists/connections";
 
 import { Button, ErrorMessage, Spinner } from "@components/atoms";
 import { Select } from "@components/molecules";
+
 import { ExternalLinkIcon } from "@assets/image/icons";
 
 export const LinearOauthForm = ({

--- a/src/components/organisms/connections/integrations/linear/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/oauth.tsx
@@ -7,6 +7,7 @@ import { selectIntegrationLinearActor } from "@src/constants/lists/connections";
 
 import { Button, ErrorMessage, Spinner } from "@components/atoms";
 import { Select } from "@components/molecules";
+import { ExternalLinkIcon } from "@assets/image/icons";
 
 export const LinearOauthForm = ({
 	control,
@@ -51,12 +52,12 @@ export const LinearOauthForm = ({
 			</div>
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/linear/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/oauthPrivate.tsx
@@ -49,6 +49,7 @@ export const LinearOauthPrivateForm = ({
 						<Select
 							{...field}
 							aria-label={t("linear.placeholders.actor")}
+							disabled={isLoading}
 							isError={!!errors.actor}
 							label={t("linear.placeholders.actor")}
 							onChange={(selected) => {

--- a/src/components/organisms/connections/integrations/linear/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/oauthPrivate.tsx
@@ -9,6 +9,8 @@ import { getApiBaseUrl } from "@src/utilities";
 import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 import { CopyButton, Select } from "@components/molecules";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 export const LinearOauthPrivateForm = ({
 	control,
 	errors,
@@ -147,12 +149,12 @@ export const LinearOauthPrivateForm = ({
 			</div>
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/linear/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/linear/authMethods/oauthPrivate.tsx
@@ -67,6 +67,7 @@ export const LinearOauthPrivateForm = ({
 				<Input
 					{...register("client_id")}
 					aria-label={t("linear.placeholders.clientId")}
+					disabled={isLoading}
 					isError={!!errors.client_id}
 					isRequired
 					label={t("linear.placeholders.clientId")}
@@ -80,6 +81,7 @@ export const LinearOauthPrivateForm = ({
 						type="password"
 						{...register("client_secret")}
 						aria-label={t("linear.placeholders.clientSecret")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("client_secret", newValue)}
 						handleLockAction={(newLockState) =>
 							setLockState((prevState) => ({ ...prevState, clientSecret: newLockState }))
@@ -94,6 +96,7 @@ export const LinearOauthPrivateForm = ({
 					<Input
 						{...register("client_secret")}
 						aria-label={t("linear.placeholders.clientSecret")}
+						disabled={isLoading}
 						isError={!!errors.client_secret}
 						isRequired
 						label={t("linear.placeholders.clientSecret")}
@@ -119,6 +122,7 @@ export const LinearOauthPrivateForm = ({
 						type="password"
 						{...register("webhook_secret")}
 						aria-label={t("linear.placeholders.webhookSecret")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("webhook_secret", newValue)}
 						handleLockAction={(newLockState) =>
 							setLockState((prevState) => ({ ...prevState, webhookSecret: newLockState }))
@@ -132,6 +136,7 @@ export const LinearOauthPrivateForm = ({
 					<Input
 						{...register("webhook_secret")}
 						aria-label={t("linear.placeholders.webhookSecret")}
+						disabled={isLoading}
 						isError={!!errors.webhook_secret}
 						label={t("linear.placeholders.webhookSecret")}
 						value={webhookSecret}
@@ -142,6 +147,7 @@ export const LinearOauthPrivateForm = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/openAI/add.tsx
+++ b/src/components/organisms/connections/integrations/openAI/add.tsx
@@ -74,7 +74,6 @@ export const OpenAiIntegrationAddForm = ({
 				variant="outline"
 			>
 				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
-
 				{t("buttons.saveConnection")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/openAI/add.tsx
+++ b/src/components/organisms/connections/integrations/openAI/add.tsx
@@ -16,8 +16,10 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const OpenAiIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -40,6 +42,7 @@ export const OpenAiIntegrationAddForm = ({
 				<Input
 					{...register("key")}
 					aria-label={t("openAi.placeholders.apiKey")}
+					disabled={isCreatingConnection || isLoading}
 					isError={!!errors.key}
 					isRequired
 					label={t("openAi.placeholders.apiKey")}
@@ -68,11 +71,15 @@ export const OpenAiIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isLoading}
+				disabled={isCreatingConnection || isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
+				{isCreatingConnection || isLoading ? (
+					<Spinner />
+				) : (
+					<FloppyDiskIcon className="size-5 fill-white transition" />
+				)}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/openAI/add.tsx
+++ b/src/components/organisms/connections/integrations/openAI/add.tsx
@@ -16,10 +16,8 @@ import { ExternalLinkIcon, FloppyDiskIcon } from "@assets/image/icons";
 export const OpenAiIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -42,7 +40,7 @@ export const OpenAiIntegrationAddForm = ({
 				<Input
 					{...register("key")}
 					aria-label={t("openAi.placeholders.apiKey")}
-					disabled={isCreatingConnection || isLoading}
+					disabled={isLoading}
 					isError={!!errors.key}
 					isRequired
 					label={t("openAi.placeholders.apiKey")}
@@ -71,15 +69,11 @@ export const OpenAiIntegrationAddForm = ({
 			<Button
 				aria-label={t("buttons.saveConnection")}
 				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isCreatingConnection || isLoading ? (
-					<Spinner />
-				) : (
-					<FloppyDiskIcon className="size-5 fill-white transition" />
-				)}
+				{isLoading ? <Spinner /> : <FloppyDiskIcon className="size-5 fill-white transition" />}
 
 				{t("buttons.saveConnection")}
 			</Button>

--- a/src/components/organisms/connections/integrations/openAI/edit.tsx
+++ b/src/components/organisms/connections/integrations/openAI/edit.tsx
@@ -35,6 +35,7 @@ export const OpenAiIntegrationEditForm = () => {
 					type="password"
 					{...register("key")}
 					aria-label={t("openAi.placeholders.apiKey")}
+					disabled={isLoading}
 					handleInputChange={(newValue) => setValue("key", newValue)}
 					handleLockAction={setLockState}
 					isError={!!errors.key}

--- a/src/components/organisms/connections/integrations/salesforce/add.tsx
+++ b/src/components/organisms/connections/integrations/salesforce/add.tsx
@@ -9,6 +9,8 @@ import { salesforceIntegrationSchema } from "@validations";
 
 import { Button, ErrorMessage, Input, Spinner } from "@components/atoms";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 export const SalesforceIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
@@ -62,7 +64,7 @@ export const SalesforceIntegrationAddForm = ({
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/salesforce/edit.tsx
+++ b/src/components/organisms/connections/integrations/salesforce/edit.tsx
@@ -13,6 +13,8 @@ import { salesforceIntegrationSchema } from "@validations";
 
 import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 export const SalesforceIntegrationEditForm = () => {
 	const { t } = useTranslation("integrations");
 	const [lockState, setLockState] = useState(true);
@@ -69,7 +71,7 @@ export const SalesforceIntegrationEditForm = () => {
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</form>

--- a/src/components/organisms/connections/integrations/slack/add.tsx
+++ b/src/components/organisms/connections/integrations/slack/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const SlackIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -89,6 +91,7 @@ export const SlackIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={filteredAuthMethods}
@@ -100,7 +103,7 @@ export const SlackIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						register={register}
 					/>
 				) : null}

--- a/src/components/organisms/connections/integrations/slack/add.tsx
+++ b/src/components/organisms/connections/integrations/slack/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const SlackIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -91,7 +89,7 @@ export const SlackIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={filteredAuthMethods}
@@ -103,7 +101,7 @@ export const SlackIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						register={register}
 					/>
 				) : null}

--- a/src/components/organisms/connections/integrations/slack/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/oauth.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 
 import { infoSlackOAuthLinks } from "@src/constants/lists/connections";
 
-import { Button, Loader } from "@components/atoms";
+import { Button, Spinner } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
@@ -34,12 +34,12 @@ export const OauthForm = ({ isLoading }: { isLoading: boolean }) => {
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-500 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Loader size="sm" /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/slack/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/oauth.tsx
@@ -5,12 +5,12 @@ import { Link } from "react-router-dom";
 
 import { infoSlackOAuthLinks } from "@src/constants/lists/connections";
 
-import { Button } from "@components/atoms";
+import { Button, Loader } from "@components/atoms";
 import { Accordion } from "@components/molecules";
 
 import { ExternalLinkIcon } from "@assets/image/icons";
 
-export const OauthForm = () => {
+export const OauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
 
 	return (
@@ -35,9 +35,11 @@ export const OauthForm = () => {
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-500 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
+				{isLoading ? <Loader size="sm" /> : null}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/slack/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/oauthPrivate.tsx
@@ -54,12 +54,12 @@ export const SlackOauthPrivateForm: React.FC<SlackOauthPrivateFormProps> = ({
 				const error = errors[name]?.message as string;
 				const commonProps = {
 					...register(name),
-					"disabled": isLoading,
+					disabled: isLoading,
 					"aria-label": label,
-					"isError": !!errors[name],
-					"isRequired": true,
+					isError: !!errors[name],
+					isRequired: true,
 					label,
-					"value": values[name as any],
+					value: values[name as any],
 				};
 
 				return (

--- a/src/components/organisms/connections/integrations/slack/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/oauthPrivate.tsx
@@ -54,6 +54,7 @@ export const SlackOauthPrivateForm: React.FC<SlackOauthPrivateFormProps> = ({
 				const error = errors[name]?.message as string;
 				const commonProps = {
 					...register(name),
+					"disabled": isLoading,
 					"aria-label": label,
 					"isError": !!errors[name],
 					"isRequired": true,
@@ -82,6 +83,7 @@ export const SlackOauthPrivateForm: React.FC<SlackOauthPrivateFormProps> = ({
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
 				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>

--- a/src/components/organisms/connections/integrations/slack/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/oauthPrivate.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 const initialLockState: Record<string, boolean> = {
 	clientSecret: true,
 	webhookSecret: true,
@@ -82,12 +84,12 @@ export const SlackOauthPrivateForm: React.FC<SlackOauthPrivateFormProps> = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/slack/authMethods/socket.tsx
+++ b/src/components/organisms/connections/integrations/slack/authMethods/socket.tsx
@@ -43,6 +43,7 @@ export const SocketForm = ({
 						type="password"
 						{...register("bot_token")}
 						aria-label={t("slack.placeholders.botToken")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("bot_token", newValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, bot_token: newLockState }))
@@ -57,6 +58,7 @@ export const SocketForm = ({
 					<Input
 						{...register("bot_token")}
 						aria-label={t("slack.placeholders.botToken")}
+						disabled={isLoading}
 						isError={!!errors.bot_token}
 						isRequired
 						label={t("slack.placeholders.botToken")}
@@ -70,6 +72,7 @@ export const SocketForm = ({
 						type="password"
 						{...register("app_token")}
 						aria-label={t("slack.placeholders.appToken")}
+						disabled={isLoading}
 						handleInputChange={(newValue) => setValue("app_token", newValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, app_token: newLockState }))
@@ -84,6 +87,7 @@ export const SocketForm = ({
 					<Input
 						{...register("app_token")}
 						aria-label={t("slack.placeholders.appToken")}
+						disabled={isLoading}
 						isError={!!errors.app_token}
 						isRequired
 						label={t("slack.placeholders.appToken")}

--- a/src/components/organisms/connections/integrations/twilio/add.tsx
+++ b/src/components/organisms/connections/integrations/twilio/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const TwilioIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -60,12 +58,12 @@ export const TwilioIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={selectIntegrationTwilio}
 				placeholder={t("placeholders.selectConnectionType")}
 				value={connectionType}
-				disabled={isCreatingConnection || isLoading}
 			/>
 
 			<form className="mt-6 flex w-full flex-col gap-6" onSubmit={handleSubmit(triggerParentFormSubmit)}>
@@ -73,7 +71,7 @@ export const TwilioIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/twilio/add.tsx
+++ b/src/components/organisms/connections/integrations/twilio/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const TwilioIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -63,6 +65,7 @@ export const TwilioIntegrationAddForm = ({
 				options={selectIntegrationTwilio}
 				placeholder={t("placeholders.selectConnectionType")}
 				value={connectionType}
+				disabled={isCreatingConnection || isLoading}
 			/>
 
 			<form className="mt-6 flex w-full flex-col gap-6" onSubmit={handleSubmit(triggerParentFormSubmit)}>
@@ -70,7 +73,7 @@ export const TwilioIntegrationAddForm = ({
 					<ConnectionTypeComponent
 						control={control}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/twilio/authMethods/apiKey.tsx
+++ b/src/components/organisms/connections/integrations/twilio/authMethods/apiKey.tsx
@@ -46,6 +46,7 @@ export const ApiKeyTwilioForm = ({
 						type="password"
 						{...register("account_sid")}
 						aria-label={t("twilio.placeholders.sid")}
+						disabled={isLoading}
 						handleInputChange={(newSidValue) => setValue("account_sid", newSidValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, account_sid: newLockState }))
@@ -60,6 +61,7 @@ export const ApiKeyTwilioForm = ({
 					<Input
 						{...register("account_sid")}
 						aria-label={t("twilio.placeholders.sid")}
+						disabled={isLoading}
 						isError={!!errors.account_sid}
 						isRequired
 						label={t("twilio.placeholders.sid")}
@@ -73,6 +75,7 @@ export const ApiKeyTwilioForm = ({
 						type="password"
 						{...register("api_key")}
 						aria-label={t("twilio.placeholders.key")}
+						disabled={isLoading}
 						handleInputChange={(newKeyValue) => setValue("api_key", newKeyValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, api_key: newLockState }))
@@ -87,6 +90,7 @@ export const ApiKeyTwilioForm = ({
 					<Input
 						{...register("api_key")}
 						aria-label={t("twilio.placeholders.key")}
+						disabled={isLoading}
 						isError={!!errors.api_key}
 						isRequired
 						label={t("twilio.placeholders.key")}
@@ -100,6 +104,7 @@ export const ApiKeyTwilioForm = ({
 						type="password"
 						{...register("api_secret")}
 						aria-label={t("twilio.placeholders.secret")}
+						disabled={isLoading}
 						handleInputChange={(newSecretValue) => setValue("api_secret", newSecretValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, api_secret: newLockState }))
@@ -114,6 +119,7 @@ export const ApiKeyTwilioForm = ({
 					<Input
 						{...register("api_secret")}
 						aria-label={t("twilio.placeholders.secret")}
+						disabled={isLoading}
 						isError={!!errors.api_secret}
 						isRequired
 						label={t("twilio.placeholders.secret")}

--- a/src/components/organisms/connections/integrations/twilio/authMethods/authToken.tsx
+++ b/src/components/organisms/connections/integrations/twilio/authMethods/authToken.tsx
@@ -51,6 +51,7 @@ export const AuthTokenTwilioForm = ({
 						type="password"
 						{...register("account_sid")}
 						aria-label={t("twilio.placeholders.sid")}
+						disabled={isLoading}
 						handleInputChange={(newSidValue) => setValue("account_sid", newSidValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, account_sid: newLockState }))
@@ -65,6 +66,7 @@ export const AuthTokenTwilioForm = ({
 					<Input
 						{...register("account_sid")}
 						aria-label={t("twilio.placeholders.sid")}
+						disabled={isLoading}
 						isError={!!errors.account_sid}
 						isRequired
 						label={t("twilio.placeholders.sid")}
@@ -78,6 +80,7 @@ export const AuthTokenTwilioForm = ({
 						type="password"
 						{...register("auth_token")}
 						aria-label={t("twilio.placeholders.token")}
+						disabled={isLoading}
 						handleInputChange={(newTokenValue) => setValue("auth_token", newTokenValue)}
 						handleLockAction={(newLockState: boolean) =>
 							setLockState((prevState) => ({ ...prevState, auth_token: newLockState }))
@@ -92,6 +95,7 @@ export const AuthTokenTwilioForm = ({
 					<Input
 						{...register("auth_token")}
 						aria-label={t("twilio.placeholders.token")}
+						disabled={isLoading}
 						isError={!!errors.auth_token}
 						isRequired
 						label={t("twilio.placeholders.token")}

--- a/src/components/organisms/connections/integrations/zoom/add.tsx
+++ b/src/components/organisms/connections/integrations/zoom/add.tsx
@@ -16,10 +16,8 @@ import { Select } from "@components/molecules";
 export const ZoomIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
-	isCreatingConnection,
 }: {
 	connectionId?: string;
-	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -92,7 +90,7 @@ export const ZoomIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
-				disabled={isCreatingConnection || isLoading}
+				disabled={isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={zoomIntegrationAuthMethods}
@@ -105,7 +103,7 @@ export const ZoomIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isCreatingConnection || isLoading}
+						isLoading={isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/zoom/add.tsx
+++ b/src/components/organisms/connections/integrations/zoom/add.tsx
@@ -16,8 +16,10 @@ import { Select } from "@components/molecules";
 export const ZoomIntegrationAddForm = ({
 	connectionId,
 	triggerParentFormSubmit,
+	isCreatingConnection,
 }: {
 	connectionId?: string;
+	isCreatingConnection: boolean;
 	triggerParentFormSubmit: () => void;
 }) => {
 	const { t } = useTranslation("integrations");
@@ -90,6 +92,7 @@ export const ZoomIntegrationAddForm = ({
 		<>
 			<Select
 				aria-label={t("placeholders.selectConnectionType")}
+				disabled={isCreatingConnection || isLoading}
 				label={t("placeholders.connectionType")}
 				onChange={(option) => setConnectionType(option)}
 				options={zoomIntegrationAuthMethods}
@@ -102,7 +105,7 @@ export const ZoomIntegrationAddForm = ({
 						control={control}
 						copyToClipboard={copyToClipboard}
 						errors={errors}
-						isLoading={isLoading}
+						isLoading={isCreatingConnection || isLoading}
 						mode="create"
 						register={register}
 						setValue={setValue}

--- a/src/components/organisms/connections/integrations/zoom/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/oauth.tsx
@@ -2,7 +2,9 @@ import React from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { Button, Loader } from "@components/atoms";
+import { Button, Spinner } from "@components/atoms";
+
+import { ExternalLinkIcon } from "@assets/image/icons";
 
 export const ZoomOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
@@ -10,12 +12,12 @@ export const ZoomOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	return (
 		<Button
 			aria-label={t("buttons.startOAuthFlow")}
-			className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+			className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 			disabled={isLoading}
 			type="submit"
 			variant="outline"
 		>
-			{isLoading ? <Loader size="sm" /> : null}
+			{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 			{t("buttons.startOAuthFlow")}
 		</Button>
 	);

--- a/src/components/organisms/connections/integrations/zoom/authMethods/oauth.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/oauth.tsx
@@ -2,18 +2,20 @@ import React from "react";
 
 import { useTranslation } from "react-i18next";
 
-import { Button } from "@components/atoms";
+import { Button, Loader } from "@components/atoms";
 
-export const ZoomOauthForm = () => {
+export const ZoomOauthForm = ({ isLoading }: { isLoading: boolean }) => {
 	const { t } = useTranslation("integrations");
 
 	return (
 		<Button
 			aria-label={t("buttons.startOAuthFlow")}
 			className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+			disabled={isLoading}
 			type="submit"
 			variant="outline"
 		>
+			{isLoading ? <Loader size="sm" /> : null}
 			{t("buttons.startOAuthFlow")}
 		</Button>
 	);

--- a/src/components/organisms/connections/integrations/zoom/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/oauthPrivate.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 const initialLockState: Record<string, boolean> = {
 	clientSecret: true,
 	secretToken: true,
@@ -81,12 +83,12 @@ export const ZoomOauthPrivateForm = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/integrations/zoom/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/oauthPrivate.tsx
@@ -53,12 +53,12 @@ export const ZoomOauthPrivateForm = ({
 				const error = errors[name]?.message as string;
 				const commonProps = {
 					...register(name),
-					"disabled": isLoading,
+					disabled: isLoading,
 					"aria-label": label,
-					"isError": !!errors[name],
-					"isRequired": isRequired,
+					isError: !!errors[name],
+					isRequired: isRequired,
 					label,
-					"value": values[name as any],
+					value: values[name as any],
 				};
 
 				return (

--- a/src/components/organisms/connections/integrations/zoom/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/oauthPrivate.tsx
@@ -53,6 +53,7 @@ export const ZoomOauthPrivateForm = ({
 				const error = errors[name]?.message as string;
 				const commonProps = {
 					...register(name),
+					"disabled": isLoading,
 					"aria-label": label,
 					"isError": !!errors[name],
 					"isRequired": isRequired,

--- a/src/components/organisms/connections/integrations/zoom/authMethods/serverToServer.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/serverToServer.tsx
@@ -52,12 +52,12 @@ export const ZoomServerToServerForm = ({
 				const error = errors[name]?.message as string;
 				const commonProps = {
 					...register(name),
-					"disabled": isLoading,
+					disabled: isLoading,
 					"aria-label": label,
-					"isError": !!errors[name],
-					"isRequired": isRequired,
+					isError: !!errors[name],
+					isRequired: isRequired,
 					label,
-					"value": values[name as any],
+					value: values[name as any],
 				};
 
 				return (

--- a/src/components/organisms/connections/integrations/zoom/authMethods/serverToServer.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/serverToServer.tsx
@@ -52,6 +52,7 @@ export const ZoomServerToServerForm = ({
 				const error = errors[name]?.message as string;
 				const commonProps = {
 					...register(name),
+					"disabled": isLoading,
 					"aria-label": label,
 					"isError": !!errors[name],
 					"isRequired": isRequired,

--- a/src/components/organisms/connections/integrations/zoom/authMethods/serverToServer.tsx
+++ b/src/components/organisms/connections/integrations/zoom/authMethods/serverToServer.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from "react-i18next";
 
 import { Button, ErrorMessage, Input, SecretInput, Spinner } from "@components/atoms";
 
+import { ExternalLinkIcon } from "@assets/image/icons";
+
 const initialLockState: Record<string, boolean> = {
 	clientSecret: true,
 };
@@ -80,12 +82,12 @@ export const ZoomServerToServerForm = ({
 
 			<Button
 				aria-label={t("buttons.startOAuthFlow")}
-				className="ml-auto w-fit border-black bg-white px-3 font-medium hover:bg-gray-950 hover:text-white"
+				className="ml-auto w-fit border-white px-3 font-medium text-white hover:bg-black"
 				disabled={isLoading}
 				type="submit"
 				variant="outline"
 			>
-				{isLoading ? <Spinner /> : null}
+				{isLoading ? <Spinner /> : <ExternalLinkIcon className="size-4 fill-white transition" />}
 				{t("buttons.startOAuthFlow")}
 			</Button>
 		</>

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -9,13 +9,7 @@ import { namespaces } from "@src/constants";
 import { Connection } from "@type/models";
 
 import { useSort } from "@hooks";
-import {
-	useCacheStore,
-	useConnectionCheckerStore,
-	useHasActiveDeployments,
-	useModalStore,
-	useToastStore,
-} from "@store";
+import { useCacheStore, useConnectionStore, useHasActiveDeployments, useModalStore, useToastStore } from "@store";
 
 import { Button, IconButton, IconSvg, Loader, TBody, THead, Table, Td, Th, Tr } from "@components/atoms";
 import {
@@ -50,7 +44,7 @@ export const ConnectionsTable = () => {
 	const hasActiveDeployments = useHasActiveDeployments();
 
 	const { items: sortedConnections, requestSort, sortConfig } = useSort<Connection>(connections || [], "name");
-	const { resetChecker, setFetchConnectionsCallback } = useConnectionCheckerStore();
+	const { resetChecker, setFetchConnectionsCallback } = useConnectionStore();
 
 	const [warningModalAction, setWarningModalAction] = useState<"edit" | "add">();
 

--- a/src/constants/forms/formSelectInput.constants.ts
+++ b/src/constants/forms/formSelectInput.constants.ts
@@ -16,13 +16,13 @@ const baseStyles = {
 	"::-webkit-scrollbar-thumb:hover": {
 		background: formThemes["gray-950"],
 	},
-	"borderRadius": "8px",
-	"boxShadow": "none",
+	borderRadius: "8px",
+	boxShadow: "none",
 
-	"cursor": "pointer",
-	"fontSize": "16px",
-	"padding": "6px 11px 6px 16px",
-	"svg": {
+	cursor: "pointer",
+	fontSize: "16px",
+	padding: "6px 11px 6px 16px",
+	svg: {
 		height: "24px",
 		width: "24px",
 	},
@@ -76,23 +76,23 @@ const getSelectStyles = (
 
 			backgroundColor,
 
-			"border": defaultBorderColor,
+			border: defaultBorderColor,
 
-			"borderBottom": state.menuIsOpen ? "transparent" : defaultBorderColor,
+			borderBottom: state.menuIsOpen ? "transparent" : defaultBorderColor,
 
-			"borderBottomLeftRadius": state.menuIsOpen ? "0px" : undefined,
+			borderBottomLeftRadius: state.menuIsOpen ? "0px" : undefined,
 
-			"borderBottomRightRadius": state.menuIsOpen ? "0px" : undefined,
+			borderBottomRightRadius: state.menuIsOpen ? "0px" : undefined,
 
-			"borderLeft": state.menuIsOpen ? greenBorderColor : defaultBorderColor,
+			borderLeft: state.menuIsOpen ? greenBorderColor : defaultBorderColor,
 
-			"borderRight": state.menuIsOpen ? greenBorderColor : defaultBorderColor,
+			borderRight: state.menuIsOpen ? greenBorderColor : defaultBorderColor,
 
-			"borderTop": state.menuIsOpen ? greenBorderColor : defaultBorderColor,
+			borderTop: state.menuIsOpen ? greenBorderColor : defaultBorderColor,
 
-			"boxSizing": "border-box",
-			"color": oppositeSchemeColor,
-			"fontWeight": state.menuIsOpen ? 500 : 400,
+			boxSizing: "border-box",
+			color: oppositeSchemeColor,
+			fontWeight: state.menuIsOpen ? 500 : 400,
 		}),
 		dropdownIndicator: (provided, state) => ({
 			...provided,
@@ -100,8 +100,8 @@ const getSelectStyles = (
 			"&:hover": {
 				color: oppositeSchemeColor,
 			},
-			"color": oppositeSchemeColor,
-			"transform": state.selectProps.menuIsOpen ? "matrix(1,0,0,-1,0,0)" : "none",
+			color: oppositeSchemeColor,
+			transform: state.selectProps.menuIsOpen ? "matrix(1,0,0,-1,0,0)" : "none",
 		}),
 		indicatorSeparator: () => ({
 			display: "none",
@@ -134,15 +134,15 @@ const getSelectStyles = (
 				backgroundColor: hoverBackgroundColor,
 				color: formThemes.light,
 			},
-			"backgroundColor": state.isSelected ? selectedBackgroundColor : backgroundColor,
-			"borderRadius": "8px",
-			"color": state.isSelected
+			backgroundColor: state.isSelected ? selectedBackgroundColor : backgroundColor,
+			borderRadius: "8px",
+			color: state.isSelected
 				? selectedTextColor
 				: state.isDisabled
 					? formThemes["gray-750"]
 					: oppositeSchemeColor,
-			"cursor": state.isDisabled ? "not-allowed" : "pointer",
-			"marginTop": "4px",
+			cursor: state.isDisabled ? "not-allowed" : "pointer",
+			marginTop: "4px",
 		}),
 		placeholder: (provided, state) => ({
 			...provided,

--- a/src/constants/forms/formThemes.constants.ts
+++ b/src/constants/forms/formThemes.constants.ts
@@ -5,9 +5,9 @@ import tailwindConfig from "tailwind-config";
 const twConfig = resolveConfig(tailwindConfig);
 
 export const formThemes = {
-	"dark": twConfig.theme.colors.black["DEFAULT"],
-	"error": twConfig.theme.colors.error["DEFAULT"],
-	"light": twConfig.theme.colors.white["DEFAULT"],
+	dark: twConfig.theme.colors.black["DEFAULT"],
+	error: twConfig.theme.colors.error["DEFAULT"],
+	light: twConfig.theme.colors.white["DEFAULT"],
 	"gray-600": twConfig.theme.colors.gray[600],
 	"gray-750": twConfig.theme.colors.gray[750],
 	"gray-950": twConfig.theme.colors.gray[950],

--- a/src/enums/storeName.enum.ts
+++ b/src/enums/storeName.enum.ts
@@ -4,7 +4,6 @@ export enum StoreName {
 	organization = "OrganizationStore",
 	user = "UserStore",
 	files = "FileStore",
-	connectionChecker = "ConnectionCheckerStore",
 	manualRun = "ManualRunStore",
 	cache = "CacheStore",
 	templates = "TemplatesStore",

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -33,7 +33,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 	const navigate = useNavigate();
 	const apiBaseUrl = getApiBaseUrl();
 	const [formSchema, setFormSchema] = useState<ZodObject<ZodRawShape>>(validationSchema);
-	const { startCheckingStatus, setConnectionInProgress, creatingConnection: isLoading } = useConnectionStore();
+	const { startCheckingStatus, setConnectionInProgress, connectionInProgress: isLoading } = useConnectionStore();
 	const { fetchConnections } = useCacheStore();
 	const {
 		clearErrors,

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -33,7 +33,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 	const navigate = useNavigate();
 	const apiBaseUrl = getApiBaseUrl();
 	const [formSchema, setFormSchema] = useState<ZodObject<ZodRawShape>>(validationSchema);
-	const { startCheckingStatus, setCreatingConnection, creatingConnection: isLoading } = useConnectionStore();
+	const { startCheckingStatus, setConnectionInProgress, creatingConnection: isLoading } = useConnectionStore();
 	const { fetchConnections } = useCacheStore();
 	const {
 		clearErrors,
@@ -119,7 +119,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		integrationName?: string
 	): Promise<void> => {
 		try {
-			setCreatingConnection(true);
+			setConnectionInProgress(true);
 			const { error } = await VariablesService.setByConnectiontId(connectionId!, {
 				name: "auth_type",
 				value: connectionAuthType,
@@ -163,7 +163,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 					namespaces.hooks.connectionForm,
 					tErrors("errorCreatingNewConnectionExtended", { error: error?.response?.data })
 				);
-				setCreatingConnection(false);
+				setConnectionInProgress(false);
 
 				return;
 			}
@@ -176,7 +176,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 
 	const editConnection = async (connectionId: string, integrationName?: string): Promise<void> => {
 		try {
-			setCreatingConnection(true);
+			setConnectionInProgress(true);
 			if (connectionType) {
 				const { error } = await VariablesService.setByConnectiontId(connectionId!, {
 					name: "auth_type",
@@ -223,13 +223,13 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 					namespaces.hooks.connectionForm,
 					tErrors("errorEditingConnectionExtended", { error: error?.response?.data })
 				);
-				setCreatingConnection(false);
+				setConnectionInProgress(false);
 
 				return;
 			}
 			LoggerService.error(namespaces.hooks.connectionForm, tErrors("errorEditingConnectionExtended", { error }));
 		} finally {
-			setCreatingConnection(false);
+			setConnectionInProgress(false);
 		}
 	};
 
@@ -273,7 +273,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 
 	const createNewConnection = async () => {
 		try {
-			setCreatingConnection(true);
+			setConnectionInProgress(true);
 			const {
 				connectionName,
 				integration: { value: integrationName },
@@ -307,7 +307,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 
 			setConnectionId(responseConnectionId);
 		} catch (error) {
-			setCreatingConnection(false);
+			setConnectionInProgress(false);
 			addToast({
 				message: tErrors("connectionNotCreated"),
 				type: "error",
@@ -338,7 +338,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		const oauthType = ConnectionAuthType.OauthDefault;
 
 		try {
-			setCreatingConnection(true);
+			setConnectionInProgress(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId!, {
 				name: "auth_type",
 				value: oauthType,
@@ -362,14 +362,14 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				tErrors("errorCreatingNewConnectionExtended", { error })
 			);
 		} finally {
-			setCreatingConnection(false);
+			setConnectionInProgress(false);
 		}
 	};
 
 	const handleLegacyOAuth = async (oauthConnectionId: string, integrationName: keyof typeof Integrations) => {
 		const oauthType = ConnectionAuthType.Oauth;
 		try {
-			setCreatingConnection(true);
+			setConnectionInProgress(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId!, {
 				name: "auth_type",
 				value: oauthType,
@@ -393,7 +393,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				tErrors("errorCreatingNewConnectionExtended", { error })
 			);
 		} finally {
-			setCreatingConnection(false);
+			setConnectionInProgress(false);
 		}
 	};
 
@@ -407,7 +407,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 			| ConnectionAuthType.OauthDefault = ConnectionAuthType.Oauth
 	) => {
 		try {
-			setCreatingConnection(true);
+			setConnectionInProgress(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId, {
 				name: "auth_type",
 				value: authType,
@@ -440,7 +440,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				tErrors("errorCreatingNewConnectionExtended", { error })
 			);
 		} finally {
-			setCreatingConnection(false);
+			setConnectionInProgress(false);
 		}
 	};
 

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -344,6 +344,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		const oauthType = ConnectionAuthType.OauthDefault;
 
 		try {
+			setIsLoading(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId!, {
 				name: "auth_type",
 				value: oauthType,
@@ -374,6 +375,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 	const handleLegacyOAuth = async (oauthConnectionId: string, integrationName: keyof typeof Integrations) => {
 		const oauthType = ConnectionAuthType.Oauth;
 		try {
+			setIsLoading(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId!, {
 				name: "auth_type",
 				value: oauthType,
@@ -410,8 +412,8 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 			| ConnectionAuthType.Oauth
 			| ConnectionAuthType.OauthDefault = ConnectionAuthType.Oauth
 	) => {
-		setIsLoading(true);
 		try {
+			setIsLoading(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId, {
 				name: "auth_type",
 				value: authType,

--- a/src/hooks/useConnectionForm.ts
+++ b/src/hooks/useConnectionForm.ts
@@ -15,7 +15,7 @@ import { integrationDataKeys } from "@src/constants/connections/integrationsData
 import { ConnectionAuthType } from "@src/enums";
 import { Integrations, ModalName, defaultGoogleConnectionName, isGoogleIntegration } from "@src/enums/components";
 import { SelectOption } from "@src/interfaces/components";
-import { useCacheStore, useConnectionCheckerStore, useModalStore, useToastStore } from "@src/store";
+import { useCacheStore, useConnectionStore, useModalStore, useToastStore } from "@src/store";
 import { FormMode } from "@src/types/components";
 import { Variable } from "@src/types/models";
 import { flattenFormData, getApiBaseUrl, openPopup, stripGoogleConnectionName } from "@src/utilities";
@@ -33,7 +33,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 	const navigate = useNavigate();
 	const apiBaseUrl = getApiBaseUrl();
 	const [formSchema, setFormSchema] = useState<ZodObject<ZodRawShape>>(validationSchema);
-	const { startCheckingStatus } = useConnectionCheckerStore();
+	const { startCheckingStatus, setCreatingConnection, creatingConnection: isLoading } = useConnectionStore();
 	const { fetchConnections } = useCacheStore();
 	const {
 		clearErrors,
@@ -55,7 +55,6 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 	const [connectionId, setConnectionId] = useState(paramConnectionId);
 	const [connectionType, setConnectionType] = useState<string>();
 	const [connectionVariables, setConnectionVariables] = useState<Variable[]>();
-	const [isLoading, setIsLoading] = useState(false);
 	const [connectionName, setConnectionName] = useState<string>();
 	const [integration, setIntegration] = useState<SingleValue<SelectOption>>();
 	const addToast = useToastStore((state) => state.addToast);
@@ -119,9 +118,8 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		connectionAuthType: ConnectionAuthType,
 		integrationName?: string
 	): Promise<void> => {
-		setIsLoading(true);
-
 		try {
+			setCreatingConnection(true);
 			const { error } = await VariablesService.setByConnectiontId(connectionId!, {
 				name: "auth_type",
 				value: connectionAuthType,
@@ -165,7 +163,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 					namespaces.hooks.connectionForm,
 					tErrors("errorCreatingNewConnectionExtended", { error: error?.response?.data })
 				);
-				setIsLoading(false);
+				setCreatingConnection(false);
 
 				return;
 			}
@@ -173,14 +171,12 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				namespaces.hooks.connectionForm,
 				tErrors("errorCreatingNewConnectionExtended", { error })
 			);
-		} finally {
-			setIsLoading(false);
 		}
 	};
 
 	const editConnection = async (connectionId: string, integrationName?: string): Promise<void> => {
-		setIsLoading(true);
 		try {
+			setCreatingConnection(true);
 			if (connectionType) {
 				const { error } = await VariablesService.setByConnectiontId(connectionId!, {
 					name: "auth_type",
@@ -207,7 +203,6 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				connectionData
 			);
 
-			setIsLoading(false);
 			addToast({
 				message: t("connectionEditedSuccessfully"),
 				type: "success",
@@ -228,13 +223,13 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 					namespaces.hooks.connectionForm,
 					tErrors("errorEditingConnectionExtended", { error: error?.response?.data })
 				);
-				setIsLoading(false);
+				setCreatingConnection(false);
 
 				return;
 			}
 			LoggerService.error(namespaces.hooks.connectionForm, tErrors("errorEditingConnectionExtended", { error }));
 		} finally {
-			setIsLoading(false);
+			setCreatingConnection(false);
 		}
 	};
 
@@ -278,7 +273,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 
 	const createNewConnection = async () => {
 		try {
-			setIsLoading(true);
+			setCreatingConnection(true);
 			const {
 				connectionName,
 				integration: { value: integrationName },
@@ -312,13 +307,12 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 
 			setConnectionId(responseConnectionId);
 		} catch (error) {
+			setCreatingConnection(false);
 			addToast({
 				message: tErrors("connectionNotCreated"),
 				type: "error",
 			});
 			LoggerService.error(namespaces.hooks.connectionForm, tErrors("connectionNotCreatedExtended", { error }));
-		} finally {
-			setIsLoading(false);
 		}
 	};
 
@@ -344,7 +338,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 		const oauthType = ConnectionAuthType.OauthDefault;
 
 		try {
-			setIsLoading(true);
+			setCreatingConnection(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId!, {
 				name: "auth_type",
 				value: oauthType,
@@ -368,14 +362,14 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				tErrors("errorCreatingNewConnectionExtended", { error })
 			);
 		} finally {
-			setIsLoading(false);
+			setCreatingConnection(false);
 		}
 	};
 
 	const handleLegacyOAuth = async (oauthConnectionId: string, integrationName: keyof typeof Integrations) => {
 		const oauthType = ConnectionAuthType.Oauth;
 		try {
-			setIsLoading(true);
+			setCreatingConnection(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId!, {
 				name: "auth_type",
 				value: oauthType,
@@ -399,7 +393,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				tErrors("errorCreatingNewConnectionExtended", { error })
 			);
 		} finally {
-			setIsLoading(false);
+			setCreatingConnection(false);
 		}
 	};
 
@@ -413,7 +407,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 			| ConnectionAuthType.OauthDefault = ConnectionAuthType.Oauth
 	) => {
 		try {
-			setIsLoading(true);
+			setCreatingConnection(true);
 			await VariablesService.setByConnectiontId(oauthConnectionId, {
 				name: "auth_type",
 				value: authType,
@@ -446,7 +440,7 @@ export const useConnectionForm = (validationSchema: ZodObject<ZodRawShape>, mode
 				tErrors("errorCreatingNewConnectionExtended", { error })
 			);
 		} finally {
-			setIsLoading(false);
+			setCreatingConnection(false);
 		}
 	};
 

--- a/src/hooks/useProjectActions.tsx
+++ b/src/hooks/useProjectActions.tsx
@@ -12,7 +12,7 @@ import { Manifest } from "@src/interfaces/models";
 import { FileStructure } from "@src/interfaces/utilities";
 import { unpackFileZip } from "@src/utilities";
 
-import { useConnectionCheckerStore, useModalStore, useProjectStore, useToastStore } from "@store";
+import { useConnectionStore, useModalStore, useProjectStore, useToastStore } from "@store";
 
 export const useProjectActions = () => {
 	const { t } = useTranslation("dashboard", { keyPrefix: "actions" });
@@ -41,7 +41,7 @@ export const useProjectActions = () => {
 	const { saveAllFiles } = useFileOperations("");
 	const [templateFiles, setTemplateFiles] = useState<FileStructure>();
 	const fileInputRef = useRef<HTMLInputElement>(null);
-	const { resetChecker } = useConnectionCheckerStore();
+	const { resetChecker } = useConnectionStore();
 
 	const handleCreateProject = async (name: string) => {
 		setIsCreatingNewProject(true);

--- a/src/interfaces/store/connectionStore.interface.ts
+++ b/src/interfaces/store/connectionStore.interface.ts
@@ -1,7 +1,8 @@
 import { Connection } from "@src/types/models";
 
-export interface ConnectionCheckerStore {
+export interface ConnectionStore {
 	retries: number;
+	creatingConnection: boolean;
 	incrementRetries: () => void;
 	resetChecker: () => void;
 	recheckIntervalIds: NodeJS.Timeout[];
@@ -9,4 +10,5 @@ export interface ConnectionCheckerStore {
 	avoidNextRerenderCleanup: boolean;
 	fetchConnectionsCallback: (() => void) | null;
 	setFetchConnectionsCallback: (callback: (() => Promise<void | Connection[]>) | null) => void;
+	setCreatingConnection: (value: boolean) => void;
 }

--- a/src/interfaces/store/connectionStore.interface.ts
+++ b/src/interfaces/store/connectionStore.interface.ts
@@ -2,7 +2,7 @@ import { Connection } from "@src/types/models";
 
 export interface ConnectionStore {
 	retries: number;
-	creatingConnection: boolean;
+	connectionInProgress: boolean;
 	incrementRetries: () => void;
 	resetChecker: () => void;
 	recheckIntervalIds: NodeJS.Timeout[];
@@ -10,5 +10,5 @@ export interface ConnectionStore {
 	avoidNextRerenderCleanup: boolean;
 	fetchConnectionsCallback: (() => void) | null;
 	setFetchConnectionsCallback: (callback: (() => Promise<void | Connection[]>) | null) => void;
-	setCreatingConnection: (value: boolean) => void;
+	setConnectionInProgress: (value: boolean) => void;
 }

--- a/src/interfaces/store/index.ts
+++ b/src/interfaces/store/index.ts
@@ -6,7 +6,7 @@ export type {
 	SessionOutputData,
 } from "@interfaces/store/activitiesAndOutputsCache.store.interface";
 export type { CacheStore, ProjectValidationLevel } from "@interfaces/store/cacheStore.interface";
-export type { ConnectionCheckerStore } from "@interfaces/store/connectionCheckerStore.interface";
+export type { ConnectionStore } from "@src/interfaces/store/connectionStore.interface";
 export type { DrawerStore } from "@interfaces/store/drawerStore.interface";
 export type { FileStore } from "@interfaces/store/fileStore.interface";
 export type { LoggerStore } from "@interfaces/store/loggerStore.interface";

--- a/src/services/http.service.ts
+++ b/src/services/http.service.ts
@@ -16,7 +16,7 @@ const createAxiosInstance = (baseAddress: string, withCredentials = false) => {
 		baseURL: baseAddress,
 		headers: {
 			"Content-Type": "application/x-www-form-urlencoded",
-			"Authorization": jwtAuthToken,
+			Authorization: jwtAuthToken,
 		},
 		withCredentials: isWithCredentials,
 		timeout: apiRequestTimeout,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@ export { useActivitiesCacheStore } from "@src/store/cache/useActivitiesCacheStor
 export { useCacheStore, useHasActiveDeployments } from "@src/store/cache/useCacheStore";
 export { useOutputsCacheStore } from "@src/store/cache/useOutputsCacheStore";
 export { useTemplatesStore } from "@src/store/useTemplatesStore";
-export { useConnectionCheckerStore } from "@store/useConnectionCheckerStore";
+export { useConnectionStore } from "@store/useConnectionStore";
 export { useDrawerStore } from "@store/useDrawerStore";
 export { useFileStore } from "@store/useFileStore";
 export { useLoggerStore } from "@store/useLoggerStore";

--- a/src/store/useConnectionStore.ts
+++ b/src/store/useConnectionStore.ts
@@ -13,7 +13,7 @@ const store: StateCreator<ConnectionStore> = (set, get) => ({
 	retries: 0,
 	recheckIntervalIds: [],
 	avoidNextRerenderCleanup: true,
-	creatingConnection: false,
+	connectionInProgress: false,
 	fetchConnectionsCallback: () => {},
 
 	incrementRetries: () => {
@@ -123,11 +123,11 @@ const store: StateCreator<ConnectionStore> = (set, get) => ({
 			return state;
 		});
 	},
-	setCreatingConnection: (value) => {
+	setConnectionInProgress: (value) => {
 		set((state) => {
-			if (state.creatingConnection === value) return state;
+			if (state.connectionInProgress === value) return state;
 
-			state.creatingConnection = value;
+			state.connectionInProgress = value;
 
 			return state;
 		});

--- a/src/store/useConnectionStore.ts
+++ b/src/store/useConnectionStore.ts
@@ -1,20 +1,19 @@
 import i18n from "i18next";
 import { StateCreator, create } from "zustand";
-import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
-import { StoreName } from "@enums";
-import { ConnectionCheckerStore } from "@interfaces/store";
+import { ConnectionStore } from "@interfaces/store";
 import { ConnectionService, LoggerService } from "@services";
 import { namespaces } from "@src/constants";
 import { ConnectionStatusType } from "@type/models";
 
 import { useToastStore } from "@store";
 
-const store: StateCreator<ConnectionCheckerStore> = (set, get) => ({
+const store: StateCreator<ConnectionStore> = (set, get) => ({
 	retries: 0,
 	recheckIntervalIds: [],
 	avoidNextRerenderCleanup: true,
+	creatingConnection: false,
 	fetchConnectionsCallback: () => {},
 
 	incrementRetries: () => {
@@ -124,6 +123,15 @@ const store: StateCreator<ConnectionCheckerStore> = (set, get) => ({
 			return state;
 		});
 	},
+	setCreatingConnection: (value) => {
+		set((state) => {
+			if (state.creatingConnection === value) return state;
+
+			state.creatingConnection = value;
+
+			return state;
+		});
+	},
 });
 
-export const useConnectionCheckerStore = create(persist(immer(store), { name: StoreName.connectionChecker }));
+export const useConnectionStore = create(immer(store));


### PR DESCRIPTION
## Description
Disable all fields on add/edit connection screen when saving And Add Loader on button
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1364/disable-all-fields-on-addedit-connection-screen-when-saving-and-add
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
