### PR TITLE
fix(UI-1882): proto objects conversion

### DIFF
--- a/src/components/molecules/jsonViewer.tsx
+++ b/src/components/molecules/jsonViewer.tsx
@@ -6,7 +6,7 @@ import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
 import { cn } from "@src/utilities";
 
 export const JsonViewer = ({
-	value,
+	value = {},
 	className,
 	isCollapsed,
 }: {

--- a/src/components/organisms/deployments/sessions/tabs/activities/singleActivityInfo.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/singleActivityInfo.tsx
@@ -66,7 +66,7 @@ export const SingleActivityInfo = ({
 					)}
 
 					<div className="mb-4 mt-8 font-bold">{t("returnValues")}</div>
-					<ValueRenderer value={activity.returnValue} />
+					<ValueRenderer value={activity.returnValue?.value} />
 				</div>
 			</div>
 		</div>

--- a/src/models/activity.model.ts
+++ b/src/models/activity.model.ts
@@ -67,7 +67,7 @@ export function convertSessionLogRecordsProtoToActivitiesModel(
 				args: args,
 				kwargs: kwargs,
 				endTime: undefined,
-				returnValue: {} as DeepProtoValueResult,
+				returnValue: { type: "object", value: {} } as DeepProtoValueResult,
 				sequence: callSpec?.seq,
 				status: ActivityState.created,
 			};
@@ -84,10 +84,14 @@ export function convertSessionLogRecordsProtoToActivitiesModel(
 
 			if (callAttemptComplete.result?.value) {
 				try {
-					currentActivity.returnValue = safeParseSingleProtoValue(callAttemptComplete.result.value);
+					const parsedValue = safeParseSingleProtoValue(callAttemptComplete.result.value);
+					currentActivity.returnValue =
+						parsedValue || ({ type: "object", value: {} } as DeepProtoValueResult);
 				} catch {
 					currentActivity.returnValue = { type: "object", value: {} } as DeepProtoValueResult;
 				}
+			} else {
+				currentActivity.returnValue = { type: "object", value: {} } as DeepProtoValueResult;
 			}
 
 			const xAxisName = currentActivity.sequence

--- a/src/models/session.model.ts
+++ b/src/models/session.model.ts
@@ -8,7 +8,7 @@ function convertProtoSessionBase(protoSession: ProtoSession) {
 	return {
 		createdAt: convertTimestampToDate(protoSession.createdAt),
 		inputs: safeParseObjectProtoValue(protoSession.inputs),
-		memo: protoSession.memo,
+		memo: protoSession.memo || {},
 		sessionId: protoSession.sessionId,
 		state: protoSession.state,
 		triggerName: protoSession.memo?.trigger_name,

--- a/src/models/session.model.ts
+++ b/src/models/session.model.ts
@@ -8,7 +8,7 @@ function convertProtoSessionBase(protoSession: ProtoSession) {
 	return {
 		createdAt: convertTimestampToDate(protoSession.createdAt),
 		inputs: safeParseObjectProtoValue(protoSession.inputs),
-		memo: protoSession.memo || {},
+		memo: protoSession.memo,
 		sessionId: protoSession.sessionId,
 		state: protoSession.state,
 		triggerName: protoSession.memo?.trigger_name,

--- a/src/utilities/convertProtoValue.ts
+++ b/src/utilities/convertProtoValue.ts
@@ -10,13 +10,13 @@ export const safeParseSingleProtoValue = (input: any): Record<string, unknown> |
 	return safeJsonParse(input.string.v);
 };
 
-export const safeParseObjectProtoValue = (input: any): Record<string, unknown> | undefined => {
+export const safeParseObjectProtoValue = (input: any): Record<string, unknown> => {
 	if (!input) {
-		return undefined;
+		return {};
 	}
 
 	if (typeof input !== "object") {
-		return undefined;
+		return {};
 	}
 
 	return Object.fromEntries(


### PR DESCRIPTION
## Description
Fixed a TypeError: `Cannot convert undefined or null to object error` in the JsonViewer by identifying that
  **null**/**undefined** values from activity return values, session inputs, and event data were causing `Object.keys()` to fail in the **@uiw/react-json-view** library. 

We resolved this at the source level by modifying the `safeParseObjectProtoValue` utility function to return {} instead of **undefined**, and enhanced the activity model's **null** handling, ensuring all data passed to UI components is always a valid object.

## Linear Ticket

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [ ] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
