### PR TITLE
fix(UI-1911): prevent getEnrichedOrganizations call before currentOrg exist

### DIFF
--- a/src/components/organisms/sidebar/sidebar.tsx
+++ b/src/components/organisms/sidebar/sidebar.tsx
@@ -36,7 +36,6 @@ export const Sidebar = () => {
 	}, [location.pathname]);
 
 	const loadOrganizations = async () => {
-		if (!currentOrganization) return;
 		const { data, error } = await getEnrichedOrganizations();
 		if (error || !data) {
 			addToast({

--- a/src/components/organisms/sidebar/sidebar.tsx
+++ b/src/components/organisms/sidebar/sidebar.tsx
@@ -24,7 +24,7 @@ import { CircleQuestionIcon, FileIcon } from "@assets/image/icons/sidebar";
 export const Sidebar = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
-	const { user, getEnrichedOrganizations } = useOrganizationStore();
+	const { user, getEnrichedOrganizations, currentOrganization } = useOrganizationStore();
 	const { isNewLogs, setSystemLogHeight, setNewLogs, lastLogType, systemLogHeight } = useLoggerStore();
 	const location = useLocation();
 	const { t } = useTranslation("sidebar");
@@ -36,6 +36,7 @@ export const Sidebar = () => {
 	}, [location.pathname]);
 
 	const loadOrganizations = async () => {
+		if (!currentOrganization) return;
 		const { data, error } = await getEnrichedOrganizations();
 		if (error || !data) {
 			addToast({
@@ -48,11 +49,11 @@ export const Sidebar = () => {
 
 	useEffect(() => {
 		if (!descopeProjectId) return;
-		if (descopeProjectId && user) {
+		if (descopeProjectId && user && currentOrganization) {
 			loadOrganizations();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [user]);
+	}, [user, currentOrganization]);
 
 	const handleLogoClick = () => {
 		navigate("/");


### PR DESCRIPTION
## Description
## Problem
Fixed a race condition in the sidebar that caused errors during login.

## Root Cause
The sidebar's useEffect was calling `getEnrichedOrganizations()` immediately when both `user` and `currentOrganization` became truthy. However, `getEnrichedOrganizations()` internally requires `currentOrganization` to be fully initialized in the store state, which wasn't guaranteed at the time of the call.

## Impact
This timing issue caused error logs on login as the function would execute before the organization data was properly synchronized in the store.

## Solution
Validate we have currentOrganization before we call `getEnrichedOrganizations()`

## Linear Ticket
https://linear.app/autokitteh/issue/UI-1911/fix-failed-to-fetch-organizations-error-on-login

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
