### PR TITLE
fix(UI-1598): disable hover effects in usage progress bar

### DIFF
--- a/src/components/organisms/settings/organization/billing/usageProgressBar.tsx
+++ b/src/components/organisms/settings/organization/billing/usageProgressBar.tsx
@@ -92,6 +92,18 @@ export const UsageProgressBar = ({ value, max, "aria-label": ariaLabel, classNam
 			stroke: {
 				lineCap: "round" as const,
 			},
+			states: {
+				hover: {
+					filter: {
+						type: "none",
+					},
+				},
+				active: {
+					filter: {
+						type: "none",
+					},
+				},
+			},
 			accessibility: {
 				enabled: true,
 				description:


### PR DESCRIPTION
## Description
  This PR disables hover and active state effects in the usage progress
  bar component to improve consistency in the billing usage display.

  ## Linear Ticket

  UI-1598

  ## What type of PR is this? (check all applicable)

  - [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)

  ## Changes Made
  - Add states configuration to disable hover and active filters in
  ApexCharts
  - Prevents visual effects on user interaction with the progress bar
  - Improves consistency in billing usage display

  ## Test Plan
  1. Navigate to the organization billing page
  2. Hover over the usage progress bar
  3. Verify that no visual hover effects occur
  4. Click on the progress bar
  5. Verify that no active state effects occur