### PR TITLE
fix(UI-1413): fix saving trigger with empty filter value

### DIFF
--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -136,7 +136,7 @@ export const EditTrigger = () => {
 				entryFunction,
 				schedule: cron,
 				eventType: eventTypeSelect.value,
-				filter: filter ? filter : ".",
+				filter: filter || ".",
 				triggerId: triggerId!,
 			});
 			if (error) {

--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -136,7 +136,7 @@ export const EditTrigger = () => {
 				entryFunction,
 				schedule: cron,
 				eventType: eventTypeSelect.value,
-				filter,
+				filter: filter ? "" : ".",
 				triggerId: triggerId!,
 			});
 			if (error) {

--- a/src/components/organisms/triggers/edit.tsx
+++ b/src/components/organisms/triggers/edit.tsx
@@ -136,7 +136,7 @@ export const EditTrigger = () => {
 				entryFunction,
 				schedule: cron,
 				eventType: eventTypeSelect.value,
-				filter: filter ? "" : ".",
+				filter: filter ? filter : ".",
 				triggerId: triggerId!,
 			});
 			if (error) {


### PR DESCRIPTION
## Description
When we have a trigger with some value, for example: data.text == "break-glass"

When we delete the filter in our frontend, the frontend won't send it to the backend, because the value is empty, the key will drop in the data object.

**The solution is:** to send a dot (".") to the backend, it will interpolate it as an empty value.

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1413/in-case-of-an-empty-filter-value-in-trigger-send-a-dot

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
