### PR TITLE
refactor(UI-1398): always open first session on Sessions page

### DIFF
--- a/src/components/organisms/deployments/sessions/table/table.tsx
+++ b/src/components/organisms/deployments/sessions/table/table.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Outlet, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { ListOnItemsRenderedProps } from "react-window";
 
-import { defaultSplitFrameSize, namespaces, sessionRowHeight } from "@constants";
+import { defaultSplitFrameSize, namespaces } from "@constants";
 import { ModalName } from "@enums/components";
 import { reverseSessionStateConverter } from "@models/utils";
 import { LoggerService, SessionsService } from "@services";
@@ -176,8 +176,7 @@ export const SessionsTable = () => {
 				{
 					stateType: reverseSessionStateConverter(urlSessionStateFilter as SessionStateKeyType),
 				},
-				nextPageToken,
-				sessionRowHeight
+				nextPageToken
 			);
 
 			if (error) {
@@ -211,6 +210,10 @@ export const SessionsTable = () => {
 			setSessionsNextPageToken(data.nextPageToken);
 			setIsLoading(false);
 			setIsInitialLoad(false);
+
+			if (!nextPageToken && data.sessions.length > 0) {
+				navigateInSessions("", data.sessions[0].sessionId);
+			}
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[deploymentId, urlSessionStateFilter]

--- a/src/constants/global.constants.ts
+++ b/src/constants/global.constants.ts
@@ -16,7 +16,7 @@ export const version = packageJson.version;
 
 export const fetchProjectsMenuItemsInterval = 60000;
 export const fetchSessionsInterval = 10000;
-export const defaultSessionsVisiblePageSize = 10;
+export const defaultSessionsVisiblePageSize = 1;
 export const maxLogs = 20;
 export const fileSizeUploadLimit = 50 * 1024; // 50KB
 export const apiRequestTimeout = isDevelopment ? 1000 * 60 : 1000 * 10; // 1 minute in development, 10 seconds in production

--- a/src/constants/global.constants.ts
+++ b/src/constants/global.constants.ts
@@ -16,7 +16,6 @@ export const version = packageJson.version;
 
 export const fetchProjectsMenuItemsInterval = 60000;
 export const fetchSessionsInterval = 10000;
-export const defaultSessionsVisiblePageSize = 1;
 export const maxLogs = 20;
 export const fileSizeUploadLimit = 50 * 1024; // 50KB
 export const apiRequestTimeout = isDevelopment ? 1000 * 60 : 1000 * 10; // 1 minute in development, 10 seconds in production

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -57,7 +57,6 @@ export {
 	standardScreenHeightFallback,
 	sessionsEditorLineHeight,
 	sessionLogRowHeight,
-	sessionRowHeight,
 } from "@constants/sessions.constants";
 export { initialSortConfig } from "@constants/sortConfig.constants";
 export { infoCronExpressionsLinks, extraTriggerTypes } from "@constants/triggers.constants";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,5 @@
 export { featureFlags } from "@constants/featureFlags.constants";
 export {
-	defaultSessionsVisiblePageSize,
 	descopeProjectId,
 	fetchProjectsMenuItemsInterval,
 	fetchSessionsInterval,

--- a/src/constants/sessions.constants.ts
+++ b/src/constants/sessions.constants.ts
@@ -11,4 +11,3 @@ export const sessionTabs = [
 export const sessionLogRowHeight = Math.ceil(
 	(standardScreenHeightFallback / defaultSessionLogRecordsListRowHeight) * 1.5
 );
-export const sessionRowHeight = Math.ceil((standardScreenHeightFallback / defaultSessionsListRowHeight) * 1.5);

--- a/src/services/sessions.service.ts
+++ b/src/services/sessions.service.ts
@@ -8,7 +8,7 @@ import {
 } from "@ak-proto-ts/sessions/v1/session_pb";
 import { StartRequest } from "@ak-proto-ts/sessions/v1/svc_pb";
 import { sessionsClient } from "@api/grpc/clients.grpc.api";
-import { defaultSessionsVisiblePageSize, namespaces } from "@constants";
+import { namespaces } from "@constants";
 import { convertSessionLogProtoToModel, convertSessionProtoToModel, convertSessionProtoToViewerModel } from "@models";
 import { LoggerService } from "@services";
 import { SessionLogType } from "@src/enums";
@@ -133,7 +133,7 @@ export class SessionsService {
 		try {
 			const { nextPageToken, sessions: sessionsResponse } = await sessionsClient.list({
 				deploymentId,
-				pageSize: pageSize || defaultSessionsVisiblePageSize,
+				pageSize: pageSize,
 				pageToken,
 				stateType: filter?.stateType,
 			});
@@ -157,7 +157,7 @@ export class SessionsService {
 		try {
 			const { nextPageToken, sessions: sessionsResponse } = await sessionsClient.list({
 				projectId,
-				pageSize: pageSize || defaultSessionsVisiblePageSize,
+				pageSize: pageSize,
 				pageToken,
 				stateType: filter?.stateType,
 			});


### PR DESCRIPTION
## Description
Expected flow when the user clicks the Sessions button in the navigation bar:

1.Run sessions.List filtered by projectId with pageSize=1
2.navigate to the session's page
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1398/always-select-first-session-on-sessions-page
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
