### PR TITLE
fix(UI-1771): display login buttons if the login failed

### DIFF
--- a/src/components/templates/descopeMiddleware.tsx
+++ b/src/components/templates/descopeMiddleware.tsx
@@ -101,6 +101,13 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
+	const reRenderDescopeWithCookies = (shouldClearAuthCookies: boolean = true) => {
+		if (shouldClearAuthCookies) {
+			clearAuthCookies();
+		}
+		setDescopeRenderKey((prevKey) => prevKey + 1);
+	};
+
 	const handleSuccess = useCallback(
 		async (event: CustomEvent<any>) => {
 			try {
@@ -115,15 +122,14 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 					const { data: user, error } = await login();
 					if (error) {
 						addToast({ message: t("errors.loginFailedTryAgainLater"), type: "error" });
-						clearAuthCookies();
-						setDescopeRenderKey((prevKey) => prevKey + 1);
+						reRenderDescopeWithCookies();
 						return;
 					}
 					clearLogs();
 					gTagEvent(googleTagManagerEvents.login, { method: "descope", ...user });
 					setIdentity(user!.email);
 					await submitHubspot(user!);
-					setDescopeRenderKey((prevKey) => prevKey + 1);
+					reRenderDescopeWithCookies(false);
 					const chatStartMessage = Cookies.get(systemCookies.chatStartMessage);
 					if (chatStartMessage) {
 						Cookies.remove(systemCookies.chatStartMessage, { path: "/" });
@@ -140,8 +146,7 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 				}
 				LoggerService.error(namespaces.ui.loginPage, t("errors.noAuthCookies"), true);
 				addToast({ message: t("errors.loginFailedTryAgainLater"), type: "error" });
-				clearAuthCookies();
-				setDescopeRenderKey((prevKey) => prevKey + 1);
+				reRenderDescopeWithCookies();
 			} catch (error) {
 				addToast({
 					message: t("errors.loginFailedTryAgainLater"),
@@ -149,8 +154,7 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 					hideSystemLogLinkOnError: true,
 				});
 				LoggerService.error(namespaces.ui.loginPage, t("errors.loginFailedExtended", { error }), true);
-				clearAuthCookies();
-				setDescopeRenderKey((prevKey) => prevKey + 1);
+				reRenderDescopeWithCookies();
 			}
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/templates/descopeMiddleware.tsx
+++ b/src/components/templates/descopeMiddleware.tsx
@@ -63,6 +63,10 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 
 	useEffect(() => {
 		refreshCookie();
+
+		if (playwrightTestsAuthBearer && !isLoggingIn && !user) {
+			attemptLogin();
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -94,13 +98,6 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	useEffect(() => {
-		if (playwrightTestsAuthBearer && !isLoggingIn && !user) {
-			attemptLogin();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
 	const handleSuccess = useCallback(
 		async (event: CustomEvent<any>) => {
 			try {
@@ -116,6 +113,7 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 					if (error) {
 						addToast({ message: t("errors.loginFailedTryAgainLater"), type: "error" });
 						clearAuthCookies();
+						setDescopeRenderKey((prevKey) => prevKey + 1);
 						return;
 					}
 					clearLogs();
@@ -140,6 +138,7 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 				LoggerService.error(namespaces.ui.loginPage, t("errors.noAuthCookies"), true);
 				addToast({ message: t("errors.loginFailedTryAgainLater"), type: "error" });
 				clearAuthCookies();
+				setDescopeRenderKey((prevKey) => prevKey + 1);
 			} catch (error) {
 				addToast({
 					message: t("errors.loginFailedTryAgainLater"),
@@ -148,6 +147,7 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 				});
 				LoggerService.error(namespaces.ui.loginPage, t("errors.loginFailedExtended", { error }), true);
 				clearAuthCookies();
+				setDescopeRenderKey((prevKey) => prevKey + 1);
 			}
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/templates/descopeMiddleware.tsx
+++ b/src/components/templates/descopeMiddleware.tsx
@@ -63,10 +63,6 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 
 	useEffect(() => {
 		refreshCookie();
-
-		if (playwrightTestsAuthBearer && !isLoggingIn && !user) {
-			attemptLogin();
-		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -93,6 +89,13 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 			if (startParam) paramsToKeep.start = startParam;
 			setSearchParams(paramsToKeep, { replace: true });
 
+			attemptLogin();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
+		if (playwrightTestsAuthBearer && !isLoggingIn && !user) {
 			attemptLogin();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/templates/descopeMiddleware.tsx
+++ b/src/components/templates/descopeMiddleware.tsx
@@ -101,8 +101,8 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	const reRenderDescopeWithCookies = (shouldClearAuthCookies: boolean = true) => {
-		if (shouldClearAuthCookies) {
+	const resetDescopeComponent = (clearCookies: boolean = true) => {
+		if (clearCookies) {
 			clearAuthCookies();
 		}
 		setDescopeRenderKey((prevKey) => prevKey + 1);
@@ -122,14 +122,14 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 					const { data: user, error } = await login();
 					if (error) {
 						addToast({ message: t("errors.loginFailedTryAgainLater"), type: "error" });
-						reRenderDescopeWithCookies();
+						resetDescopeComponent();
 						return;
 					}
 					clearLogs();
 					gTagEvent(googleTagManagerEvents.login, { method: "descope", ...user });
 					setIdentity(user!.email);
 					await submitHubspot(user!);
-					reRenderDescopeWithCookies(false);
+					resetDescopeComponent(false);
 					const chatStartMessage = Cookies.get(systemCookies.chatStartMessage);
 					if (chatStartMessage) {
 						Cookies.remove(systemCookies.chatStartMessage, { path: "/" });
@@ -146,7 +146,7 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 				}
 				LoggerService.error(namespaces.ui.loginPage, t("errors.noAuthCookies"), true);
 				addToast({ message: t("errors.loginFailedTryAgainLater"), type: "error" });
-				reRenderDescopeWithCookies();
+				resetDescopeComponent();
 			} catch (error) {
 				addToast({
 					message: t("errors.loginFailedTryAgainLater"),
@@ -154,7 +154,7 @@ export const DescopeMiddleware = ({ children }: { children: ReactNode }) => {
 					hideSystemLogLinkOnError: true,
 				});
 				LoggerService.error(namespaces.ui.loginPage, t("errors.loginFailedExtended", { error }), true);
-				reRenderDescopeWithCookies();
+				resetDescopeComponent();
 			}
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Description
**Issue:** Login buttons were missing after authentication failures, leaving users unable to retry login.

**Root Cause:** After login failures, the code was calling clearAuthCookies() directly but not properly resetting the Descope component state, which
  prevented the login UI from re-rendering.

**Solution:**
  - Created unified resetDescopeComponent() function that handles both cookie clearing and component state reset
  - Replaced direct clearAuthCookies() calls with resetDescopeComponent() in error handlers
  - Added an optional parameter to control whether cookies should be cleared (useful for successful logins)
  - Ensures login buttons are properly displayed after failed login attempts

Technical Details: The fix consolidates cleanup logic into a single function that increments descopeRenderKey to force component re-render, ensuring the interface is always available to users after authentication failures.

Before:
<img width="1552" height="1012" alt="image" src="https://github.com/user-attachments/assets/db49c3bc-d123-42d9-9c1c-bc9280cf4969" />

After:
<img width="1552" height="1012" alt="image" src="https://github.com/user-attachments/assets/d6811595-d89b-4e57-8719-20aac9768954" />


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1771/missing-log-in-buttons


## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
