### PR TITLE
feat(UI-1394): enhance toast component with customizable position, offset, and styles

### DIFF
--- a/src/components/molecules/toast.tsx
+++ b/src/components/molecules/toast.tsx
@@ -21,11 +21,23 @@ export const Toast = () => {
 	const [hoveredToasts, setHoveredToasts] = useState<{ [id: string]: boolean }>({});
 
 	const updateToastPositions = () => {
-		let currentBottom = 26;
-		toastRefs.current.forEach((ref) => {
-			if (ref) {
-				ref.style.bottom = `${currentBottom}px`;
-				currentBottom += ref.offsetHeight + 8;
+		let topPosition = 15;
+		let bottomPosition = 15;
+
+		toastRefs.current.forEach((ref, index) => {
+			if (!ref) return;
+
+			const { position, offset = 20 } = toasts[index];
+			const spacing = ref.offsetHeight + 8;
+
+			if (position === "top-right") {
+				ref.style.top = `${topPosition + offset}px`;
+				ref.style.bottom = "";
+				topPosition += spacing;
+			} else {
+				ref.style.bottom = `${bottomPosition + offset}px`;
+				ref.style.top = "";
+				bottomPosition += spacing;
 			}
 		});
 	};
@@ -70,13 +82,17 @@ export const Toast = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [toasts]);
 
-	const baseStyle = (toastType: ToasterTypes, isHovered: boolean) =>
-		cn("fixed right-20 z-50 max-w-420 rounded-4xl border px-4 py-3 pl-6 transition-colors duration-200", {
-			"bg-black": !isHovered,
-			"bg-gray-1250": isHovered,
-			"border-error": toastType === "error",
-			"border-green-800": toastType === "success",
-		});
+	const baseStyle = (toastType: ToasterTypes, isHovered: boolean, customClassName: string) =>
+		cn(
+			"fixed z-50 max-w-420 rounded-4xl border px-4 py-3 pl-6 transition-colors duration-200",
+			{
+				"bg-black": !isHovered,
+				"bg-gray-1250": isHovered,
+				"border-error": toastType === "error",
+				"border-green-800": toastType === "success",
+			},
+			customClassName
+		);
 
 	const titleStyle = (toastType: ToasterTypes) =>
 		cn("w-full font-semibold", {
@@ -84,59 +100,86 @@ export const Toast = () => {
 			"text-green-800": toastType === "success",
 		});
 
+	const positionStyle = (position: string, offset: number) => {
+		if (position === "top-right") {
+			return { top: offset, right: 20 };
+		}
+		return { bottom: offset, right: 20 };
+	};
+
 	const variants = {
 		hidden: { opacity: 0, y: 50 },
 		visible: { opacity: 1, y: 0 },
 	};
 
 	const renderToasts = () =>
-		toasts.map(({ id, message, type, hideSystemLogLinkOnError }, index) => {
-			const title = t(`titles.${type}`);
+		toasts.map(
+			(
+				{
+					id,
+					message,
+					type,
+					hideSystemLogLinkOnError,
+					position = "default",
+					offset = 0,
+					className = "",
+					hiddenCloseButton,
+					customTitle,
+				},
+				index
+			) => {
+				const title = t(`titles.${type}`);
 
-			return (
-				<AnimatePresence key={id}>
-					<motion.div
-						animate="visible"
-						className={baseStyle(type, hoveredToasts[id])}
-						exit="hidden"
-						initial="hidden"
-						key={id}
-						onMouseEnter={() => handleMouseEnter(id)}
-						onMouseLeave={() => handleMouseLeave(id)}
-						ref={(element) => {
-							toastRefs.current[index] = element;
-						}}
-						transition={{ duration: 0.3 }}
-						variants={variants}
-					>
-						<div className="flex gap-2.5" role="alert" title={title}>
-							<div className="text-white">
-								<p className={titleStyle(type)}>{title}</p>
+				return (
+					<AnimatePresence key={id}>
+						<motion.div
+							animate="visible"
+							className={baseStyle(type, hoveredToasts[id], className)}
+							exit="hidden"
+							initial="hidden"
+							key={id}
+							onMouseEnter={() => handleMouseEnter(id)}
+							onMouseLeave={() => handleMouseLeave(id)}
+							ref={(element) => {
+								toastRefs.current[index] = element;
+							}}
+							style={positionStyle(position, offset)}
+							transition={{ duration: 0.3 }}
+							variants={variants}
+						>
+							<div className="flex gap-2.5" role="alert" title={title}>
+								<div className="text-white">
+									{customTitle ? customTitle : <p className={titleStyle(type)}>{title}</p>}
 
-								{message}
+									{message}
 
-								{type === "error" && !hideSystemLogLinkOnError ? (
-									<Button
-										className="cursor-pointer gap-1.5 p-0 font-medium text-error underline"
-										onClick={() => setSystemLogHeight(systemLogHeight > 0 ? systemLogHeight : 20)}
+									{type === "error" && !hideSystemLogLinkOnError ? (
+										<Button
+											className="cursor-pointer gap-1.5 p-0 font-medium text-error underline"
+											onClick={() =>
+												setSystemLogHeight(systemLogHeight > 0 ? systemLogHeight : 20)
+											}
+										>
+											{t("showMore")}
+											<ExternalLinkIcon className="size-3.5 fill-error duration-200" />
+										</Button>
+									) : null}
+								</div>
+
+								{hiddenCloseButton ? null : (
+									<IconButton
+										className="group ml-auto h-default-icon w-default-icon bg-gray-1050 p-0"
+										onClick={() => removeToast(id)}
 									>
-										{t("showMore")}
-										<ExternalLinkIcon className="size-3.5 fill-error duration-200" />
-									</Button>
-								) : null}
+										<Close className="size-3 fill-white transition" />
+									</IconButton>
+								)}
 							</div>
-
-							<IconButton
-								className="group ml-auto h-default-icon w-default-icon bg-gray-1050 p-0"
-								onClick={() => removeToast(id)}
-							>
-								<Close className="size-3 fill-white transition" />
-							</IconButton>
-						</div>
-					</motion.div>
-				</AnimatePresence>
-			);
-		});
+						</motion.div>
+					</AnimatePresence>
+				);
+			}
+		);
 
 	return toasts.length ? renderToasts() : null;
 };

--- a/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunButtons.tsx
@@ -62,6 +62,11 @@ export const ManualRunButtons = () => {
 					/>
 				),
 				type: "success",
+				position: "top-right",
+				offset: 35,
+				hiddenCloseButton: true,
+				className: "rounded-3xl p-0 border-2",
+				customTitle: " ",
 			});
 			setTimeout(() => {
 				fetchDeployments(projectId, true);

--- a/src/components/organisms/topbar/project/manualRun/manualRunSuccessToastMessage.tsx
+++ b/src/components/organisms/topbar/project/manualRun/manualRunSuccessToastMessage.tsx
@@ -20,15 +20,17 @@ export const ManualRunSuccessToastMessage = ({
 	const navigate = useNavigate();
 
 	return (
-		<>
-			{t("executionSucceed")}
-			<Button
-				className="flex cursor-pointer items-center gap-1 p-0 text-green-800"
-				onClick={() => navigate(`/projects/${projectId}/deployments/${deploymentId}/sessions/${sessionId}`)}
-			>
-				{t("showMore")}
-				<ExternalLinkIcon className="size-3.5 fill-green-800 duration-200" />
-			</Button>
-		</>
+		<button
+			aria-label={t("executionSucceed")}
+			className="cursor-pointer p-4"
+			onClick={() => navigate(`/projects/${projectId}/deployments/${deploymentId}/sessions/${sessionId}`)}
+		>
+			<div className="flex flex-col">
+				<span className="font-semibold text-green-800">{t("executionSucceed")}</span>
+				<Button className="flex items-center gap-1 p-0 text-green-800 underline">
+					{t("showMore")} <ExternalLinkIcon className="size-3 animate-bounce fill-green-800" />
+				</Button>
+			</div>
+		</button>
 	);
 };

--- a/src/interfaces/components/toast.interface.ts
+++ b/src/interfaces/components/toast.interface.ts
@@ -3,6 +3,11 @@ export interface Toast {
 	message: React.ReactNode;
 	type: ToasterTypes;
 	hideSystemLogLinkOnError?: boolean;
+	position?: "top-right" | "default";
+	offset?: number;
+	className?: string;
+	hiddenCloseButton?: boolean;
+	customTitle?: React.ReactNode | string;
 }
 
 export type ToasterTypes = "error" | "info" | "success";

--- a/src/store/useToastStore.ts
+++ b/src/store/useToastStore.ts
@@ -9,7 +9,16 @@ export const useToastStore = create<ToastStore>(
 			const id = Date.now().toString();
 
 			return set((state) => ({
-				toasts: [...state.toasts, { ...toast, id }],
+				toasts: [
+					...state.toasts,
+					{
+						...toast,
+						id,
+						position: toast.position,
+						offset: toast.offset,
+						className: toast.className,
+					},
+				],
 			}));
 		},
 		removeToast: (id) =>


### PR DESCRIPTION
## Description
It can be similar to the toast we have today - it should be simple, easily clickable to allow the user to open the session he just ran.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1394/add-toast-with-the-session-link-under-the-run-button-after-manual-run
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
