### PR TITLE
fix(UI-1465): adjust scrolling in profile page

### DIFF
--- a/src/components/organisms/settings/user/profile.tsx
+++ b/src/components/organisms/settings/user/profile.tsx
@@ -143,7 +143,7 @@ export const Profile = () => {
 				</Button>
 			</div>
 			<div className="h-full" />
-			<div className="mb-1 flex items-end text-xs text-white">Version: v{version}</div>
+			<div className="mb-2 mt-5 flex items-end text-xs text-white">Version: v{version}</div>
 			<DeleteAccountModal onDelete={onDeleteAccount} />
 		</div>
 	);

--- a/src/components/templates/settingsLayout.tsx
+++ b/src/components/templates/settingsLayout.tsx
@@ -48,7 +48,7 @@ export const SettingsLayout = () => {
 				<div className="flex size-full">
 					<Sidebar />
 					<SystemLogLayout>
-						<div className="flex flex-1 flex-col">
+						<div className="flex h-full flex-1 flex-col">
 							<TitleTopbar title={settingsTitle} />
 
 							<div className="relative flex size-full overflow-hidden pt-2">


### PR DESCRIPTION
## Description
User can't see full profile page because there's no scrolling - fix it
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1465/user-cant-see-full-profile-page-because-theres-no-scrolling
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
