### PR TITLE
fix(UI-1766): preserve cursor position moving from and to the editor

### DIFF
--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -355,9 +355,16 @@ export const EditorTabs = () => {
 		try {
 			const fileSaved = await saveFile(activeEditorFileName, newContent || "");
 			if (!fileSaved) {
-				throw new Error(tErrors("codeSaveFailed"));
-			}
+				addToast({
+					message: tErrors("codeSaveFailed"),
+					type: "error",
+				});
 
+				LoggerService.error(
+					namespaces.ui.projectCodeEditor,
+					tErrors("codeSaveFailedExtended", { error: tErrors("unknownError"), projectId })
+				);
+			} else {
 			const cacheStore = useCacheStore.getState();
 			const currentResources = cacheStore.resources;
 			const updatedResources = {
@@ -370,6 +377,7 @@ export const EditorTabs = () => {
 			}));
 
 			setLastSaved(dayjs().format(dateTimeFormat));
+			}
 		} catch (error) {
 			addToast({
 				message: tErrors("codeSaveFailed"),

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -89,7 +89,6 @@ export const EditorTabs = () => {
 	const initialContentRef = useRef("");
 	const [isFirstContentLoad, setIsFirstContentLoad] = useState(true);
 	const [editorMounted, setEditorMounted] = useState(false);
-	const isRestoringPositionRef = useRef<{ [projectId: string]: boolean }>({});
 	const [codeFixData, setCodeFixData] = useState<{
 		endLine: number;
 		modifiedCode: string;
@@ -281,17 +280,12 @@ export const EditorTabs = () => {
 		const projectCursorPosition = cursorPositionPerProject[projectId!]?.[activeEditorFileName];
 
 		if (projectCursorPosition) {
-			isRestoringPositionRef.current[projectId!] = true;
 			_editor.revealLineInCenter(projectCursorPosition.startLine);
 			_editor.focus();
 			_editor.setPosition({
 				lineNumber: projectCursorPosition.startLine,
 				column: projectCursorPosition.startColumn,
 			});
-
-			if (isRestoringPositionRef.current) {
-				isRestoringPositionRef.current[projectId!] = false;
-			}
 		}
 	};
 
@@ -316,10 +310,6 @@ export const EditorTabs = () => {
 	const handleEditorFocus = (event: monaco.editor.ICursorPositionChangedEvent) => {
 		if (!projectId || !activeEditorFileName) return;
 
-		if (isRestoringPositionRef.current[projectId]) {
-			return;
-		}
-
 		if (!projectLoaded || !contentLoaded || !content || content.trim() === "") {
 			return;
 		}
@@ -341,12 +331,6 @@ export const EditorTabs = () => {
 			code: getLineCode({ startLine: position.lineNumber }),
 		});
 	};
-
-	useEffect(() => {
-		if (isRestoringPositionRef.current && projectId) {
-			isRestoringPositionRef.current[projectId] = false;
-		}
-	}, [projectId]);
 
 	useEffect(() => {
 		if (!editorMounted || !projectId || !activeEditorFileName) return;
@@ -525,7 +509,6 @@ export const EditorTabs = () => {
 	const handleEditorChange = (newContent?: string) => {
 		if (!newContent) return;
 		setContent(newContent);
-		// changeCursorPosition();
 		if (autoSaveMode && activeEditorFileName) {
 			debouncedAutosave(newContent);
 		}

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -270,15 +270,14 @@ export const EditorTabs = () => {
 
 	const restoreCursorPosition = (_editor: monaco.editor.IStandaloneCodeEditor) => {
 		const projectCursorPosition = cursorPositionPerProject[projectId!]?.[activeEditorFileName];
+		if (!projectCursorPosition) return;
 
-		if (projectCursorPosition) {
-			_editor.revealLineInCenter(projectCursorPosition.startLine);
-			_editor.focus();
-			_editor.setPosition({
-				lineNumber: projectCursorPosition.startLine,
-				column: projectCursorPosition.startColumn,
-			});
-		}
+		_editor.revealLineInCenter(projectCursorPosition.startLine);
+		_editor.focus();
+		_editor.setPosition({
+			lineNumber: projectCursorPosition.startLine,
+			column: projectCursorPosition.startColumn,
+		});
 	};
 
 	const handleEditorDidMount = (_editor: monaco.editor.IStandaloneCodeEditor, monaco: Monaco) => {

--- a/src/components/organisms/editorTabs.tsx
+++ b/src/components/organisms/editorTabs.tsx
@@ -54,7 +54,7 @@ export const EditorTabs = () => {
 		} catch (error) {
 			LoggerService.error(
 				namespaces.ui.projectCodeEditor,
-				`Error loading project "${projectId}": ${(error as Error).message}`
+				tErrors("errorLoadingProject", { projectId, error: (error as Error).message })
 			);
 		}
 	};
@@ -178,7 +178,7 @@ export const EditorTabs = () => {
 		} catch (error) {
 			LoggerService.warn(
 				namespaces.ui.projectCodeEditor,
-				`Error loading file "${activeEditorFileName}": ${error.message}`
+				tErrors("errorLoadingFile", { fileName: activeEditorFileName, error: error.message })
 			);
 		}
 	};
@@ -344,10 +344,10 @@ export const EditorTabs = () => {
 
 		if (!activeEditorFileName) {
 			addToast({
-				message: `No file is currently open for editing in project ${projectId}`,
+				message: tErrors("noFileOpenForEditing", { projectId }),
 				type: "error",
 			});
-			LoggerService.warn(namespaces.projectUICode, `Save attempted with no active file for project ${projectId}`);
+			LoggerService.warn(namespaces.projectUICode, tErrors("saveAttemptedNoActiveFile", { projectId }));
 			return;
 		}
 
@@ -365,18 +365,18 @@ export const EditorTabs = () => {
 					tErrors("codeSaveFailedExtended", { error: tErrors("unknownError"), projectId })
 				);
 			} else {
-			const cacheStore = useCacheStore.getState();
-			const currentResources = cacheStore.resources;
-			const updatedResources = {
-				...currentResources,
-				[activeEditorFileName]: new TextEncoder().encode(newContent),
-			};
-			useCacheStore.setState((state) => ({
-				...state,
-				resources: updatedResources,
-			}));
+				const cacheStore = useCacheStore.getState();
+				const currentResources = cacheStore.resources;
+				const updatedResources = {
+					...currentResources,
+					[activeEditorFileName]: new TextEncoder().encode(newContent),
+				};
+				useCacheStore.setState((state) => ({
+					...state,
+					resources: updatedResources,
+				}));
 
-			setLastSaved(dayjs().format(dateTimeFormat));
+				setLastSaved(dayjs().format(dateTimeFormat));
 			}
 		} catch (error) {
 			addToast({

--- a/src/locales/en/dashboard/translation.json
+++ b/src/locales/en/dashboard/translation.json
@@ -110,7 +110,6 @@
 		"useTemplate": "Start From Template",
 		"useTemplateDesc": "Select from a collection of out of the box templates",
 		"projectCreationFailed": "Project creation failed"
-
 	},
 	"welcomeLanding": {
 		"createNew": "Start",

--- a/src/locales/en/errors/translation.json
+++ b/src/locales/en/errors/translation.json
@@ -102,5 +102,9 @@
 	"organizationNotFoundExtended": "Organization not found, organization ID: {{organizationId}}",
 	"fileNotFoundInFetchedResources": "File \"{{fileName}}\" not found in project {{projectName}}",
 	"fileNotFoundInFetchedResourcesDetailed": "File \"{{fileName}}\" not found in project {{projectId}} ({{projectName}})",
-	"unknownProject": "Unknown project"
+	"unknownProject": "Unknown project",
+	"errorLoadingProject": "Error loading project \"{{projectId}}\": {{error}}",
+	"errorLoadingFile": "Error loading file \"{{fileName}}\": {{error}}",
+	"noFileOpenForEditing": "No file is currently open for editing in project {{projectId}}",
+	"saveAttemptedNoActiveFile": "Save attempted with no active file for project {{projectId}}"
 }


### PR DESCRIPTION
## Description

This PR fixes cursor position preservation and editor state management issues in the Monaco editor when switching between projects and files.

  ### Problem

  The editor was experiencing inconsistent behavior when switching contexts:

  1. **Cursor position loss**: Position wasn't restored reliably when switching between files/projects
  2. **Content loading synchronization**: State restoration attempted before content was fully loaded
  3. **Complex state management**: Unnecessary focus/typing state tracking causing race conditions
  4. **Over-engineered event handling**: Unused selection tracking and excessive listeners

  ### Key Changes

  #### **Editor State Synchronization**
  - Added `contentLoaded` state flag to ensure cursor restoration waits for content
  - Combined content setup and cursor restoration into a single effect
  - Proper sequencing: content load → content loaded flag → cursor restoration

  #### **Simplified Cursor Position Management**
  - Removed `isFocusedAndTyping` and `isFirstCursorPositionChange` state tracking
  - Extracted `restoreCursorPosition` function with proper null checks and early returns
  - Only restore position when `currentProject && contentLoaded && content` are ready

  #### **Editor Mounting Improvements**
  - Added `key={projectId}` to Monaco editor for proper re-mounting on project switch
  - Simplified event listener management to only track cursor position changes
  - Removed unused selection change handling and related complexity

  #### **Error Handling & Internationalization**
  - Improved error logging with structured messages

  #### **Code Cleanup**
  - Removed unused refs (`hasOpenedFile`, `keydownListenerRef`)
  - Simplified event listener cleanup
  - Eliminated unnecessary state variables and complex dependency arrays
  - Streamlined content update error handling

  ### Technical Implementation

  **State Flow**: `projectLoaded` → `contentLoaded` → `content ready` → `restoreCursorPosition()`

  **Error Messages**: All error strings now use i18n with proper variable substitution.


## Linear Ticket
https://linear.app/autokitteh/issue/UI-1766/moving-between-pages-line-number-is-not-preserved

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
