### PR TITLE
fix(UI-1598): schedule triggers validation display

### DIFF
--- a/src/components/molecules/select/base.tsx
+++ b/src/components/molecules/select/base.tsx
@@ -24,6 +24,7 @@ export const BaseSelect = forwardRef<HTMLDivElement, BaseSelectProps>(
 			defaultValue,
 			disabled = false,
 			isError = false,
+			isRequired = false,
 			label,
 			noOptionsLabel,
 			onChange,
@@ -125,13 +126,13 @@ export const BaseSelect = forwardRef<HTMLDivElement, BaseSelectProps>(
 					onCreateOption={onCreateOption}
 					onFocus={handleFocus}
 					options={options}
-					placeholder={placeholder}
+					placeholder={isRequired ? `${placeholder} *` : placeholder}
 					styles={selectStyles}
 					value={selectedOption || defaultValue}
 				/>
 
 				<label className={labelClass} htmlFor={id}>
-					<span className="relative z-10">{label}</span>
+					<span className="relative z-10">{isRequired ? `${label} *` : label}</span>
 					<span className={borderOverlayLabelClass} />
 				</label>
 			</div>

--- a/src/components/organisms/triggers/formParts/fileAndFunction.tsx
+++ b/src/components/organisms/triggers/formParts/fileAndFunction.tsx
@@ -39,6 +39,8 @@ export const TriggerSpecificFields = ({
 	const [options, setOptions] = useState<SelectOption[]>([]);
 	const [triggerRerender, setTriggerRerender] = useState(0);
 
+	const isScheduleTrigger = connectionType === TriggerTypes.schedule;
+
 	useEffect(() => {
 		setValue("eventTypeSelect", undefined);
 		setTriggerRerender((prev) => prev + 1);
@@ -100,6 +102,7 @@ export const TriggerSpecificFields = ({
 							aria-label={t("placeholders.selectFile")}
 							dataTestid="select-file"
 							isError={!!errors.filePath}
+							isRequired={isScheduleTrigger}
 							label={t("placeholders.file")}
 							noOptionsLabel={t("noFilesAvailable")}
 							options={filesNameList}
@@ -120,6 +123,7 @@ export const TriggerSpecificFields = ({
 						disabled={shouldDisableFunctionInput}
 						{...register("entryFunction")}
 						isError={!!errors.entryFunction}
+						isRequired={isScheduleTrigger}
 						label={t("placeholders.functionName")}
 						value={watchedFunctionName}
 					/>

--- a/src/components/organisms/triggers/formParts/nameAndConnection.tsx
+++ b/src/components/organisms/triggers/formParts/nameAndConnection.tsx
@@ -59,6 +59,7 @@ export const NameAndConnectionFields = ({ isEdit }: { isEdit?: boolean }) => {
 							dataTestid="select-trigger-type"
 							disabled={isEdit}
 							isError={!!errors.connection}
+							isRequired
 							label={t("placeholders.connection")}
 							noOptionsLabel={t("noConnectionsAvailable")}
 							options={formattedConnections}

--- a/src/components/organisms/triggers/formParts/scheduler.tsx
+++ b/src/components/organisms/triggers/formParts/scheduler.tsx
@@ -30,6 +30,7 @@ export const SchedulerFields = () => {
 				aria-label={t("placeholders.cron")}
 				{...register("cron")}
 				isError={!!errors.cron}
+				isRequired
 				label={t("placeholders.cron")}
 				value={cronValue}
 			/>

--- a/src/interfaces/components/forms/select.interface.ts
+++ b/src/interfaces/components/forms/select.interface.ts
@@ -5,6 +5,7 @@ import { ColorSchemes } from "@type";
 export interface SelectProps {
 	dataTestid?: string;
 	isError?: boolean;
+	isRequired?: boolean;
 	noOptionsLabel?: string;
 	label?: string;
 	onBlur?: () => void;

--- a/src/validations/trigger.schema.ts
+++ b/src/validations/trigger.schema.ts
@@ -18,23 +18,31 @@ const fallbackTriggerSchema = z
 		filter: z.string().optional(),
 		cron: z.string().optional(),
 	})
-	.refine(
-		(data) => {
-			if (data.connection.value === TriggerTypes.webhook || data.connection.value === TriggerTypes.connection) {
-				return true;
+	.superRefine((data, ctx) => {
+		if (data.connection.value === TriggerTypes.schedule) {
+			if (!data.filePath?.value) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "File is required",
+					path: ["filePath"],
+				});
 			}
-
-			if (data.connection.value === TriggerTypes.schedule) {
-				return data.filePath?.label && data.entryFunction && data.entryFunction.length > 0;
+			if (!data.entryFunction || data.entryFunction.length === 0) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Entry function is required",
+					path: ["entryFunction"],
+				});
 			}
-
-			return true;
-		},
-		{
-			message: "Entry function is required",
-			path: ["entryFunction"],
+			if (!data.cron || data.cron.length === 0) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Cron expression is required",
+					path: ["cron"],
+				});
+			}
 		}
-	);
+	});
 
 export let triggerSchema: z.ZodSchema = fallbackTriggerSchema;
 
@@ -60,26 +68,31 @@ i18n.on("initialized", () => {
 			filter: z.string().optional(),
 			cron: z.string().optional(),
 		})
-		.refine(
-			(data) => {
-				if (
-					data.connection.value === TriggerTypes.webhook ||
-					data.connection.value === TriggerTypes.connection
-				) {
-					return true;
+		.superRefine((data, ctx) => {
+			if (data.connection.value === TriggerTypes.schedule) {
+				if (!data.filePath?.label) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: t("triggers.form.validations.fileRequired", { ns: "tabs" }),
+						path: ["filePath"],
+					});
 				}
-
-				if (data.connection.value === TriggerTypes.schedule) {
-					return data.filePath?.label && data.entryFunction && data.entryFunction.length > 0;
+				if (!data.entryFunction || data.entryFunction.length === 0) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: t("triggers.form.validations.functionRequired", { ns: "tabs" }),
+						path: ["entryFunction"],
+					});
 				}
-
-				return true;
-			},
-			{
-				message: t("triggers.form.validations.functionRequired", { ns: "tabs" }),
-				path: ["entryFunction"],
+				if (!data.cron || data.cron.length === 0) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: t("triggers.form.validations.cronRequired", { ns: "tabs" }),
+						path: ["cron"],
+					});
+				}
 			}
-		);
+		});
 });
 
 export type TriggerFormData = z.infer<typeof triggerSchema>;


### PR DESCRIPTION
## Description
  This PR fixes the validation display for schedule triggers to show  asterisks (*) for required fields in the form.

## Linear Ticket
  UI-1598

## What type of PR is this? (check all applicable)
  - [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)

## Changes Made
  - Add `isRequired` prop to Select component interface and implementation
  - Update schedule trigger form fields to show asterisks (*) for required
   fields when schedule trigger type is selected
  - Fix validation schema to properly validate required fields for
  schedule triggers
  - File, Function Name, and Cron Expression fields now display asterisks
  when schedule trigger type is selected
  - Connection field now shows asterisk as it's always required

## Test Plan
  1. Navigate to triggers page
  2. Click "Add Trigger"
  3. Select "Schedule" as trigger type
  4. Verify that File, Function Name, and Cron Expression fields show
  asterisks (*)
  5. Verify validation works properly when submitting empty required 
  fields