### PR TITLE
feat(UI-1578): enhance welcome message to include organization name

### DIFF
--- a/src/components/organisms/topbar/dashboard.tsx
+++ b/src/components/organisms/topbar/dashboard.tsx
@@ -6,7 +6,7 @@ import { featureFlags } from "@src/constants";
 import { EventListenerName } from "@src/enums";
 import { ModalName } from "@src/enums/components";
 import { triggerEvent, useProjectActions } from "@src/hooks";
-import { useModalStore } from "@src/store";
+import { useModalStore, useOrganizationStore } from "@src/store";
 
 import { Button, IconSvg, Typography } from "@components/atoms";
 import { ImportProjectModal } from "@components/organisms";
@@ -17,6 +17,7 @@ import MagicAiIcon from "@assets/image/icons/ai";
 export const DashboardTopbar = () => {
 	const { t } = useTranslation("dashboard", { keyPrefix: "topbar" });
 	const { fileInputRef, handleImportFile, loadingImportFile } = useProjectActions();
+	const { currentOrganization } = useOrganizationStore();
 	const { openModal } = useModalStore();
 
 	const triggerFileInput = () => {
@@ -30,7 +31,7 @@ export const DashboardTopbar = () => {
 					className="mb-8 w-full text-center font-averta text-2xl font-semibold md:mb-0 md:text-left md:text-2xl"
 					element="h1"
 				>
-					{t("welcome")}
+					{t("welcome", { organization: currentOrganization?.displayName || t("autoKitteh") })}
 				</Typography>
 
 				<div className="relative hidden h-8 gap-1.5 self-center rounded-3xl border border-gray-750 p-1 transition hover:border-white md:flex">

--- a/src/locales/en/dashboard/translation.json
+++ b/src/locales/en/dashboard/translation.json
@@ -72,7 +72,8 @@
 		},
 		"hello": "Hello",
 		"logout": "Logout",
-		"welcome": "Welcome to AutoKitteh"
+		"welcome": "Welcome to {{organization}}",
+		"autoKitteh": "AutoKitteh"
 	},
 	"tours": {
 		"projectCreationFailed": "Project creation failed",


### PR DESCRIPTION
## Description
On Homepage write "Welcome to {ORG_NAME}" instead of "Welcome to AutoKitteh"
## Linear Ticket
https://linear.app/autokitteh/issue/UI-1578/on-homepage-write-welcome-to-org-name-instead-of-welcome-to-autokitteh
## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
