### PR TITLE
fix(UI-1393): fix save cursor postion on editor code

### DIFF
--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -52,6 +52,7 @@ export const EditorTabs = ({
 	const [isFirstContentLoad, setIsFirstContentLoad] = useState(true);
 	const [isFirstCursorPositionChange, setIsFirstCursorPositionChange] = useState(true);
 	const [isFocusedAndTyping, setIsFocusedAndTyping] = useState(false);
+	const [editorMounted, setEditorMounted] = useState(false);
 
 	useEffect(() => {
 		if (!content || !isFirstContentLoad) return;
@@ -138,6 +139,7 @@ export const EditorTabs = ({
 			}
 			_editor.trigger("keyboard", "undo", null);
 		});
+		setEditorMounted(true);
 	};
 
 	useEffect(() => {
@@ -164,7 +166,7 @@ export const EditorTabs = ({
 			cursorPositionChangeListener.dispose();
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [projectId, currentProjectId, activeEditorFileName, editorRef]);
+	}, [projectId, currentProjectId, activeEditorFileName, editorRef, editorMounted]);
 
 	const revealAndFocusOnLineInEditor = (
 		codeEditor: monaco.editor.IStandaloneCodeEditor,
@@ -300,14 +302,12 @@ export const EditorTabs = ({
 	const changePointerPosition = () => {
 		const codeEditor = editorRef.current;
 		if (!codeEditor || !codeEditor.getModel()) return;
-		if (codeEditor && codeEditor.getModel()) {
-			const position = codeEditor.getPosition();
-			if (position) {
-				setCursorPosition(projectId!, activeEditorFileName, {
-					column: position.column,
-					lineNumber: position.lineNumber,
-				});
-			}
+		const position = codeEditor.getPosition();
+		if (position) {
+			setCursorPosition(projectId!, activeEditorFileName, {
+				column: position.column,
+				lineNumber: position.lineNumber,
+			});
 		}
 	};
 


### PR DESCRIPTION
## Description
When the user edits his code in a file editor, then he goes to other pages, other projects, when he's back, we should display the editor focused on the same line.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1393/open-file-on-the-same-line-when-coming-back-from-sessions-page
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
