### PR TITLE
fix: chatbot loaded twice

### DIFF
--- a/src/components/organisms/chatbotIframe/chatbotIframe.tsx
+++ b/src/components/organisms/chatbotIframe/chatbotIframe.tsx
@@ -43,6 +43,8 @@ export const ChatbotIframe = ({
 	const [chatbotUrlWithOrgId, setChatbotUrlWithOrgId] = useState("");
 
 	useEffect(() => {
+		if (descopeProjectId && !currentOrganization?.id) return;
+
 		const params = new URLSearchParams();
 		if (currentOrganization?.id) {
 			params.append("orgId", currentOrganization.id);
@@ -59,11 +61,19 @@ export const ChatbotIframe = ({
 		}
 		const url = `${aiChatbotUrl}?${params.toString()}`;
 
-		if (chatbotUrlWithOrgId && url !== chatbotUrlWithOrgId && iframeRef.current) {
-			iframeCommService.reset();
-		}
+		if (url !== chatbotUrlWithOrgId) {
+			console.debug("[Chatbot] URL changing from:", chatbotUrlWithOrgId, "to:", url);
 
-		setChatbotUrlWithOrgId(url);
+			if (descopeProjectId && chatbotUrlWithOrgId && !currentOrganization?.id) {
+				console.warn("[Chatbot] Preventing URL change that would remove orgId");
+				return;
+			}
+
+			if (chatbotUrlWithOrgId && iframeRef.current) {
+				iframeCommService.reset();
+			}
+			setChatbotUrlWithOrgId(url);
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [currentOrganization?.id, chatbotHelperConfigMode, projectId, displayDeployButton, aiChatbotUrl, isTransparent]);
 
@@ -168,6 +178,7 @@ export const ChatbotIframe = ({
 				<iframe
 					className={className}
 					height={height}
+					key={chatbotUrlWithOrgId}
 					onLoad={handleIframeElementLoad}
 					ref={iframeRef}
 					sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-storage-access-by-user-activation"

--- a/src/hooks/useChatbotIframe.ts
+++ b/src/hooks/useChatbotIframe.ts
@@ -127,7 +127,8 @@ export const useChatbotIframeConnection = (iframeRef: React.RefObject<HTMLIFrame
 			setIsIframeElementLoaded(false);
 			isConnectingRef.current = false;
 
-			const urlToUse = aiChatbotUrl;
+			const currentSrc = iframeRef.current.src;
+			const urlToUse = currentSrc || aiChatbotUrl;
 
 			try {
 				const url = new URL(urlToUse);


### PR DESCRIPTION
## Description
  The ChatbotIframe component was loading twice on every render:
  1. First request: Correct URL with orgId parameter (304 status)
  2. Second request: Base URL without parameters (200 status)

  This caused authentication issues and poor user experience as the chatbot would fail to work properly.

## Root Cause

The handleRetry function in useChatbotIframe.ts was using the base aiChatbotUrl constant instead of preserving the current iframe's src URL with all its parameters. When the connection process automatically triggered after iframe load, it would reload the iframe with the wrong URL.

## Solution
  1. Fixed handleRetry function: Modified to use the current iframe's src to preserve URL parameters including orgId
  2. Optimized URL construction: Added checks to prevent unnecessary URL updates in ChatbotIframe component
  3. Added iframe key: Used URL as React key to ensure proper iframe recreation on URL changes
  4. Enhanced debugging: Added console logs to track URL changes and parameter preservation
  
## Testing
  - Verified iframe now loads only once with correct orgId parameter
  - Confirmed chatbot authentication works properly
  - Added debugging logs for future troubleshooting
## Linear Ticket

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
