### PR TITLE
fix: exec log now properly renders return values

### DIFF
--- a/src/components/organisms/deployments/sessions/tabs/activities/singleActivityInfo.tsx
+++ b/src/components/organisms/deployments/sessions/tabs/activities/singleActivityInfo.tsx
@@ -7,7 +7,7 @@ import { triggerEvent } from "@src/hooks";
 import { SessionActivity } from "@src/interfaces/models";
 
 import { Button } from "@components/atoms";
-import { JsonViewer, ValueRenderer } from "@components/molecules";
+import { JsonViewer } from "@components/molecules";
 
 import { ArrowLeft, Close } from "@assets/image/icons";
 
@@ -66,7 +66,12 @@ export const SingleActivityInfo = ({
 					)}
 
 					<div className="mb-4 mt-8 font-bold">{t("returnValues")}</div>
-					<ValueRenderer value={activity.returnValue?.value} />
+
+					{activity.returnValue?.value && Object.keys(activity.returnValue.value).length ? (
+						<JsonViewer isCollapsed={true} value={activity.returnValue.value} />
+					) : (
+						<div>{t("noReturnValuesFound")}</div>
+					)}
 				</div>
 			</div>
 		</div>

--- a/src/models/activity.model.ts
+++ b/src/models/activity.model.ts
@@ -84,9 +84,19 @@ export function convertSessionLogRecordsProtoToActivitiesModel(
 
 			if (callAttemptComplete.result?.value) {
 				try {
-					const parsedValue = safeParseSingleProtoValue(callAttemptComplete.result.value);
-					currentActivity.returnValue =
-						parsedValue || ({ type: "object", value: {} } as DeepProtoValueResult);
+					let parsedValue = safeParseSingleProtoValue(callAttemptComplete.result.value);
+
+					if (typeof parsedValue === "string") {
+						try {
+							parsedValue = JSON.parse(parsedValue);
+						} catch {
+							parsedValue = { value: parsedValue };
+						}
+					}
+
+					currentActivity.returnValue = parsedValue
+						? { type: "object", value: parsedValue }
+						: { type: "object", value: {} };
 				} catch {
 					currentActivity.returnValue = { type: "object", value: {} } as DeepProtoValueResult;
 				}


### PR DESCRIPTION
## Description


  Fix: Session execution log return values not rendering

  Problem

  Return values in the Session Execution Log were not displaying correctly - they appeared as non-expandable items showing character counts (e.g., "180 items") instead
   of the actual JSON data.

  Root Cause

  1. Parsed return values weren't wrapped in the correct DeepProtoValueResult structure, causing activity.returnValue.value to be undefined
  2. JSON return values could be double-encoded (JSON string containing JSON string), causing JsonViewer to treat them as character arrays instead of objects

  Changes

  src/models/activity.model.ts:85-103
  - Wrapped parsed return values in proper { type: "object", value: parsedValue } structure
  - Added double-parse logic to handle nested JSON strings
  - Added fallback to wrap plain strings in objects for proper display

  src/components/organisms/deployments/sessions/tabs/activities/singleActivityInfo.tsx:68-74
  - Replaced ValueRenderer with JsonViewer for consistency with Arguments/KW Arguments sections
  - Ensured return values are expandable and display correctly

  Result

  Return values now display and expand correctly in the Session Execution Log, matching the behavior of arguments and kwargs.

## What type of PR is this? (check all applicable)

- [ ] 💡 (feat) - A new feature (non-breaking change which adds functionality)
- [ ] 🔄 (refactor) - Code Refactoring - A code change that neither fixes a bug nor adds a feature
- [x] 🐞 (fix) - Bug Fix (non-breaking change which fixes an issue)
- [ ] 🏎 (perf) - Optimization
- [ ] 📄 (docs) - Documentation - Documentation only changes
- [ ] 📄 (test) - Tests - Adding missing tests or correcting existing tests
- [ ] ⚙️ (ci) - Continuous Integrations - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] ☑️ (chore) - Chores - Other changes that don't modify src or test files
- [ ] ↩️ (revert) - Reverts - Reverts a previous commit(s).

<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages (as described below).
     - 📗 Update any related documentation and include any relevant screenshots.
     Commit Message Structure (all lower-case):
     <type>(optional ticket number): <description>
     [optional body]
-->
