### PR TITLE
feat(UI-1475): add app name field to OAuth private form and validation schema

### DIFF
--- a/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
@@ -44,6 +44,18 @@ export const OauthPrivateForm = ({
 		<>
 			<div className="relative">
 				<Input
+					{...register("app_id")}
+					aria-label={t("github.placeholders.appId")}
+					disabled={isLoading}
+					isError={!!errors.app_id}
+					isRequired
+					label={t("github.placeholders.appId")}
+					value={appId}
+				/>
+				<ErrorMessage>{errors.app_id?.message as string}</ErrorMessage>
+			</div>
+			<div className="relative">
+				<Input
 					{...register("client_id")}
 					aria-label={t("github.placeholders.clientId")}
 					disabled={isLoading}
@@ -83,18 +95,6 @@ export const OauthPrivateForm = ({
 					/>
 				)}
 				<ErrorMessage>{errors.client_secret?.message as string}</ErrorMessage>
-			</div>
-			<div className="relative">
-				<Input
-					{...register("app_id")}
-					aria-label={t("github.placeholders.appId")}
-					disabled={isLoading}
-					isError={!!errors.app_id}
-					isRequired
-					label={t("github.placeholders.appId")}
-					value={appId}
-				/>
-				<ErrorMessage>{errors.app_id?.message as string}</ErrorMessage>
 			</div>
 			<div className="relative">
 				<Input

--- a/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
+++ b/src/components/organisms/connections/integrations/github/authMethods/oauthPrivate.tsx
@@ -36,6 +36,7 @@ export const OauthPrivateForm = ({
 	const webhookSecret = useWatch({ control, name: "webhook_secret" });
 	const enterpriseUrl = useWatch({ control, name: "enterprise_url" });
 	const privateKey = useWatch({ control, name: "private_key" });
+	const appName = useWatch({ control, name: "app_name" });
 
 	const isEditMode = mode === "edit";
 
@@ -94,6 +95,18 @@ export const OauthPrivateForm = ({
 					value={appId}
 				/>
 				<ErrorMessage>{errors.app_id?.message as string}</ErrorMessage>
+			</div>
+			<div className="relative">
+				<Input
+					{...register("app_name")}
+					aria-label={t("github.placeholders.appName")}
+					disabled={isLoading}
+					isError={!!errors.app_name}
+					isRequired
+					label={t("github.placeholders.appName")}
+					value={appName}
+				/>
+				<ErrorMessage>{errors.app_name?.message as string}</ErrorMessage>
 			</div>
 			{isEditMode ? (
 				<SecretInput

--- a/src/constants/connections/integrationVariablesMapping.constants.ts
+++ b/src/constants/connections/integrationVariablesMapping.constants.ts
@@ -10,6 +10,7 @@ export const integrationVariablesMapping = {
 		app_id: "app_id",
 		enterprise_url: "enterprise_url",
 		private_key: "private_key",
+		app_name: "app_name",
 	},
 	[Integrations.auth0]: {
 		client_id: "client_id",

--- a/src/constants/connections/integrationsDataKeys.constants.ts
+++ b/src/constants/connections/integrationsDataKeys.constants.ts
@@ -1,7 +1,7 @@
 export const integrationDataKeys = {
 	auth0: ["cid", "client_id", "client_secret", "auth0_domain"],
 	google: ["auth_scopes", "cal_id", "form_id"],
-	github: ["client_id", "client_secret", "app_id", "webhook_secret", "enterprise_url", "private_key"],
+	github: ["client_id", "client_secret", "app_id", "webhook_secret", "enterprise_url", "private_key", "app_name"],
 	slack: ["client_id", "client_secret", "signing_secret"],
 	height: ["client_id", "client_secret", "api_key"],
 	linear: ["client_id", "client_secret", "webhook_secret", "api_key"],

--- a/src/locales/en/integrations/translation.json
+++ b/src/locales/en/integrations/translation.json
@@ -58,6 +58,7 @@
 			"clientId": "Client ID",
 			"clientSecret": "Client Secret",
 			"appId": "App ID",
+			"appName": "App Name",
 			"webhookSercet": "Webhook Secret",
 			"enterpriseUrl": "Enterprise URL",
 			"privateKey": "Private Key"

--- a/src/validations/connection.schema.ts
+++ b/src/validations/connection.schema.ts
@@ -13,6 +13,7 @@ export const githubPrivateAuthIntegrationSchema = z.object({
 	client_id: z.string().min(1, "Client ID is required"),
 	client_secret: z.string().min(1, "Client Secret is required"),
 	app_id: z.string().min(1, "App ID is required"),
+	app_name: z.string().min(1, "App Name is required"),
 	webhook_secret: z.string(),
 	private_key: z.string().min(1, "Private Key is required"),
 });


### PR DESCRIPTION
## Description
Add a new input field for App Name in the GitHub private OAuth connection form.

Use app_name as the key to match the backend variable name.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1475/add-app-name-field-in-github-private-connection
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
