### PR TITLE
refactor(UI-1283): refactor button 'ok' minimum width in modals

### DIFF
--- a/src/components/organisms/activeDeploymentWarningModal.tsx
+++ b/src/components/organisms/activeDeploymentWarningModal.tsx
@@ -42,7 +42,7 @@ export const ActiveDeploymentWarningModal = ({
 
 				<Button
 					ariaLabel={t("agreeButton")}
-					className="bg-gray-1100 px-4 py-3 font-semibold"
+					className="min-w-20 justify-center bg-gray-1100 px-4 py-3 font-semibold"
 					onClick={onOkClick}
 					variant="filled"
 				>

--- a/src/components/organisms/connections/deleteModal.tsx
+++ b/src/components/organisms/connections/deleteModal.tsx
@@ -63,7 +63,7 @@ export const DeleteConnectionModal = ({ id, isDeleting, onDelete }: DeleteModalP
 
 				<Button
 					ariaLabel={t("deleteButton")}
-					className="bg-gray-1100 px-4 py-3 font-semibold hover:text-error"
+					className="min-w-20 justify-center bg-gray-1100 px-4 py-3 font-semibold hover:text-error"
 					disabled={isDeleting}
 					onClick={onDelete}
 					variant="filled"

--- a/src/components/organisms/modals/deleteDrainingDeploymentProjectModal.tsx
+++ b/src/components/organisms/modals/deleteDrainingDeploymentProjectModal.tsx
@@ -23,7 +23,7 @@ export const DeleteDrainingDeploymentProjectModal = () => {
 			<div className="mt-8 flex w-full justify-end gap-2">
 				<Button
 					ariaLabel={t("okButton")}
-					className="px-4 py-3 font-semibold hover:bg-gray-1100 hover:text-white"
+					className="min-w-20 justify-center px-4 py-3 font-semibold hover:bg-gray-1100 hover:text-white"
 					onClick={() => closeModal(ModalName.deleteWithDrainingDeploymentProject)}
 					variant="outline"
 				>

--- a/src/components/organisms/modals/deleteProjectModal.tsx
+++ b/src/components/organisms/modals/deleteProjectModal.tsx
@@ -39,7 +39,7 @@ export const DeleteProjectModal = ({ isDeleting, onDelete }: DeleteModalProps) =
 
 				<Button
 					ariaLabel={t("okButton")}
-					className="bg-gray-1100 px-4 py-3 font-semibold hover:text-error"
+					className="min-w-20 justify-center bg-gray-1100 px-4 py-3 font-semibold hover:text-error"
 					disabled={isDeleting}
 					onClick={onDelete}
 					variant="filled"


### PR DESCRIPTION
## Description
Change min modal button (ok) width
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1283/min-modal-button-ok-width
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
