### PR TITLE
fix: disable conflicting AI navigation buttons when drawer is open

### DIFF
--- a/src/components/organisms/topbar/project/navigation.tsx
+++ b/src/components/organisms/topbar/project/navigation.tsx
@@ -6,7 +6,7 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { featureFlags, mainNavigationItems, aiProjectNavigationItems, tourStepsHTMLIds } from "@src/constants";
 import { EventListenerName } from "@src/enums";
 import { triggerEvent, useLastVisitedEntity } from "@src/hooks";
-import { useProjectStore } from "@src/store";
+import { useDrawerStore, useProjectStore, useSharedBetweenProjectsStore } from "@src/store";
 import { cn } from "@src/utilities";
 
 import { Button, IconSvg } from "@components/atoms";
@@ -16,6 +16,12 @@ export const ProjectTopbarNavigation = () => {
 	const { pathname } = useLocation();
 	const { latestOpened } = useProjectStore();
 	const navigate = useNavigate();
+	const { isDrawerOpen } = useDrawerStore();
+	const chatbotHelperConfigMode = useSharedBetweenProjectsStore((state) => state.chatbotHelperConfigMode);
+
+	const currentProjectConfigMode = useMemo(() => {
+		return projectId ? chatbotHelperConfigMode[projectId] : false;
+	}, [projectId, chatbotHelperConfigMode]);
 
 	const { deploymentId, deployments } = useLastVisitedEntity(projectId, paramDeploymentId, sessionId);
 
@@ -106,24 +112,31 @@ export const ProjectTopbarNavigation = () => {
 				</Button>
 			))}
 			{featureFlags.displayChatbot
-				? Object.values(aiProjectNavigationItems).map(({ key, label, icon, action }) => (
-						<Button
-							ariaLabel={label}
-							className="group relative size-full gap-2 whitespace-nowrap rounded-none bg-transparent p-3.5 text-gray-1500 hover:bg-gray-1050 hover:text-white"
-							key={key}
-							onClick={() => handleAiButtonClick(action)}
-							role="navigation"
-							title={label}
-							variant="filledGray"
-						>
-							<IconSvg
-								className="size-5 fill-green-200 text-green-200 transition group-hover:text-green-200 group-active:text-green-800"
-								size="lg"
-								src={icon}
-							/>
-							<span className="group-hover:text-white">{label}</span>
-						</Button>
-					))
+				? Object.values(aiProjectNavigationItems).map(({ key, label, icon, action }) => {
+						const isDisabled =
+							isDrawerOpen("chatbot") &&
+							((currentProjectConfigMode && key === "config") ||
+								(!currentProjectConfigMode && key === "chatbot"));
+						return (
+							<Button
+								ariaLabel={label}
+								className="group relative size-full gap-2 whitespace-nowrap rounded-none bg-transparent p-3.5 text-gray-1500 hover:bg-gray-1050 hover:text-white"
+								disabled={isDisabled}
+								key={key}
+								onClick={() => handleAiButtonClick(action)}
+								role="navigation"
+								title={label}
+								variant="filledGray"
+							>
+								<IconSvg
+									className="size-5 fill-green-200 text-green-200 transition group-hover:text-green-200 group-active:text-green-800"
+									size="lg"
+									src={icon}
+								/>
+								<span className="group-hover:text-white">{label}</span>
+							</Button>
+						);
+					})
 				: null}
 		</div>
 	);


### PR DESCRIPTION
Prevent user confusion by disabling the appropriate AI navigation button based on current mode when the chatbot drawer is open:
- Disable Config button when in config mode
- Disable Chat button when in chatbot mode

## Description

## Linear Ticket

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
