### PR TITLE
feat(UI-1534): limit activites loading in first time

### DIFF
--- a/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
@@ -79,7 +79,7 @@ export const ActivityList = () => {
 	);
 
 	return (
-		<Frame className="pb-0 mr-3 transition rounded-b-none size-full md:py-0">
+		<Frame className="mr-3 size-full rounded-b-none pb-0 transition md:py-0">
 			{selectedActivity ? (
 				<SingleActivityInfo activity={selectedActivity} setActivity={setSelectedActivity} />
 			) : null}
@@ -116,7 +116,7 @@ export const ActivityList = () => {
 			</AutoSizer>
 
 			{!activities.length ? (
-				<div className="flex items-center justify-center h-full py-5 text-xl font-semibold">
+				<div className="flex h-full items-center justify-center py-5 text-xl font-semibold">
 					{t("noActivitiesFound")}
 				</div>
 			) : null}

--- a/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/infiniteList.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 import { AutoSizer, InfiniteLoader, List, ListRowProps } from "react-virtualized";
 
 import { defaultSessionsActivitiesPageSize } from "@src/constants";
@@ -16,9 +15,7 @@ import { ActivityRow, SingleActivityInfo } from "@components/organisms/deploymen
 export const ActivityList = () => {
 	const { t } = useTranslation("deployments", { keyPrefix: "sessions.viewer" });
 	const [selectedActivity, setSelectedActivity] = useState<SessionActivity>();
-	const { sessionId } = useParams();
 	const [rowHeight, setRowHeight] = useState(60);
-	const loadedPagesRef = useRef(0);
 
 	const {
 		isRowLoaded,
@@ -27,19 +24,6 @@ export const ActivityList = () => {
 		loadMoreRows,
 		nextPageToken,
 	} = useVirtualizedList<SessionActivity>(SessionLogType.Activity, defaultSessionsActivitiesPageSize);
-
-	const loadNextPage = useCallback(async () => {
-		if (loadedPagesRef.current >= 5) return;
-		await loadMoreRows();
-		loadedPagesRef.current += 1;
-	}, [loadMoreRows]);
-
-	useEffect(() => {
-		if (!sessionId || !nextPageToken) return;
-
-		loadNextPage();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [sessionId, nextPageToken]);
 
 	useEffect(() => {
 		const handleResize = () => {

--- a/src/hooks/useVirtualizedList.tsx
+++ b/src/hooks/useVirtualizedList.tsx
@@ -21,7 +21,7 @@ export function useVirtualizedList<T extends SessionOutputLog | SessionActivity>
 	const { t } = useTranslation("deployments", { keyPrefix: "sessions.viewer" });
 	const frameRef = useRef<HTMLDivElement>(null);
 	const addToast = useToastStore((state) => state.addToast);
-
+	const loadingRef = useRef(false);
 	const outputsCacheStore = useOutputsCacheStore();
 	const activitiesCacheStore = useActivitiesCacheStore();
 
@@ -77,11 +77,16 @@ export function useVirtualizedList<T extends SessionOutputLog | SessionActivity>
 	};
 
 	const loadMoreRows = async () => {
-		if (!sessionId || !shouldLoadMore) {
+		if (!sessionId || !shouldLoadMore || loadingRef.current) {
 			return;
 		}
 
-		fetchLogs(sessionId, pageSize);
+		loadingRef.current = true;
+		try {
+			await fetchLogs(sessionId, pageSize);
+		} finally {
+			loadingRef.current = false;
+		}
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
## Description
Session opened - load 5 requests each request 50
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1534/load-all-activites-refactor
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
