### PR TITLE
feat(UI-1310): add project export functionality with modal and download option

### DIFF
--- a/src/components/organisms/topbar/project/buttons.tsx
+++ b/src/components/organisms/topbar/project/buttons.tsx
@@ -4,6 +4,7 @@ import { debounce } from "lodash";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { ProjectExportModal } from "./projectExportModal";
 import { ModalName, TopbarButton } from "@enums/components";
 import { LoggerService, ProjectsService } from "@services";
 import { namespaces } from "@src/constants";
@@ -31,7 +32,7 @@ export const ProjectTopbarButtons = () => {
 	const { fetchManualRunConfiguration } = useManualRunStore();
 	const projectValidationErrors = Object.values(projectValidationState).filter((error) => error.message !== "");
 	const projectErrors = isValid ? "" : Object.values(projectValidationErrors).join(", ");
-	const { deleteProject, downloadProjectExport, deactivateDeployment, isDeleting, isExporting } = useProjectActions();
+	const { deleteProject, deactivateDeployment, isDeleting, isExporting } = useProjectActions();
 	const navigate = useNavigate();
 	const addToast = useToastStore((state) => state.addToast);
 	const [loadingButton, setLoadingButton] = useState<Record<string, boolean>>({});
@@ -232,7 +233,7 @@ export const ProjectTopbarButtons = () => {
 						<Button
 							ariaLabel={t("topbar.buttons.export")}
 							className="group h-8 px-4 text-white"
-							onClick={() => downloadProjectExport(projectId!)}
+							onClick={() => openModal(ModalName.projectExport)}
 							variant="outline"
 						>
 							{isExporting ? (
@@ -288,6 +289,7 @@ export const ProjectTopbarButtons = () => {
 			<DeleteDrainingDeploymentProjectModal />
 			<DeleteActiveDeploymentProjectModal isDeleting={isDeleting} onDelete={handleProjectDelete} />
 			<DeleteProjectModal isDeleting={isDeleting} onDelete={handleProjectDelete} />
+			<ProjectExportModal />
 		</div>
 	);
 };

--- a/src/components/organisms/topbar/project/projectExportModal.tsx
+++ b/src/components/organisms/topbar/project/projectExportModal.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useEffect } from "react";
+
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+
+import { ModalName } from "@enums/components";
+import { useProjectActions } from "@src/hooks";
+import { useModalStore, useToastStore, useProjectStore } from "@src/store";
+
+import { Button, ErrorMessage, Input, Loader } from "@components/atoms";
+import { Modal } from "@components/molecules";
+
+export const ProjectExportModal = () => {
+	const { t } = useTranslation("modals", { keyPrefix: "projectExport" });
+	const [isExporting, setIsExporting] = useState(false);
+	const [currentProjectName, setCurrentProjectName] = useState<string>();
+	const { downloadProjectExport } = useProjectActions();
+	const { getProject } = useProjectStore();
+	const { closeModal } = useModalStore();
+	const { projectId } = useParams();
+	const addToast = useToastStore((state) => state.addToast);
+
+	const {
+		formState: { errors },
+		handleSubmit,
+		register,
+		setValue,
+		watch,
+	} = useForm<{ projectName: string }>({
+		mode: "onChange",
+		defaultValues: {
+			projectName: "",
+		},
+	});
+
+	useEffect(() => {
+		const fetchProject = async () => {
+			if (!projectId) return;
+			const { data: project, error: getProjectError } = await getProject(projectId);
+
+			if (getProjectError) {
+				addToast({
+					message: t("errorGetProject"),
+					type: "error",
+				});
+				return;
+			}
+			setCurrentProjectName(project?.name);
+			setValue("projectName", project?.name || "");
+		};
+
+		fetchProject();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [projectId]);
+
+	const onSubmit = async (data: { projectName: string }) => {
+		setIsExporting(true);
+		const { projectName } = data;
+
+		const { error } = await downloadProjectExport(projectId!, projectName);
+		if (error) {
+			addToast({
+				message: t("errorExportingProject"),
+				type: "error",
+			});
+		}
+		if (!error) {
+			addToast({
+				message: t("successfullyExported"),
+				type: "success",
+			});
+		}
+		setIsExporting(false);
+		closeModal(ModalName.projectExport);
+	};
+
+	return (
+		<Modal hideCloseButton name={ModalName.projectExport}>
+			<form onSubmit={handleSubmit(onSubmit)}>
+				<div className="mx-6">
+					<h3 className="mb-5 text-xl font-bold">{t("title", { name: currentProjectName })}</h3>
+
+					<Input
+						label={t("renameProjectForExport")}
+						value={watch("projectName")}
+						variant="light"
+						{...register("projectName", {
+							required: t("nameRequired"),
+							validate: (value) => value.trim().length > 0 || t("nameRequired"),
+						})}
+						isError={!!errors.projectName}
+					/>
+					{errors.projectName ? (
+						<ErrorMessage className="relative mt-0.5">{errors.projectName.message}</ErrorMessage>
+					) : null}
+				</div>
+
+				<div className="mt-8 flex w-full justify-end gap-2">
+					<Button
+						ariaLabel={t("cancelButton")}
+						className="px-4 py-3 font-semibold hover:bg-gray-1100 hover:text-white"
+						disabled={isExporting}
+						onClick={() => closeModal(ModalName.projectExport)}
+						variant="outline"
+					>
+						{t("cancelButton")}
+					</Button>
+
+					<Button
+						ariaLabel={t("exportButton")}
+						className="bg-gray-1100 px-4 py-3 font-semibold"
+						disabled={isExporting}
+						variant="filled"
+					>
+						{isExporting ? <Loader size="sm" /> : null}
+						{t("exportButton")}
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+};

--- a/src/enums/components/modal.enum.ts
+++ b/src/enums/components/modal.enum.ts
@@ -21,4 +21,5 @@ export enum ModalName {
 	organizationMemberCreate = "organizationMemberCreate",
 	deleteOrganization = "deleteOrganization",
 	invitedUser = "invitedUser",
+	projectExport = "projectExport",
 }

--- a/src/hooks/useProjectActions.tsx
+++ b/src/hooks/useProjectActions.tsx
@@ -22,7 +22,6 @@ export const useProjectActions = () => {
 		createProjectFromManifest,
 		deleteProject: removeProject,
 		exportProject,
-		getProject,
 		getProjectsList,
 		pendingFile,
 		projectsList,
@@ -187,47 +186,23 @@ export const useProjectActions = () => {
 		}
 	};
 
-	const downloadProjectExport = async (projectId: string) => {
+	const downloadProjectExport = async (projectId: string, projectName: string) => {
 		setIsExporting(true);
 
 		const { data: akProjectArchiveZip, error: exportError } = await exportProject(projectId);
 
 		if (exportError) {
-			addToast({
-				message: t("errorExportingProject"),
-				type: "error",
-			});
 			setIsExporting(false);
 
-			return null;
+			return { error: exportError };
 		}
 
 		const blob = new Blob([akProjectArchiveZip!], { type: "application/zip" });
 		const url = URL.createObjectURL(blob);
 
-		const { data: project, error: getProjectError } = await getProject(projectId!);
-
-		if (getProjectError) {
-			return { error: getProjectError };
-		}
-
-		const now = new Date();
-		const dateTime = now
-			.toLocaleString("en-GB", {
-				day: "2-digit",
-				month: "2-digit",
-				year: "numeric",
-				hour: "2-digit",
-				minute: "2-digit",
-				hour12: false,
-			})
-			.replace(/[/:]/g, "")
-			.replace(", ", "-");
-
-		const fileName = `ak-${project?.name}-${dateTime}-archive.zip`;
 		const link = Object.assign(document.createElement("a"), {
 			href: url,
-			download: fileName,
+			download: `${projectName}.zip`,
 		});
 
 		document.body.appendChild(link);
@@ -235,6 +210,8 @@ export const useProjectActions = () => {
 		document.body.removeChild(link);
 		URL.revokeObjectURL(url);
 		setIsExporting(false);
+
+		return { error: false };
 	};
 
 	const deleteProject = async (projectId: string) => {

--- a/src/locales/en/dashboard/translation.json
+++ b/src/locales/en/dashboard/translation.json
@@ -24,7 +24,6 @@
 		"projectManifestNotFoundInArchive": "Project manifest not found in the archive",
 		"projectManifestNotFoundInArchiveExtended": "Project manifest not found in the archive: {{archiveName}}",
 		"projectManifestExtractionFailedExtended": "Project manifest extraction failed, error: {{error}}",
-		"errorExportingProject": "Failed to export project",
 		"deleteProjectSuccessExtended": "Project deletion completed successfully, project name: {{projectName}}, project ID: {{projectId}}"
 	},
 	"templates": {

--- a/src/locales/en/modals/translation.json
+++ b/src/locales/en/modals/translation.json
@@ -122,5 +122,15 @@
 		"noReadmeAvailable": "No README available",
 		"failedReadmeFetch": "Failed to load README",
 		"projectCreationFailed": "Project creation failed"
+	},
+	"projectExport": {
+		"title": "Export project: {{name}}",
+		"renameProjectForExport": "Rename project for export",
+		"cancelButton": "Cancel",
+		"exportButton": "Export",
+		"nameRequired": "Name is required",
+		"errorExportingProject": "Failed to export project",
+		"successfullyExported": "Project exported successfully",
+		"errorGetProject": "Failed to get project"
 	}
 }


### PR DESCRIPTION
## Description
Add modal for rename file and export project to PC
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1310/duplicate-project
## What type of PR is this? (check all applicable)

- [x] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
