### PR TITLE
fix(UI-1483): reset connection checker on error in status check

### DIFF
--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -105,7 +105,7 @@ export const ConnectionsTable = () => {
 			return;
 		}
 		setConnectionId(undefined);
-		resetChecker();
+		resetChecker(true);
 
 		const connection = connections?.find((connection) => connection.connectionId === connectionId);
 

--- a/src/hooks/useProjectActions.tsx
+++ b/src/hooks/useProjectActions.tsx
@@ -253,7 +253,7 @@ export const useProjectActions = () => {
 			return { error };
 		}
 
-		resetChecker();
+		resetChecker(true);
 
 		const projectName = projectsList.find(({ id }) => id === projectId)?.name;
 		LoggerService.info(namespaces.projectUI, t("deleteProjectSuccessExtended", { projectId, projectName }));

--- a/src/interfaces/store/connectionStore.interface.ts
+++ b/src/interfaces/store/connectionStore.interface.ts
@@ -5,7 +5,7 @@ export interface ConnectionStore {
 	retries: number;
 	connectionInProgress: boolean;
 	incrementRetries: () => void;
-	resetChecker: () => void;
+	resetChecker: (force?: boolean) => void;
 	recheckIntervalIds: NodeJS.Timeout[];
 	startCheckingStatus: (connectionId: string) => void;
 	avoidNextRerenderCleanup: boolean;

--- a/src/store/useConnectionStore.ts
+++ b/src/store/useConnectionStore.ts
@@ -97,7 +97,7 @@ const store: StateCreator<ConnectionStore> = (set, get) => ({
 					});
 
 					LoggerService.error(namespaces.stores.connectionCheckerStore, logeExtended);
-
+					resetChecker();
 					return;
 				}
 

--- a/src/store/useConnectionStore.ts
+++ b/src/store/useConnectionStore.ts
@@ -34,10 +34,10 @@ const store: StateCreator<ConnectionStore> = (set, get) => ({
 		});
 	},
 
-	resetChecker: () => {
+	resetChecker: (force) => {
 		const { avoidNextRerenderCleanup, recheckIntervalIds } = get();
 
-		if (avoidNextRerenderCleanup) {
+		if (avoidNextRerenderCleanup && !force) {
 			set((state) => {
 				state.avoidNextRerenderCleanup = false;
 
@@ -97,7 +97,6 @@ const store: StateCreator<ConnectionStore> = (set, get) => ({
 					});
 
 					LoggerService.error(namespaces.stores.connectionCheckerStore, logeExtended);
-					resetChecker();
 					return;
 				}
 


### PR DESCRIPTION
## Description
Description:

after creating an unsuccessful connection and deleting it we receive an error in the system logs.

Steps to reproduce: 
create a slack an unsuccessful private OAuth connection (use random values for the credentials), and save it 
delete it 

Current behavior: 
we get the errors mentioned above until we refresh.

Expected behavior:
don't receive any errors after deleting the connection.
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1483/receive-error-after-deleting-an-unsuccessful-connection
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
