### PR TITLE
fix(UI-1847): user and project menu should appear above all elements

### DIFF
--- a/src/components/atoms/dropdownMenu.tsx
+++ b/src/components/atoms/dropdownMenu.tsx
@@ -29,7 +29,7 @@ export const DropdownMenu = ({
 	};
 
 	const menuStyle = cn(
-		"absolute z-40 mt-1 rounded-lg border border-gray-950 bg-gray-1250 p-2.5 shadow-xl",
+		"absolute z-popover mt-1 rounded-lg border border-gray-950 bg-gray-1250 p-2.5 shadow-xl",
 		"left-1/2 -translate-x-1/2 !transform",
 		className
 	);

--- a/src/components/molecules/popover/popoverContentBase.tsx
+++ b/src/components/molecules/popover/popoverContentBase.tsx
@@ -13,7 +13,7 @@ export const PopoverContentBase = forwardRef<HTMLDivElement, PopoverContentBaseP
 	propRef
 ) {
 	const ref = useMergeRefsCustom(context.refs.setFloating, propRef);
-	const popoverClassName = cn("z-40", props?.className);
+	const popoverClassName = cn("z-popover", props?.className);
 
 	return (
 		<FloatingPortal>

--- a/src/components/organisms/connections/table.tsx
+++ b/src/components/organisms/connections/table.tsx
@@ -234,7 +234,7 @@ export const ConnectionsTable = () => {
 														<IconSvg className="size-4" src={InfoIcon} />
 													</IconButton>
 												</PopoverTrigger>
-												<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
+												<PopoverContent className="rounded-lg border-0.5 border-white bg-black p-4">
 													<div className="flex flex-col">
 														<div className="mb-2 font-semibold">
 															{t("table.popover.titleInfo")}

--- a/src/components/organisms/dashboard/templates/tabs/multiplePopoverSelect.tsx
+++ b/src/components/organisms/dashboard/templates/tabs/multiplePopoverSelect.tsx
@@ -115,7 +115,7 @@ export const MultiplePopoverSelect = ({
 					</div>
 				</PopoverListTrigger>
 				<PopoverListContent
-					className="z-40 flex w-full flex-col gap-0.5 rounded-lg border border-gray-750 bg-white p-1 pt-1.5 text-black"
+					className="flex w-full flex-col gap-0.5 rounded-lg border border-gray-750 bg-white p-1 pt-1.5 text-black"
 					closeOnSelect={false}
 					displaySearch={items.length > 6}
 					emptyListMessage={emptyListMessage}

--- a/src/components/organisms/sidebar/sidebar.tsx
+++ b/src/components/organisms/sidebar/sidebar.tsx
@@ -214,7 +214,7 @@ export const Sidebar = () => {
 										) : null}
 									</AnimatePresence>
 								</PopoverTrigger>
-								<PopoverContent className="z-40 min-w-56 rounded-2xl border border-gray-950 bg-white px-3.5 py-2.5 font-averta shadow-2xl">
+								<PopoverContent className="min-w-56 rounded-2xl border border-gray-950 bg-white px-3.5 py-2.5 font-averta shadow-2xl">
 									<UserMenu openFeedbackForm={() => setIsFeedbackOpen(true)} />
 								</PopoverContent>
 							</PopoverWrapper>

--- a/src/components/organisms/triggers/table.tsx
+++ b/src/components/organisms/triggers/table.tsx
@@ -198,7 +198,7 @@ export const TriggersTable = () => {
 													<IconSvg className="size-4" src={InfoIcon} />
 												</IconButton>
 											</PopoverTrigger>
-											<PopoverContent className="z-40 rounded-lg border-0.5 border-white bg-black p-4">
+											<PopoverContent className="rounded-lg border-0.5 border-white bg-black p-4">
 												<InformationPopoverContent trigger={trigger} />
 											</PopoverContent>
 										</PopoverWrapper>

--- a/src/components/pages/project.tsx
+++ b/src/components/pages/project.tsx
@@ -135,7 +135,7 @@ export const Project = () => {
 								<ArrowRightCarouselIcon className="size-3.5 fill-black stroke-black" />
 							</IconButton>
 						</PopoverTrigger>
-						<PopoverContent className="z-popover rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
+						<PopoverContent className="rounded-lg border-0.5 border-white bg-black p-1 px-1.5">
 							<div className="text-white">{tUI("display")}</div>
 						</PopoverContent>
 					</PopoverWrapper>

--- a/src/utilities/domTourHighight.utils.ts
+++ b/src/utilities/domTourHighight.utils.ts
@@ -132,7 +132,7 @@ const createTourOverlay = (): HTMLElement | undefined => {
 	removeTourOverlay();
 	const overlayElement = document.createElement("div");
 	overlayElement.id = "tour-overlay";
-	overlayElement.className = "fixed inset-0 z-40 size-full bg-black/30";
+	overlayElement.className = "fixed inset-0 z-overlay size-full bg-black/30";
 	document.body.appendChild(overlayElement);
 
 	return overlayElement;


### PR DESCRIPTION
# Fix User Menu Z-Index Layering Over AI Assistant Tab

## **Description**
Fixed z-index layering issue where user and project menus were appearing behind the AI assistant tab and other interface elements ([UI-1847](https://linear.app/autokitteh/issue/UI-1847/fix-user-menu-z-index-layering-over-ai-assistant-tab)).

## **Changes**

### Z-Index Standardization & Layering Fix
- **Replaced hardcoded `z-40` with semantic z-index utilities** across 8 components
- **Implemented proper layering hierarchy** using Tailwind's structured z-index system:
  - `z-popover` (120) for dropdown menus, popovers, and user/project menus
  - `z-overlay` (100) for tour overlays
  - Removed redundant inline z-index overrides

## **Benefits**
1. ** Consistent Layering**: All popover elements now use the same semantic z-index value (120)
2. ** Future-Proof**: Using Tailwind's structured z-index system prevents future layering conflicts
3. ** Maintainable**: Semantic naming (`z-popover`, `z-overlay`) makes intent clear
4. ** Clean Code**: Removed redundant z-index declarations that were overriding base styles


### Before vs After

| **Before** | **After** |
|------------|-----------|
| Mixed hardcoded `z-40` values | Consistent semantic z-index utilities |
| Inconsistent layering causing UI conflicts | Proper visual hierarchy |
| Manual z-index management | Systematic layering approach |

Screenshots:
<img width="2032" height="1192" alt="image" src="https://github.com/user-attachments/assets/5c68b027-a70c-4e17-acb1-36da7b11ebb7" />

<img width="2032" height="1192" alt="image" src="https://github.com/user-attachments/assets/c93067ee-3167-401e-b5f8-a5f70f33b8ab" />


## Linear Ticket
[Linear Issue UI-1847](https://linear.app/autokitteh/issue/UI-1847/fix-user-menu-z-index-layering-over-ai-assistant-tab)

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] 🎨 (style) - Styles - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
