### PR TITLE
fix(UI-1767): fix the assets pane expand button when it close

### DIFF
--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -124,7 +124,7 @@ export const Project = () => {
 	return (
 		<>
 			{isNavigationCollapsed ? (
-				<div className="absolute left-1 top-1 z-[2002] m-1">
+				<div className="absolute left-1 top-1 z-project-nav-button m-1">
 					<PopoverWrapper animation="slideFromBottom" delay={500} interactionType="hover">
 						<PopoverTrigger>
 							<IconButton
@@ -135,7 +135,7 @@ export const Project = () => {
 								<ArrowRightCarouselIcon className="size-3.5 fill-black stroke-black" />
 							</IconButton>
 						</PopoverTrigger>
-						<PopoverContent className="z-[2010] rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
+						<PopoverContent className="z-project-nav-popover rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
 							<div className="text-white">{tUI("display")}</div>
 						</PopoverContent>
 					</PopoverWrapper>
@@ -196,7 +196,7 @@ export const Project = () => {
 								</div>
 							</div>
 							{!isNavigationCollapsed && hasOpenFiles ? (
-								<div className="absolute right-0 top-1 z-[1010] m-1">
+								<div className="absolute right-0 top-1 z-project-nav-button m-1">
 									<PopoverWrapper animation="slideFromBottom" delay={500} interactionType="hover">
 										<PopoverTrigger>
 											<IconButton
@@ -207,7 +207,7 @@ export const Project = () => {
 												<ArrowLeft className="size-3.5 fill-black stroke-black" />
 											</IconButton>
 										</PopoverTrigger>
-										<PopoverContent className="z-[2010] rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
+										<PopoverContent className="z-project-nav-popover rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
 											<div className="text-white">{tUI("hide")}</div>
 										</PopoverContent>
 									</PopoverWrapper>

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -125,7 +125,7 @@ export const Project = () => {
 		<>
 			{isNavigationCollapsed ? (
 				<div className="absolute left-1 top-1 z-[2002] m-1">
-					<PopoverWrapper animation="slideFromBottom" interactionType="hover">
+					<PopoverWrapper animation="slideFromBottom" delay={500} interactionType="hover">
 						<PopoverTrigger>
 							<IconButton
 								ariaLabel={tUI("display")}
@@ -197,7 +197,7 @@ export const Project = () => {
 							</div>
 							{!isNavigationCollapsed && hasOpenFiles ? (
 								<div className="absolute right-0 top-1 z-[1010] m-1">
-									<PopoverWrapper animation="slideFromBottom" interactionType="hover">
+									<PopoverWrapper animation="slideFromBottom" delay={500} interactionType="hover">
 										<PopoverTrigger>
 											<IconButton
 												ariaLabel={tUI("hide")}

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -18,10 +18,13 @@ import {
 import { calculatePathDepth, cn } from "@utilities";
 
 import { IconButton, IconSvg, PageTitle, Tab } from "@components/atoms";
+import { PopoverTrigger } from "@components/molecules";
 import { LoadingOverlay } from "@components/molecules/loadingOverlay";
+import { PopoverWrapper } from "@components/molecules/popover/index";
+import { PopoverContent } from "@components/molecules/popover/popoverContent";
 import { SplitFrame } from "@components/organisms";
 
-import { ArrowRightCarouselIcon, Close, WarningTriangleIcon } from "@assets/image/icons";
+import { ArrowLeft, ArrowRightCarouselIcon, WarningTriangleIcon } from "@assets/image/icons";
 
 export const Project = () => {
 	const navigate = useNavigate();
@@ -30,6 +33,7 @@ export const Project = () => {
 	const { fetchManualRunConfiguration } = useManualRunStore();
 	const { openFiles } = useFileStore();
 	const { t } = useTranslation("global", { keyPrefix: "pageTitles" });
+	const { t: tUI } = useTranslation("global", { keyPrefix: "ui.projectConfiguration" });
 	const [pageTitle, setPageTitle] = useState<string>(t("base"));
 	const { projectId } = useParams();
 	const { getProject, setLatestOpened } = useProjectStore();
@@ -120,14 +124,21 @@ export const Project = () => {
 	return (
 		<>
 			{isNavigationCollapsed ? (
-				<div className="absolute left-2 top-2 z-[999]" id="project-navigation-expand-button">
-					<IconButton
-						ariaLabel="Expand navigation"
-						className="m-1 bg-green-800 p-1 hover:bg-gray-1100"
-						onClick={showProjectNavigation}
-					>
-						<ArrowRightCarouselIcon className="size-3.5 fill-black stroke-black" />
-					</IconButton>
+				<div className="absolute left-1 top-1 z-[2002] m-1">
+					<PopoverWrapper animation="slideFromBottom" interactionType="hover">
+						<PopoverTrigger>
+							<IconButton
+								ariaLabel={tUI("display")}
+								className="rounded-full border border-white p-1 hover:bg-gray-1250"
+								onClick={showProjectNavigation}
+							>
+								<ArrowRightCarouselIcon className="size-3.5 fill-black stroke-black" />
+							</IconButton>
+						</PopoverTrigger>
+						<PopoverContent className="z-[2010] rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
+							<div className="text-white">{tUI("display")}</div>
+						</PopoverContent>
+					</PopoverWrapper>
 				</div>
 			) : null}
 
@@ -185,13 +196,22 @@ export const Project = () => {
 								</div>
 							</div>
 							{!isNavigationCollapsed && hasOpenFiles ? (
-								<IconButton
-									ariaLabel="Collapse navigation"
-									className="absolute right-2 top-5 z-10 m-1 p-1.5 pr-0 hover:bg-gray-1100"
-									onClick={hideProjectNavigation}
-								>
-									<Close className="size-4 fill-white" />
-								</IconButton>
+								<div className="absolute right-0 top-1 z-[1010] m-1">
+									<PopoverWrapper animation="slideFromBottom" interactionType="hover">
+										<PopoverTrigger>
+											<IconButton
+												ariaLabel={tUI("hide")}
+												className="rounded-full border border-white p-1 hover:bg-gray-1250"
+												onClick={hideProjectNavigation}
+											>
+												<ArrowLeft className="size-3.5 fill-black stroke-black" />
+											</IconButton>
+										</PopoverTrigger>
+										<PopoverContent className="z-[2010] rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
+											<div className="text-white">{tUI("hide")}</div>
+										</PopoverContent>
+									</PopoverWrapper>
+								</div>
 							) : null}
 							<div className="h-full">
 								<Outlet />

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -21,7 +21,7 @@ import { IconButton, IconSvg, PageTitle, Tab } from "@components/atoms";
 import { LoadingOverlay } from "@components/molecules/loadingOverlay";
 import { SplitFrame } from "@components/organisms";
 
-import { ArrowLeft, Close, WarningTriangleIcon } from "@assets/image/icons";
+import { ArrowRightCarouselIcon, Close, WarningTriangleIcon } from "@assets/image/icons";
 
 export const Project = () => {
 	const navigate = useNavigate();
@@ -126,7 +126,7 @@ export const Project = () => {
 						className="m-1 bg-green-800 p-1 hover:bg-gray-1100"
 						onClick={showProjectNavigation}
 					>
-						<ArrowLeft className="size-3.5 rotate-180 fill-black stroke-black" />
+						<ArrowRightCarouselIcon className="size-3.5 fill-black stroke-black" />
 					</IconButton>
 				</div>
 			) : null}

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -120,16 +120,14 @@ export const Project = () => {
 	return (
 		<>
 			{isNavigationCollapsed ? (
-				<div className="relative" id="project-navigation-expand-button z-[99]">
-					<div className="absolute left-4 top-4 z-[99]" id="expand-project-navigation">
-						<IconButton
-							ariaLabel="Expand navigation"
-							className="z-[99] m-1 bg-gray-250 p-1.5 hover:bg-gray-1100"
-							onClick={showProjectNavigation}
-						>
-							<ArrowLeft className="size-6 rotate-180 fill-black" />
-						</IconButton>
-					</div>
+				<div className="absolute left-2 top-2 z-[999]" id="project-navigation-expand-button">
+					<IconButton
+						ariaLabel="Expand navigation"
+						className="m-1 bg-green-800 p-1 hover:bg-gray-1100"
+						onClick={showProjectNavigation}
+					>
+						<ArrowLeft className="size-3.5 rotate-180 fill-black stroke-black" />
+					</IconButton>
 				</div>
 			) : null}
 

--- a/src/hooks/usePopover.ts
+++ b/src/hooks/usePopover.ts
@@ -95,7 +95,7 @@ export const usePopover = (
 	}
 ) => {
 	const { close, context, data, isMounted, open, setOpen, styles, arrowRef } = useBasePopover(options);
-	const { interactionType = "hover", allowDismiss } = options;
+	const { interactionType = "hover", allowDismiss, delay } = options;
 
 	const dismiss = useDismiss(context, { enabled: allowDismiss });
 
@@ -106,6 +106,7 @@ export const usePopover = (
 		hover: useHover(context, {
 			enabled: interactionType === "hover",
 			handleClose: safePolygon({ buffer: 100 }),
+			delay,
 		}),
 	};
 
@@ -134,7 +135,7 @@ export const usePopoverList = (
 	const { close, context, data, isMounted, open, setOpen, styles, arrowRef } = useBasePopover(options);
 	const [activeIndex, setActiveIndex] = useState<number | null>(null);
 	const listRef = useRef<(HTMLElement | null)[]>([]);
-	const { interactionType = "click" } = options;
+	const { interactionType = "click", delay } = options;
 
 	const listNavigation = useListNavigation(context, {
 		listRef,
@@ -152,6 +153,7 @@ export const usePopoverList = (
 		hover: useHover(context, {
 			enabled: interactionType === "hover",
 			handleClose: safePolygon({ buffer: 100 }),
+			delay,
 		}),
 	};
 

--- a/src/interfaces/components/popover.interface.ts
+++ b/src/interfaces/components/popover.interface.ts
@@ -15,6 +15,7 @@ export interface PopoverOptions {
 		};
 	};
 	allowDismiss?: boolean;
+	delay?: number | { close?: number; open?: number };
 }
 
 export interface PopoverTriggerProps {

--- a/src/locales/en/global/translation.json
+++ b/src/locales/en/global/translation.json
@@ -40,5 +40,11 @@
 	"customError": {
 		"goToHomepage": "Back to Homepage",
 		"error": "Error"
+	},
+	"ui": {
+		"projectConfiguration": {
+			"display": "Display Project Configuration",
+			"hide": "Hide Project Configuration"
+		}
 	}
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -66,6 +66,8 @@ module.exports = {
 			zIndex: {
 				modal: "121",
 				toast: "122",
+				"project-nav-button": "1010",
+				"project-nav-popover": "2010",
 			},
 		},
 		screens: {


### PR DESCRIPTION
## Description

This PR enhances the project navigation toggle buttons by adding informative hover popovers with browser-like delay timing, fixes a critical z-index bug,
  and extends the popover system with delay functionality.

**Main bug-fix: the "Hide Project Configuration" button was rendered behind project tabs due to lower z-index (z-40 vs tabs' z-[60])**
    - Impact: Users had difficulty clicking the hide button as it was obscured by overlapping elements
    - Solution: Increased z-index to z-[2010] for popover content and proper button wrapper positioning

**Enhanced Popover System with Delay Support**
    - Extended PopoverOptions interface to include delay?: number | { open?: number; close?: number }
    - Updated usePopover hooks to pass delay configuration to Floating UI's useHover
    - Added 500ms delay mimicking browser's native tooltip behavior (like title attribute)
    - Applied to both functions: usePopover and usePopoverList for consistency

**Improved buttons use UI/UX**
    - Added hover popovers with informative text for both configuration buttons
    - Replaced icons: Generic ArrowLeft/Close → semantic ArrowRightCarouselIcon/ArrowLeft
    - Updated styling: Rounded border design with consistent hover states
    - Improved positioning: Absolute positioning with proper wrapper architecture
    - Fixed button sizes: Consistent size-3.5 icons with proper padding

**Technical Implementation**
  - Z-Index Hierarchy:
    - Popover content: z-[2010] (ensures visibility above all elements)
    - Button wrappers: z-[1010]/z-[2002] (proper positioning)
    - Project tabs: z-[60] (no longer interferes)

 **User Impact**
_Before:_
  - Buttons appeared immediately but were hard to click due to z-index issues
  - No visual feedback about button functionality
  - Hardcoded English strings

_After:_
  - Natural 500ms delay prevents accidental popover triggers
  - Clear, accessible tooltips explaining button functionality
  - Reliable button interaction without z-index conflicts
  - Internationalization-ready with proper translation system

This change transforms frustrating hidden buttons into discoverable, accessible UI elements with professional tooltip behavior that matches user expectations from standard web interactions.

Demo:

https://github.com/user-attachments/assets/73f7b587-5424-4553-97f9-844062d0d28d


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1767/assets-tab-when-closed-the-open-button-should-be-above-the

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
