### PR TITLE
feat(UI-1397)(UI-1400)(UI-1422): update sessions list on Manual Run in the Sessions page

### DIFF
--- a/src/components/organisms/deployments/sessions/table/table.tsx
+++ b/src/components/organisms/deployments/sessions/table/table.tsx
@@ -294,10 +294,8 @@ export const SessionsTable = () => {
 
 	const refreshViewer = async (): Promise<void> => {
 		refreshData();
-		if (sessionId) {
-			triggerEvent(EventListenerName.sessionReload);
-			return;
-		}
+		if (!sessionId) return;
+		triggerEvent(EventListenerName.sessionReload);
 	};
 
 	return (

--- a/src/components/organisms/deployments/sessions/table/table.tsx
+++ b/src/components/organisms/deployments/sessions/table/table.tsx
@@ -150,11 +150,6 @@ export const SessionsTable = () => {
 		[projectId, deploymentId]
 	);
 
-	useEffect(() => {
-		fetchDeployments(false);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [deployments]);
-
 	const fetchSessions = useCallback(
 		async (nextPageToken?: string, forceRefresh = false) => {
 			if (!forceRefresh) {
@@ -221,11 +216,20 @@ export const SessionsTable = () => {
 
 	const debouncedFetchSessions = useMemo(() => debounce(fetchSessions, 100), [fetchSessions]);
 
-	const refreshData = useCallback(async () => {
-		setIsLoading(true);
-		await fetchSessions(undefined, true);
-		setIsLoading(false);
-	}, [fetchSessions]);
+	const refreshData = useCallback(
+		async (forceRefresh = false) => {
+			setIsLoading(true);
+			const deploymentsUpdated = await fetchDeployments();
+
+			if (deploymentsUpdated || forceRefresh) {
+				await fetchSessions(undefined, true);
+				return;
+			}
+
+			setIsLoading(false);
+		},
+		[fetchDeployments, fetchSessions]
+	);
 
 	useEffect(() => {
 		refreshData();

--- a/src/components/organisms/deployments/sessions/table/table.tsx
+++ b/src/components/organisms/deployments/sessions/table/table.tsx
@@ -211,7 +211,7 @@ export const SessionsTable = () => {
 			setIsLoading(false);
 			setIsInitialLoad(false);
 
-			if (!nextPageToken && data.sessions.length > 0) {
+			if (!nextPageToken && data.sessions.length > 0 && !sessionId) {
 				navigateInSessions("", data.sessions[0].sessionId);
 			}
 		},
@@ -288,6 +288,13 @@ export const SessionsTable = () => {
 		navigateInSessions(filterEntityId, "");
 	};
 
+	const refreshViewer = async (): Promise<void> => {
+		if (sessionId) {
+			navigate(`./${sessionId}`, { state: { refreshViewer: Date.now() } });
+		}
+		refreshData();
+	};
+
 	return (
 		<div className="mt-1.5 flex w-full flex-1 overflow-y-auto">
 			<div style={{ width: `${leftSideWidth}%` }}>
@@ -323,7 +330,7 @@ export const SessionsTable = () => {
 								onChange={(sessionState) => navigateInSessions("", "", sessionState)}
 								selectedState={urlSessionStateFilter}
 							/>
-							<RefreshButton isLoading={isLoading} onRefresh={refreshData} />
+							<RefreshButton isLoading={isLoading} onRefresh={refreshViewer} />
 						</div>
 					</div>
 

--- a/src/components/organisms/deployments/sessions/table/table.tsx
+++ b/src/components/organisms/deployments/sessions/table/table.tsx
@@ -211,7 +211,7 @@ export const SessionsTable = () => {
 			}
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[deploymentId, urlSessionStateFilter]
+		[deploymentId, urlSessionStateFilter, sessionId]
 	);
 
 	const debouncedFetchSessions = useMemo(() => debounce(fetchSessions, 100), [fetchSessions]);
@@ -232,7 +232,7 @@ export const SessionsTable = () => {
 	);
 
 	useEffect(() => {
-		refreshData();
+		refreshData(true);
 
 		return () => {
 			debouncedFetchSessions.cancel();
@@ -293,11 +293,11 @@ export const SessionsTable = () => {
 	};
 
 	const refreshViewer = async (): Promise<void> => {
+		refreshData();
 		if (sessionId) {
 			triggerEvent(EventListenerName.sessionReload);
 			return;
 		}
-		refreshData();
 	};
 
 	return (

--- a/src/components/organisms/deployments/sessions/table/table.tsx
+++ b/src/components/organisms/deployments/sessions/table/table.tsx
@@ -221,27 +221,19 @@ export const SessionsTable = () => {
 
 	const debouncedFetchSessions = useMemo(() => debounce(fetchSessions, 100), [fetchSessions]);
 
-	const refreshData = useCallback(
-		async (forceRefresh = false) => {
-			setIsLoading(true);
-			const deploymentsUpdated = await fetchDeployments();
-
-			if (deploymentsUpdated || forceRefresh) {
-				await fetchSessions(undefined, true);
-			} else {
-				setIsLoading(false);
-			}
-		},
-		[fetchDeployments, fetchSessions]
-	);
+	const refreshData = useCallback(async () => {
+		setIsLoading(true);
+		await fetchSessions(undefined, true);
+		setIsLoading(false);
+	}, [fetchSessions]);
 
 	useEffect(() => {
-		refreshData(true);
+		refreshData();
 
 		return () => {
 			debouncedFetchSessions.cancel();
 		};
-	}, [refreshData, debouncedFetchSessions]);
+	}, [refreshData, debouncedFetchSessions, deployments]);
 
 	const closeSessionLog = useCallback(() => {
 		navigateInSessions(filteredEntityId, "");
@@ -331,7 +323,7 @@ export const SessionsTable = () => {
 								onChange={(sessionState) => navigateInSessions("", "", sessionState)}
 								selectedState={urlSessionStateFilter}
 							/>
-							<RefreshButton isLoading={isLoading} onRefresh={() => refreshData(true)} />
+							<RefreshButton isLoading={isLoading} onRefresh={refreshData} />
 						</div>
 					</div>
 

--- a/src/components/organisms/deployments/sessions/table/table.tsx
+++ b/src/components/organisms/deployments/sessions/table/table.tsx
@@ -9,8 +9,8 @@ import { defaultSplitFrameSize, namespaces } from "@constants";
 import { ModalName } from "@enums/components";
 import { reverseSessionStateConverter } from "@models/utils";
 import { LoggerService, SessionsService } from "@services";
-import { SessionStateType } from "@src/enums";
-import { useResize } from "@src/hooks";
+import { EventListenerName, SessionStateType } from "@src/enums";
+import { useResize, triggerEvent } from "@src/hooks";
 import { PopoverListItem } from "@src/interfaces/components/popover.interface";
 import { Session, SessionStateKeyType } from "@src/interfaces/models";
 import { useCacheStore, useModalStore, useSharedBetweenProjectsStore, useToastStore } from "@src/store";
@@ -294,7 +294,8 @@ export const SessionsTable = () => {
 
 	const refreshViewer = async (): Promise<void> => {
 		if (sessionId) {
-			navigate(`./${sessionId}`, { state: { refreshViewer: Date.now() } });
+			triggerEvent(EventListenerName.sessionReload);
+			return;
 		}
 		refreshData();
 	};

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -215,9 +215,8 @@ export const SessionViewer = () => {
 
 	useEventListener(EventListenerName.sessionReload, () => {
 		if (
-			sessionInfo?.state === SessionState.running ||
-			sessionInfo?.state === SessionState.created ||
-			sessionInfo?.state === SessionState.unspecified
+			sessionInfo?.state &&
+			[SessionState.running, SessionState.created, SessionState.unspecified].includes(sessionInfo.state)
 		) {
 			fetchSessions();
 		}

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -234,13 +234,6 @@ export const SessionViewer = () => {
 		setActiveTab(activeTabValue);
 	}, [location.pathname]);
 
-	useEffect(() => {
-		if (location.state?.refreshViewer) {
-			fetchSessions();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [location.state?.refreshViewer]);
-
 	const goTo = useCallback(
 		(path: string) => {
 			if (path === defaultSessionTab) {

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import JsonView from "@uiw/react-json-view";
 import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
@@ -26,7 +26,7 @@ import { useActivitiesCacheStore, useOutputsCacheStore, useToastStore } from "@s
 import { copyToClipboard } from "@src/utilities";
 
 import { Button, Frame, IconSvg, Loader, LogoCatLarge, Tab, Tooltip } from "@components/atoms";
-import { Accordion, IdCopyButton, RefreshButton } from "@components/molecules";
+import { Accordion, IdCopyButton } from "@components/molecules";
 import { SessionsTableState } from "@components/organisms/deployments";
 
 import { DownloadIcon, ArrowRightIcon, CircleMinusIcon, CirclePlusIcon, CopyIcon } from "@assets/image/icons";
@@ -224,6 +224,13 @@ export const SessionViewer = () => {
 		setActiveTab(activeTabValue);
 	}, [location.pathname]);
 
+	useEffect(() => {
+		if (location.state?.refreshViewer) {
+			fetchSessions();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [location.state?.refreshViewer]);
+
 	const goTo = useCallback(
 		(path: string) => {
 			if (path === defaultSessionTab) {
@@ -252,25 +259,13 @@ export const SessionViewer = () => {
 		return `${hours ? `${String(hours).padStart(2, "0")}:` : ""}${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
 	}, []);
 
-	const isRefreshButtonDisabled = useMemo(
-		() =>
-			sessionInfo?.state !== SessionState.completed &&
-			sessionInfo?.state !== SessionState.error &&
-			sessionInfo?.state !== SessionState.stopped,
-		[sessionInfo?.state]
-	);
-
 	if (!sessionInfo) return null;
 
 	return isLoading && isInitialLoad ? (
 		<Loader size="xl" />
 	) : (
 		<Frame className="overflow-y-auto overflow-x-hidden rounded-l-none pb-3 font-fira-code">
-			<div className="flex items-center justify-end gap-2 border-b border-gray-950 pb-3.5">
-				<RefreshButton disabled={!isRefreshButtonDisabled} isLoading={isLoading} onRefresh={fetchSessions} />
-			</div>
-
-			<div className="mt-2.5 flex justify-between">
+			<div className="flex justify-between">
 				<div className="flex flex-col gap-0.5 leading-6">
 					<div className="flex items-center gap-4">
 						<div className="w-32 text-gray-1550">{t("status")}</div>

--- a/src/components/organisms/deployments/sessions/viewer.tsx
+++ b/src/components/organisms/deployments/sessions/viewer.tsx
@@ -19,7 +19,7 @@ import {
 import { LoggerService } from "@services/index";
 import { SessionsService } from "@services/sessions.service";
 import { EventListenerName, SessionLogType, SessionState } from "@src/enums";
-import { triggerEvent } from "@src/hooks";
+import { triggerEvent, useEventListener } from "@src/hooks";
 import { SessionOutputLog, ViewerSession } from "@src/interfaces/models/session.interface";
 import { convertSessionLogProtoToViewerOutput } from "@src/models";
 import { useActivitiesCacheStore, useOutputsCacheStore, useToastStore } from "@src/store";
@@ -212,6 +212,16 @@ export const SessionViewer = () => {
 		triggerEvent(EventListenerName.sessionLogViewerScrollToTop);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [sessionInfo, fetchSessionInfo, loadOutputs, loadActivities]);
+
+	useEventListener(EventListenerName.sessionReload, () => {
+		if (
+			sessionInfo?.state === SessionState.running ||
+			sessionInfo?.state === SessionState.created ||
+			sessionInfo?.state === SessionState.unspecified
+		) {
+			fetchSessions();
+		}
+	});
 
 	useEffect(() => {
 		const pathSegments = location.pathname.split("/");

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -56,6 +56,7 @@ export {
 	standardScreenHeightFallback,
 	sessionsEditorLineHeight,
 	sessionLogRowHeight,
+	defaultSessionsPageSize,
 } from "@constants/sessions.constants";
 export { initialSortConfig } from "@constants/sortConfig.constants";
 export { infoCronExpressionsLinks, extraTriggerTypes } from "@constants/triggers.constants";

--- a/src/constants/sessions.constants.ts
+++ b/src/constants/sessions.constants.ts
@@ -1,6 +1,7 @@
 export const sessionsEditorLineHeight = 20;
 export const defaultSessionLogRecordsListRowHeight = 50;
 export const defaultSessionsListRowHeight = 40;
+export const defaultSessionsPageSize = 50;
 export const standardScreenHeightFallback = 1400;
 export const defaultSessionTab = "outputs";
 export const sessionTabs = [

--- a/src/enums/eventListenerNames.enum.ts
+++ b/src/enums/eventListenerNames.enum.ts
@@ -1,3 +1,4 @@
 export enum EventListenerName {
 	sessionLogViewerScrollToTop = "sessionLogViewerScrollToTop",
+	sessionReload = "sessionReload",
 }

--- a/src/services/sessions.service.ts
+++ b/src/services/sessions.service.ts
@@ -8,7 +8,7 @@ import {
 } from "@ak-proto-ts/sessions/v1/session_pb";
 import { StartRequest } from "@ak-proto-ts/sessions/v1/svc_pb";
 import { sessionsClient } from "@api/grpc/clients.grpc.api";
-import { namespaces } from "@constants";
+import { defaultSessionsPageSize, namespaces } from "@constants";
 import { convertSessionLogProtoToModel, convertSessionProtoToModel, convertSessionProtoToViewerModel } from "@models";
 import { LoggerService } from "@services";
 import { SessionLogType } from "@src/enums";
@@ -133,7 +133,7 @@ export class SessionsService {
 		try {
 			const { nextPageToken, sessions: sessionsResponse } = await sessionsClient.list({
 				deploymentId,
-				pageSize: pageSize,
+				pageSize: pageSize || defaultSessionsPageSize,
 				pageToken,
 				stateType: filter?.stateType,
 			});
@@ -157,7 +157,7 @@ export class SessionsService {
 		try {
 			const { nextPageToken, sessions: sessionsResponse } = await sessionsClient.list({
 				projectId,
-				pageSize: pageSize,
+				pageSize: pageSize || defaultSessionsPageSize,
 				pageToken,
 				stateType: filter?.stateType,
 			});


### PR DESCRIPTION
## Description
If the user runs Manual Run from the Sessions page - after Manual Run request succeed, we should refresh the sessions list.
Also Refresh the sessions list in the table after remove session
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1397/update-sessions-list-on-manual-run-in-the-sessions-page
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
