### PR TITLE
feat(UI-1411): add allow users see the memberts list in an organization

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -274,7 +274,14 @@ export const App = () => {
 				<Route element={<Navigate replace to="/404" />} path="*" />
 			</Route>
 
-			<Route element={<SettingsLayout />} path="organization-settings">
+			<Route
+				element={
+					<ProtectedRoute allowedRole={[MemberRole.admin, MemberRole.user]}>
+						<SettingsLayout />
+					</ProtectedRoute>
+				}
+				path="organization-settings"
+			>
 				<Route
 					element={
 						<ProtectedRoute allowedRole={[MemberRole.admin]}>
@@ -283,14 +290,7 @@ export const App = () => {
 					}
 					index
 				/>
-				<Route
-					element={
-						<ProtectedRoute allowedRole={[MemberRole.admin, MemberRole.user]}>
-							<OrganizationMembersTable />
-						</ProtectedRoute>
-					}
-					path="members"
-				/>
+				<Route element={<OrganizationMembersTable />} path="members" />
 
 				<Route element={<Navigate replace to="/404" />} path="*" />
 			</Route>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -273,16 +273,24 @@ export const App = () => {
 
 				<Route element={<Navigate replace to="/404" />} path="*" />
 			</Route>
-			<Route
-				element={
-					<ProtectedRoute allowedRole={[MemberRole.admin]}>
-						<SettingsLayout />
-					</ProtectedRoute>
-				}
-				path="organization-settings"
-			>
-				<Route element={<OrganizationSettings />} index />
-				<Route element={<OrganizationMembersTable />} path="members" />
+
+			<Route element={<SettingsLayout />} path="organization-settings">
+				<Route
+					element={
+						<ProtectedRoute allowedRole={[MemberRole.admin]}>
+							<OrganizationSettings />
+						</ProtectedRoute>
+					}
+					index
+				/>
+				<Route
+					element={
+						<ProtectedRoute allowedRole={[MemberRole.admin, MemberRole.user]}>
+							<OrganizationMembersTable />
+						</ProtectedRoute>
+					}
+					path="members"
+				/>
 
 				<Route element={<Navigate replace to="/404" />} path="*" />
 			</Route>

--- a/src/components/organisms/settings/organization/members/table.tsx
+++ b/src/components/organisms/settings/organization/members/table.tsx
@@ -6,6 +6,7 @@ import { ModalName } from "@src/enums/components";
 import { CreateMemberModalRef } from "@src/interfaces/components";
 import { useModalStore, useOrganizationStore, useToastStore } from "@src/store";
 import { EnrichedMember } from "@src/types/models";
+import { cn } from "@src/utilities";
 
 import { Button, IconButton, Loader, TBody, THead, Table, Td, Th, Tr, Typography } from "@components/atoms";
 import { CreateMemberModal, DeleteMemberModal } from "@components/organisms/settings/organization";
@@ -22,6 +23,7 @@ export const OrganizationMembersTable = () => {
 		isLoading,
 		getEnrichedMembers,
 		user,
+		amIadminCurrentOrganization,
 		members: membersFromStore,
 	} = useOrganizationStore();
 	const addToast = useToastStore((state) => state.addToast);
@@ -109,21 +111,44 @@ export const OrganizationMembersTable = () => {
 			<Typography className="mb-4 font-bold" element="h2" size="xl">
 				{t("title")}
 			</Typography>
-			<Button
-				className="ml-auto border-black bg-white px-5 text-base font-medium hover:bg-gray-950 hover:text-white"
-				onClick={() => openCreateMemberModal()}
-				variant="outline"
-			>
-				{t("buttons.addMember")}
-			</Button>
+			{amIadminCurrentOrganization ? (
+				<Button
+					className="ml-auto border-black bg-white px-5 text-base font-medium hover:bg-gray-950 hover:text-white"
+					onClick={() => openCreateMemberModal()}
+					variant="outline"
+				>
+					{t("buttons.addMember")}
+				</Button>
+			) : null}
+
 			<Table className="mt-6">
 				<THead>
 					<Tr>
-						<Th className="w-1/5 min-w-16 pl-4">{t("table.headers.name")}</Th>
-						<Th className="w-2/6 min-w-16">{t("table.headers.email")}</Th>
-						<Th className="w-1/5 min-w-16">{t("table.headers.status")}</Th>
+						<Th
+							className={cn("w-1/5 min-w-16 pl-4", {
+								"w-1/3": !amIadminCurrentOrganization,
+							})}
+						>
+							{t("table.headers.name")}
+						</Th>
+						<Th
+							className={cn("w-2/6 min-w-16", {
+								"w-1/3": !amIadminCurrentOrganization,
+							})}
+						>
+							{t("table.headers.email")}
+						</Th>
+						<Th
+							className={cn("w-1/5 min-w-16", {
+								"w-1/6": !amIadminCurrentOrganization,
+							})}
+						>
+							{t("table.headers.status")}
+						</Th>
 						<Th className="w-1/6 min-w-16">{t("table.headers.role")}</Th>
-						<Th className="w-1/8 min-w-16">{t("table.headers.actions")}</Th>
+						{amIadminCurrentOrganization ? (
+							<Th className="w-1/8 min-w-16">{t("table.headers.actions")}</Th>
+						) : null}
 					</Tr>
 				</THead>
 
@@ -133,26 +158,46 @@ export const OrganizationMembersTable = () => {
 					<TBody>
 						{members?.map((member) => (
 							<Tr className="hover:bg-gray-1300" key={member.id}>
-								<Td className="w-1/5 min-w-16 pl-4">{member.name}</Td>
-								<Td className="w-2/6 min-w-16">{member.email}</Td>
-								<Td className="w-1/5 min-w-16 capitalize">{member.status}</Td>
-								<Td className="w-1/6 min-w-16 capitalize">{member.role}</Td>
-								<Td className="w-1/8 min-w-16" innerDivClassName="justify-end">
-									<IconButton
-										className="mr-1"
-										disabled={user?.id === member.id}
-										onClick={() =>
-											openModal(ModalName.deleteMemberFromOrg, {
-												name: member.name,
-												id: member.id,
-												email: member.email,
-											})
-										}
-										title={t("table.actions.delete", { name: member.name })}
-									>
-										<TrashIcon className="size-4 stroke-white" />
-									</IconButton>
+								<Td
+									className={cn("w-1/5 min-w-16 pl-4", {
+										"w-1/3": !amIadminCurrentOrganization,
+									})}
+								>
+									{member.name}
 								</Td>
+								<Td
+									className={cn("w-2/6 min-w-16", {
+										"w-1/3": !amIadminCurrentOrganization,
+									})}
+								>
+									{member.email}
+								</Td>
+								<Td
+									className={cn("w-1/5 min-w-16 capitalize", {
+										"w-1/6": !amIadminCurrentOrganization,
+									})}
+								>
+									{member.status}
+								</Td>
+								<Td className="w-1/6 min-w-16 capitalize">{member.role}</Td>
+								{amIadminCurrentOrganization ? (
+									<Td className="w-1/8 min-w-16" innerDivClassName="justify-end">
+										<IconButton
+											className="mr-1"
+											disabled={user?.id === member.id}
+											onClick={() =>
+												openModal(ModalName.deleteMemberFromOrg, {
+													name: member.name,
+													id: member.id,
+													email: member.email,
+												})
+											}
+											title={t("table.actions.delete", { name: member.name })}
+										>
+											<TrashIcon className="size-4 stroke-white" />
+										</IconButton>
+									</Td>
+								) : null}
 							</Tr>
 						))}
 					</TBody>

--- a/src/components/organisms/settings/organization/switchOrganization.tsx
+++ b/src/components/organisms/settings/organization/switchOrganization.tsx
@@ -28,21 +28,6 @@ export const SwitchOrganization = () => {
 			}, 3000);
 		};
 
-		const reloadOrganizations = async () => {
-			const { error } = await getEnrichedOrganizations();
-			if (error) {
-				navigate("/error", { state: { error: t("errors.organizationFetchingFailed") } });
-
-				return;
-			}
-
-			const organizationLoadedFromStore = getOrganizationFromStore(organizationId!);
-			if (!organizationLoadedFromStore) {
-				navigate("/error", { state: { error: t("errors.permissionDenied") } });
-
-				return;
-			}
-		};
 		const getOrganizationFromStore = (organizationId: string): boolean => {
 			const organizationFromStore =
 				organizations && Object.values(organizations).length > 0
@@ -58,15 +43,25 @@ export const SwitchOrganization = () => {
 			return false;
 		};
 
+		const handleOrganizationLoading = async () => {
+			const organizationLoadedFromStore = getOrganizationFromStore(organizationId!);
+			if (!organizationLoadedFromStore) {
+				navigate("/error", { state: { error: t("errors.permissionDenied") } });
+			}
+
+			const { error } = getEnrichedOrganizations();
+			if (error) {
+				navigate("/error", { state: { error: t("errors.organizationFetchingFailed") } });
+				return;
+			}
+		};
+
 		if (organizationId === currentOrganization?.id) {
 			timeoutId = setTimeout(() => {
 				navigate("/");
 			}, 3000);
-		}
-
-		const organizationLoadedFromStore = getOrganizationFromStore(organizationId!);
-		if (!organizationLoadedFromStore) {
-			reloadOrganizations();
+		} else {
+			handleOrganizationLoading();
 		}
 
 		return () => {

--- a/src/components/organisms/sidebar/userMenu.tsx
+++ b/src/components/organisms/sidebar/userMenu.tsx
@@ -24,10 +24,10 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 		logoutFunction,
 		enrichedOrganizations,
 		isLoading,
-		amIadminCurrentOrganization,
 		currentOrganization,
 		user,
 		updateMemberStatus,
+		getCurrentOrganizationEnriched,
 	} = useOrganizationStore();
 	const navigate = useNavigate();
 	const addToast = useToastStore((state) => state.addToast);
@@ -95,10 +95,12 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 		close();
 		navigate(href);
 	};
-	const userMenuOrganizationItems = useMemo(
-		() => getUserMenuOrganizationItems(amIadminCurrentOrganization),
-		[amIadminCurrentOrganization]
-	);
+	const userMenuOrganizationItems = useMemo(() => {
+		const { data: currentOrganization } = getCurrentOrganizationEnriched();
+		if (!currentOrganization?.currentMember) return [];
+		return getUserMenuOrganizationItems(currentOrganization.currentMember.role);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	return (
 		<div className="flex gap-4">

--- a/src/components/organisms/sidebar/userMenu.tsx
+++ b/src/components/organisms/sidebar/userMenu.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import Avatar from "react-avatar";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { usePopoverContext } from "@contexts";
-import { sentryDsn, userMenuItems, userMenuOrganizationItems } from "@src/constants";
+import { getUserMenuOrganizationItems, sentryDsn, userMenuItems } from "@src/constants";
 import { MemberStatusType } from "@src/enums";
 import { ModalName } from "@src/enums/components";
 import { useOrganizationStore, useToastStore, useModalStore } from "@src/store";
@@ -24,10 +24,10 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 		logoutFunction,
 		enrichedOrganizations,
 		isLoading,
+		amIadminCurrentOrganization,
 		currentOrganization,
 		user,
 		updateMemberStatus,
-		amIadminCurrentOrganization,
 	} = useOrganizationStore();
 	const navigate = useNavigate();
 	const addToast = useToastStore((state) => state.addToast);
@@ -95,6 +95,10 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 		close();
 		navigate(href);
 	};
+	const userMenuOrganizationItems = useMemo(
+		() => getUserMenuOrganizationItems(amIadminCurrentOrganization),
+		[amIadminCurrentOrganization]
+	);
 
 	return (
 		<div className="flex gap-4">
@@ -143,23 +147,20 @@ export const UserMenu = ({ openFeedbackForm }: { openFeedbackForm: () => void })
 				</div>
 			</div>
 
-			{amIadminCurrentOrganization ? (
-				<div className="flex w-48 flex-col border-r border-gray-950 pr-4">
-					<h3 className="mb-3 font-semibold text-black">{t("menu.organizationSettings.title")}</h3>
-					{userMenuOrganizationItems.map(({ href, icon: Icon, label }) => (
-						<Button
-							className="w-full rounded-md px-2.5 text-sm hover:bg-gray-250"
-							key={href}
-							onClick={() => menuItemClick(href)}
-							title={label}
-						>
-							<Icon className="size-4" fill="black" />
-							{label}
-						</Button>
-					))}
-				</div>
-			) : null}
-
+			<div className="flex w-48 flex-col border-r border-gray-950 pr-4">
+				<h3 className="mb-3 font-semibold text-black">{t("menu.organizationSettings.title")}</h3>
+				{userMenuOrganizationItems.map(({ href, icon: Icon, label }) => (
+					<Button
+						className="w-full rounded-md px-2.5 text-sm hover:bg-gray-250"
+						key={href}
+						onClick={() => menuItemClick(href)}
+						title={label}
+					>
+						<Icon className="size-4" fill="black" />
+						{label}
+					</Button>
+				))}
+			</div>
 			<div className="flex w-48 flex-col">
 				<h3 className="mb-3 font-semibold text-black">{t("menu.organizationsList.title")}</h3>
 				<Button

--- a/src/components/templates/settingsLayout.tsx
+++ b/src/components/templates/settingsLayout.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 import { Outlet, useLocation } from "react-router-dom";
 
 import { SystemLogLayout } from "./systemLogLayout";
-import { userMenuItems, userMenuOrganizationItems } from "@constants";
+import { getUserMenuOrganizationItems, userMenuItems } from "@constants";
 import { useOrganizationStore } from "@src/store";
 
 import { LogoCatLarge, PageTitle } from "@components/atoms";
@@ -16,7 +16,7 @@ export const SettingsLayout = () => {
 	const { t } = useTranslation("global", { keyPrefix: "pageTitles" });
 	const [pageTitle, setPageTitle] = useState<string>(t("base"));
 	const { pathname } = useLocation();
-	const { currentOrganization } = useOrganizationStore();
+	const { currentOrganization, amIadminCurrentOrganization } = useOrganizationStore();
 	const { user } = useOrganizationStore();
 
 	const getTopbarTitle = () =>
@@ -30,7 +30,10 @@ export const SettingsLayout = () => {
 		setSettingsTitle(getTopbarTitle());
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [user, pathname]);
-
+	const userMenuOrganizationItems = useMemo(
+		() => getUserMenuOrganizationItems(amIadminCurrentOrganization),
+		[amIadminCurrentOrganization]
+	);
 	const menuItems = pathname.startsWith("/settings") ? userMenuItems : userMenuOrganizationItems;
 
 	useEffect(() => {

--- a/src/components/templates/settingsLayout.tsx
+++ b/src/components/templates/settingsLayout.tsx
@@ -16,7 +16,7 @@ export const SettingsLayout = () => {
 	const { t } = useTranslation("global", { keyPrefix: "pageTitles" });
 	const [pageTitle, setPageTitle] = useState<string>(t("base"));
 	const { pathname } = useLocation();
-	const { currentOrganization, amIadminCurrentOrganization } = useOrganizationStore();
+	const { currentOrganization, getCurrentOrganizationEnriched } = useOrganizationStore();
 	const { user } = useOrganizationStore();
 
 	const getTopbarTitle = () =>
@@ -30,10 +30,12 @@ export const SettingsLayout = () => {
 		setSettingsTitle(getTopbarTitle());
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [user, pathname]);
-	const userMenuOrganizationItems = useMemo(
-		() => getUserMenuOrganizationItems(amIadminCurrentOrganization),
-		[amIadminCurrentOrganization]
-	);
+	const userMenuOrganizationItems = useMemo(() => {
+		const { data: currentOrganization } = getCurrentOrganizationEnriched();
+		if (!currentOrganization?.currentMember) return [];
+		return getUserMenuOrganizationItems(currentOrganization.currentMember.role);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 	const menuItems = pathname.startsWith("/settings") ? userMenuItems : userMenuOrganizationItems;
 
 	useEffect(() => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -42,12 +42,7 @@ export { defaultEventsTableRowHeight, maxResultsLimitToDisplay } from "@constant
 export { getSelectDarkStyles, getSelectLightStyles } from "@constants/forms";
 export { defalutFileExtension, monacoLanguages } from "@constants/monacoLanguages.constants.ts";
 export { namespaces } from "@constants/namespaces.logger.constants";
-export {
-	mainNavigationItems,
-	getUserMenuOrganizationItems,
-	userMenuItems,
-	organizationMenuItems,
-} from "@constants/navigation.constants";
+export { mainNavigationItems, getUserMenuOrganizationItems, userMenuItems } from "@constants/navigation.constants";
 export {
 	defaultProjectTab,
 	projectTabs,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -42,7 +42,7 @@ export { defaultEventsTableRowHeight, maxResultsLimitToDisplay } from "@constant
 export { getSelectDarkStyles, getSelectLightStyles } from "@constants/forms";
 export { defalutFileExtension, monacoLanguages } from "@constants/monacoLanguages.constants.ts";
 export { namespaces } from "@constants/namespaces.logger.constants";
-export { mainNavigationItems, userMenuOrganizationItems, userMenuItems } from "@constants/navigation.constants";
+export { mainNavigationItems, getUserMenuOrganizationItems, userMenuItems } from "@constants/navigation.constants";
 export {
 	defaultProjectTab,
 	projectTabs,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -42,7 +42,12 @@ export { defaultEventsTableRowHeight, maxResultsLimitToDisplay } from "@constant
 export { getSelectDarkStyles, getSelectLightStyles } from "@constants/forms";
 export { defalutFileExtension, monacoLanguages } from "@constants/monacoLanguages.constants.ts";
 export { namespaces } from "@constants/namespaces.logger.constants";
-export { mainNavigationItems, getUserMenuOrganizationItems, userMenuItems } from "@constants/navigation.constants";
+export {
+	mainNavigationItems,
+	getUserMenuOrganizationItems,
+	userMenuItems,
+	organizationMenuItems,
+} from "@constants/navigation.constants";
 export {
 	defaultProjectTab,
 	projectTabs,

--- a/src/constants/navigation.constants.ts
+++ b/src/constants/navigation.constants.ts
@@ -27,7 +27,7 @@ export const userMenuItems: NavigationSettingsItem[] = [
 	},
 ];
 
-export const organizationMenuItems: NavigationSettingsItem[] = [
+const organizationMenuItems: NavigationSettingsItem[] = [
 	{
 		icon: GearIcon,
 		href: "/organization-settings",

--- a/src/constants/navigation.constants.ts
+++ b/src/constants/navigation.constants.ts
@@ -27,19 +27,21 @@ export const userMenuItems: NavigationSettingsItem[] = [
 	},
 ];
 
+export const organizationMenuItems: NavigationSettingsItem[] = [
+	{
+		icon: GearIcon,
+		href: "/organization-settings",
+		label: "Settings",
+		stroke: false,
+		allowedRoles: [MemberRole.admin],
+	},
+	{
+		icon: UserIcon,
+		href: "/organization-settings/members",
+		label: "Members",
+		allowedRoles: [MemberRole.admin, MemberRole.user],
+	},
+];
+
 export const getUserMenuOrganizationItems = (role: MemberRole): NavigationSettingsItem[] =>
-	[
-		{
-			icon: GearIcon,
-			href: "/organization-settings",
-			label: "Settings",
-			stroke: false,
-			allowedRoles: [MemberRole.admin],
-		},
-		{
-			icon: UserIcon,
-			href: "/organization-settings/members",
-			label: "Members",
-			allowedRoles: [MemberRole.admin, MemberRole.user],
-		},
-	].filter(({ allowedRoles }) => allowedRoles?.includes(role));
+	organizationMenuItems.filter(({ allowedRoles }) => allowedRoles?.includes(role));

--- a/src/constants/navigation.constants.ts
+++ b/src/constants/navigation.constants.ts
@@ -1,3 +1,4 @@
+import { MemberRole } from "@src/enums";
 import { NavigationSettingsItem } from "@src/interfaces/components";
 
 import {
@@ -26,20 +27,19 @@ export const userMenuItems: NavigationSettingsItem[] = [
 	},
 ];
 
-export const getUserMenuOrganizationItems = (amIadminCurrentOrganization: boolean): NavigationSettingsItem[] => [
-	...(amIadminCurrentOrganization
-		? [
-				{
-					icon: GearIcon,
-					href: "/organization-settings",
-					label: "Settings",
-					stroke: false,
-				},
-			]
-		: []),
-	{
-		icon: UserIcon,
-		href: "/organization-settings/members",
-		label: "Members",
-	},
-];
+export const getUserMenuOrganizationItems = (role: MemberRole): NavigationSettingsItem[] =>
+	[
+		{
+			icon: GearIcon,
+			href: "/organization-settings",
+			label: "Settings",
+			stroke: false,
+			allowedRoles: [MemberRole.admin],
+		},
+		{
+			icon: UserIcon,
+			href: "/organization-settings/members",
+			label: "Members",
+			allowedRoles: [MemberRole.admin, MemberRole.user],
+		},
+	].filter(({ allowedRoles }) => allowedRoles?.includes(role));

--- a/src/constants/navigation.constants.ts
+++ b/src/constants/navigation.constants.ts
@@ -26,13 +26,17 @@ export const userMenuItems: NavigationSettingsItem[] = [
 	},
 ];
 
-export const userMenuOrganizationItems: NavigationSettingsItem[] = [
-	{
-		icon: GearIcon,
-		href: "/organization-settings",
-		label: "Settings",
-		stroke: false,
-	},
+export const getUserMenuOrganizationItems = (amIadminCurrentOrganization: boolean): NavigationSettingsItem[] => [
+	...(amIadminCurrentOrganization
+		? [
+				{
+					icon: GearIcon,
+					href: "/organization-settings",
+					label: "Settings",
+					stroke: false,
+				},
+			]
+		: []),
 	{
 		icon: UserIcon,
 		href: "/organization-settings/members",

--- a/src/interfaces/components/menu.interface.ts
+++ b/src/interfaces/components/menu.interface.ts
@@ -1,5 +1,7 @@
 import { FunctionComponent, SVGProps } from "react";
 
+import { MemberRole } from "@src/enums";
+
 export interface MenuProps {
 	className?: string;
 	isOpen: boolean;
@@ -10,4 +12,5 @@ export interface NavigationSettingsItem {
 	label: string;
 	href: string;
 	stroke?: boolean;
+	allowedRoles?: MemberRole[];
 }


### PR DESCRIPTION
## Description
For not-admin users, display the Organization Settings column without the , only Members, and display the same members' table as the regular admin without add.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1411/allow-users-not-admins-see-the-members-list-in-an-organization
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
