### PR TITLE
fix(UI-1588): rate-limit displayed on all grpc request errors

### DIFF
--- a/src/api/grpc/transport.grpc.api.ts
+++ b/src/api/grpc/transport.grpc.api.ts
@@ -61,9 +61,9 @@ const authInterceptor: Interceptor =
 				logoutFunction(false);
 			}
 
-			if (error.code !== Code.ResourceExhausted) handleRateLimitError(error);
-
 			const responseErrorType = error?.metadata?.get("x-error-type");
+
+			if (error.code === Code.ResourceExhausted && !responseErrorType) handleRateLimitError(error);
 
 			switch (responseErrorType) {
 				case "rate_limit_exceeded":


### PR DESCRIPTION
## Description
When grpc request failed - RateLimit displayed, even if not related to 429

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1588/when-grpc-request-failed-ratelimit-displayed-even-if-not-related-to

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
