### PR TITLE
fix: correct learn more navigation paths in AI and Welcome pages

### DIFF
--- a/src/components/organisms/welcome.tsx
+++ b/src/components/organisms/welcome.tsx
@@ -172,7 +172,7 @@ export const WelcomePage = () => {
 						{tWelcome("title")}
 					</Typography>
 				</div>
-				<Button className="text-sm text-green-800 hover:underline" onClick={() => navigate("intro")}>
+				<Button className="text-sm text-green-800 hover:underline" onClick={() => navigate("/intro")}>
 					{tWelcome("learnMore")}
 				</Button>
 			</header>


### PR DESCRIPTION
Fix broken learn more button navigation by correcting the path from 'intro' to '/intro' in both AI and Welcome page components.

## Description

## Linear Ticket

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
